### PR TITLE
Flexibility to pass in other customer properties when creating

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -448,7 +448,7 @@ class StripeGateway {
 				->setSubscriptionEndDate(null)
 				->saveBillableInstance();
 	}
-	
+
 	/**
 	 * Create a new Stripe customer instance.
 	 *
@@ -462,7 +462,7 @@ class StripeGateway {
 
 		return $this->getStripeCustomer($customer->id);
 	}
-	
+
 	/**
 	 * Get the Stripe customer for entity.
 	 *


### PR DESCRIPTION
I found that I had to make this change to create a customer and pass in an email so I could identify them from the Stripe dashboard properly.

As far as I could see there was no flexibility to allow an email (or any other properties) to be specified under the create method.

Not sure if this would need limiting in some way, but meh, provides the flexibility to assign customer_balance, currency, description, email, etc.
