### PR TITLE
Allow user to pass paramaters when fetching invoices

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -110,9 +110,9 @@ trait BillableTrait {
 	 *
 	 * @return array
 	 */
-	public function invoices()
+	public function invoices($parameters = array())
 	{
-		return $this->subscription()->invoices();
+		return $this->subscription()->invoices(false, $parameters);
 	}
 
 	/**

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -233,11 +233,11 @@ class StripeGateway {
 	 * @param  bool  $includePending
 	 * @return array
 	 */
-	public function invoices($includePending = false)
+	public function invoices($includePending = false, $parameters = array())
 	{
 		$invoices = [];
 
-		$stripeInvoices = $this->getStripeCustomer()->invoices();
+		$stripeInvoices = $this->getStripeCustomer()->invoices($parameters);
 
 		// Here we will loop through the Stripe invoices and create our own custom Invoice
 		// instances that have more helper methods and are generally more convenient to


### PR DESCRIPTION
This allows users to pass more information to the invoices request. I had a need for this in a project I was working on so I figured it'd be good to add. I'm using it to get information about the charge and card used to pay an invoice.

For example you could do something like this to get the last 4 of the card used.

```
foreach ($customer->invoices(['expand' => ['data.charge']]) as $invoice) {
    echo $invoice->charge->card->last4;
}
```
