### PR TITLE
If the customer has no card on file, don't require it.

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -538,7 +538,7 @@ class StripeGateway {
 	 */
 	protected function getLastFourCardDigits($customer)
 	{
-		return $customer->cards->retrieve($customer->default_card)->last4;
+		return ($customer->default_card) ? $customer->cards->retrieve($customer->default_card)->last4 : null;
 	}
 
 	/**


### PR DESCRIPTION
If the customer has no card on file, don't require it.

Usecase: Customer is already registered on Stripe without a credit card but has a coupon on their account for 100% off or the cost of the plan your assigning them to, you want to subscriotn(plan)->swap() but currently it throws an error as it tried to get the default card on the account (which there is none).
