### PR TITLE
Added one time payments

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -35,6 +35,16 @@ trait BillableTrait {
 	}
 
 	/**
+	 * Get a new billing gateway instance to perform a One Time Payment.
+	 *
+	 * @return \Laravel\Cashier\StripeGateway
+	 */
+	public function oneTimePayment()
+	{
+		return new StripeGateway($this);
+	}
+
+	/**
 	 * Get a new billing gateway instance for the given plan.
 	 *
 	 * @param  \Laravel\Cashier\PlanInterface|string|null  $plan

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -11,6 +11,36 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 		Mockery::close();
 	}
 
+	public function testPerformPaymentPassesProperOptionsToCustomer()
+	{
+		$billable = $this->mockBillableInterface();
+		$billable->shouldReceive('getCurrency')->andReturn('eur');
+		$billable->shouldReceive('getStripeId')->andReturn('foo');
+		$gateway = m::mock('Laravel\Cashier\StripeGateway[getStripeCustomer,updateCard,createStripeCharge,updateLocalStripeData]', array($billable, 'plan'));
+		$gateway->shouldReceive('getStripeCustomer')->andReturn($customer = m::mock('StdClass'));
+		$customer->id = 'foo';
+		$gateway->shouldReceive('updateCard')->once();
+		$gateway->shouldReceive('createStripeCharge')->once();
+		$gateway->shouldReceive('updateLocalStripeData')->once();
+
+		$gateway->performPayment('token', [], []);
+	}
+
+
+	public function testPerformPaymentWithNewCustomerPassesProperOptionsToCustomer()
+	{
+		$billable = $this->mockBillableInterface();
+		$billable->shouldReceive('getCurrency')->andReturn('eur');
+		$billable->shouldReceive('getStripeId')->once()->andReturn(false);
+		$gateway = m::mock('Laravel\Cashier\StripeGateway[createStripeCustomer,createStripeCharge,updateLocalStripeData]', array($billable, 'plan'));
+		$gateway->shouldReceive('createStripeCustomer')->andReturn($customer = m::mock('StdClass'));
+		$customer->id = 'foo';
+		$gateway->shouldReceive('createStripeCharge')->once();
+		$gateway->shouldReceive('updateLocalStripeData')->once();
+
+		$gateway->performPayment('token', [], []);
+	}
+
 
 	public function testCreatePassesProperOptionsToCustomer()
 	{


### PR DESCRIPTION
Cashier only allows to manage subscriptions, but it can't handle one time payments yet. This is very limiting since a lot of sites only need to be able to sell something without requiring a subscription.

This pull request adds a oneTimePayment() method which simply returns a Gateway instance.
A performPayment() method has been added to the Gateway to handle the payments.

performPayment() first checks if the user is already a Stripe customer. If he is, it retrieves the customer instance, otherwise it creates a new Stripe customer. Eventually the charge is performed.

The following is an example of how the method can be called

```
$user->oneTimePayment()->performPayment(Input::get('stripeToken'),
                array(
                    'amount' => Input::get('amount'),
                    'currency' => 'eur',
                    'description' => "This is a one time purchase"),
                array(
                    'card' => Input::get('stripeToken'),
                    'email' => $user->email)
            );
```

Two tests have also been added.

Please share your opinions! :)
