### PR TITLE
Fixed the minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,6 @@
         "branch-alias": {
             "dev-master": "3.0-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Composer will determine that laravel 5.0 cannot be used unless we add this fix.
