### PR TITLE
Catching error when trying to fetch card info of user w/o any card

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -538,7 +538,12 @@ class StripeGateway {
 	 */
 	protected function getLastFourCardDigits($customer)
 	{
-		return $customer->cards->retrieve($customer->default_card)->last4;
+		try{
+			return $customer->cards->retrieve($customer->default_card)->last4;
+		}
+		catch{
+			return "";
+		}
 	}
 
 	/**


### PR DESCRIPTION
Stripe allows us to create a customer on Stripe without any card or token.
This is useful when user is subscription to a Free plan.
But when we call /customer/<customer_id>/cards it throws error.

So handling this error in cashier and returning empty string if error is returned from Stripe.
