### PR TITLE
Changed onGracePeriod check

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -156,7 +156,7 @@ trait BillableTrait {
 	{
 		if ( ! is_null($endsAt = $this->getSubscriptionEndDate()))
 		{
-			return Carbon::today()->lt(Carbon::instance($endsAt));
+			return Carbon::now()->lt(Carbon::instance($endsAt));
 		}
 		else
 		{


### PR DESCRIPTION
Changed onGracePeriod check to return based on now() time instead of today() time for actuate subscription expirations.
