### PR TITLE
Added .pdf to the filename of pdf downloads

### DIFF
--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -357,7 +357,7 @@ class Invoice {
 	{
 		$prefix = ! is_null($prefix) ? $prefix.'_' : '';
 
-		return $prefix.$this->date()->month.'_'.$this->date()->year;
+		return $prefix.$this->date()->month.'_'.$this->date()->year.'.pdf';
 	}
 
 	/**


### PR DESCRIPTION
The downloaded file thats returned from the downloadInvoice method doesn't include a file extension.
This is causing problems for some of the users I am testing a product with, it would be better if the filename of the downloaded file included the .pdf extension automatically.
