### PR TITLE
Removing Coupon from Subscription

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -118,8 +118,6 @@ class StripeGateway {
 			'quantity' => $this->quantity, 'trial_end' => $this->getTrialEndForUpdate(),
 		];
 
-		if ($this->coupon) $payload['coupon'] = $this->coupon;
-
 		return $payload;
 	}
 


### PR DESCRIPTION
Previously, the coupon was added to both the Customer AND Subscription objects. This caused the coupon to be redeemed twice, which presented problems for coupons with a limited redemption count. Now, the coupon is only added to the Customer object.

Signed-off-by: Adam Engebretson adam@enge.me
