### PR TITLE
[Proposal] Added options on invoice download

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -100,9 +100,9 @@ trait BillableTrait {
 	 * @param  array   $data
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function downloadInvoice($id, array $data)
+	public function downloadInvoice($id, array $data, array $options = [])
 	{
-		return $this->findInvoiceOrFail($id)->download($data);
+		return $this->findInvoiceOrFail($id)->download($data, null, $options);
 	}
 
 	/**

--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -30,6 +30,13 @@ class Invoice {
 	protected $files;
 
 	/**
+	 * The view used to generate the invoice PDF
+	 *
+	 * @var string
+	 */
+	protected $view_receipt = 'cashier::receipt';
+
+	/**
 	 * Create a new invoice instance.
 	 *
 	 * @param  \Laravel\Cashier\BillableInterface  $billable
@@ -257,7 +264,7 @@ class Invoice {
 	{
 		$data = array_merge($data, ['invoice' => $this, 'billable' => $this->billable]);
 
-		return View::make('cashier::receipt', $data);
+		return View::make($this->view_receipt, $data);
 	}
 
 	/**
@@ -278,9 +285,20 @@ class Invoice {
 	 * @param  string  $storagePath
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function download(array $data, $storagePath = null)
+	public function download(array $data, $storagePath = null, array $options = [])
 	{
-		$filename = $this->getDownloadFilename($data['product']);
+		if (isset($options['filename']))
+		{
+			$filename = $options['filename'];
+		}
+		else
+		{
+			$filename = $this->getDownloadFilename($data['product']);
+		}
+		if (isset($options['view_receipt']))
+		{
+			$this->view_receipt = $options['view_receipt'];
+		}
 
 		$document = $this->writeInvoice($data, $storagePath);
 

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -36,9 +36,9 @@ class BillableTraitTest extends PHPUnit_Framework_TestCase {
 	{
 		$billable = m::mock('BillableTraitTestStub[findInvoice]');
 		$billable->shouldReceive('findInvoice')->once()->with('id')->andReturn($invoice = m::mock('StdClass'));
-		$invoice->shouldReceive('download')->once()->with(['foo']);
+		$invoice->shouldReceive('download')->once()->with(['foo'], '', []);
 
-		$billable->downloadInvoice('id', ['foo']);
+		$billable->downloadInvoice('id', ['foo'], []);
 	}
 
 


### PR DESCRIPTION
The default package does not allow to customize the filename when downloading an invoice.
For some specific needs, I also needed a different template for the invoice.

Here is the change that could be merged for those two features.
- filename: Allow to customize the download filename in the http headers
- view_receipt: Allow to change the view used to generate the invoice PDF
