### PR TITLE
Improved Travis Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: php
 
-php: 
-  - 5.3
+php:
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - composer self-update
+  - composer install --prefer-source --no-interaction --dev
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "illuminate/view": "~4.1",
-        "mockery/mockery": "0.9.*"
+        "mockery/mockery": "0.9.*",
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I've removed php 5.3, added 5.6 and hhvm, and updated the before_script stuff to be the same as what you have in laravel/framework. I have also included phpunit 4.0 like in laravel/framework. Also, I don't think you have actually enabled the travis build hook on this repo because there are no travis builds.
