### PR TITLE
Making BillableTrait.php support more currencies

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -476,7 +476,7 @@ trait BillableTrait {
 	 */
 	public function getCurrency()
 	{
-		return static::currency;
+		return static::$currency;
 	}
 
 	/**
@@ -486,7 +486,7 @@ trait BillableTrait {
 	 */
 	public function getCurrencyLocale()
 	{
-		return static::currencyLocale;
+		return static::$currencyLocale;
 	}
 
 	/**
@@ -508,7 +508,7 @@ trait BillableTrait {
 	 */
 	public function addCurrencySymbol($amount)
 	{
-		return static::currencySymbol.$amount;
+		return static::$currencySymbol.$amount;
 	}
 
 	/**


### PR DESCRIPTION
Previously, BillableTrait.php hardcoded values for US Dollar currency when Stripe, in reality, supports a lot more currencies.
