### PR TITLE
Allow easy access to get the date the subscription will end / automatically renew

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -401,6 +401,18 @@ class StripeGateway {
 			return $customer->subscription->current_period_end;
 		}
 	}
+	
+	/**
+	* Get the current subscription period's end date
+	* 
+	* @return \Carbon\Carbon
+	*/
+	public function getSubscriptionEndDate()
+	{
+		$customer = $this->getStripeCustomer();
+
+		return Carbon::createFromTimestamp($this->getSubscriptionEndTimestamp($customer));
+        }
 
 	/**
 	 * Update the credit card attached to the entity.


### PR DESCRIPTION
Adds public getSubscriptionEndDate function in order to get the date the subscription will renew at to show subscribers on their billing info page etc.
