### PR TITLE
updates stripe_plan on migration.stub to allow up to 500 characters instead of 25

### DIFF
--- a/src/Laravel/Cashier/stubs/migration.stub
+++ b/src/Laravel/Cashier/stubs/migration.stub
@@ -17,7 +17,7 @@ class AddCashierColumns extends Migration {
 			$table->tinyInteger('stripe_active')->default(0);
 			$table->string('stripe_id')->nullable();
 			$table->string('stripe_subscription')->nullable();
-			$table->string('stripe_plan', 25)->nullable();
+			$table->string('stripe_plan', 500)->nullable();
 			$table->string('last_four', 4)->nullable();
 			$table->timestamp('trial_ends_at')->nullable();
 			$table->timestamp('subscription_ends_at')->nullable();


### PR DESCRIPTION
The 'stripe_plan' column created only allowed for 25 characters which in turn was truncating lengthy plan IDs causing a missmatch w/ stripe.

I couldn't find it in the stripe documentation but manually found the limit as seen here: http://screencast.com/t/uaBTj52J
