### PR TITLE
[Proposal] Update BillableTrait to retrieve all time invoices

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -74,17 +74,7 @@ trait BillableTrait {
 	 * @param  string  $id
 	 * @return \Laravel\Cashier\Invoice
 	 */
-	public function findInvoiceOrFail($id)
-	{
-		if (is_null($invoice = $this->findInvoice($id)))
-		{
-			throw new NotFoundHttpException;
-		}
-		else
-		{
-			return $invoice;
-		}
-	}
+in
 
 	/**
 	 * Create an invoice download Response.
@@ -106,7 +96,7 @@ trait BillableTrait {
 	public function invoices($allTime = false)
 	{
 		
-		if($allTime)
+		if ($allTime)
 		{
 			return $this->subscription()->invoices();
 		}


### PR DESCRIPTION
If the user has cancelled the subscription, this method does not retrieve past invoices. Added `$allTime` as an argument to `invoices` method to retrieve all invoices even though the user does not have an active subscription.
