### PR TITLE
Resume subscription token should be optional - closes #15

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -143,7 +143,7 @@ class StripeGateway {
 	 * @param  string  $token
 	 * @return void
 	 */
-	public function resume($token)
+	public function resume($token = null)
 	{
 		$this->noProrate()->skipTrial()->create($token, '', $this->getStripeCustomer());
 


### PR DESCRIPTION
Per conversation in - https://github.com/laravel/cashier/issues/15

(_Though I do wonder if we could remove the `$token` var from the `resume` method entirely. Is there ever an instance when it would be necessary?_)
