### PR TITLE
Removing NotFoundHttpException from web hook controller

### DIFF
--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -23,10 +23,6 @@ class WebhookController extends Controller {
 		{
 			return $this->{$method}($payload);
 		}
-		else
-		{
-			throw new NotFoundHttpException;
-		}
 	}
 
 	/**


### PR DESCRIPTION
Web hook controller still throwing a 404 even with the missingMethods action. removing exception.
