### PR TITLE
[12.x] Apply prorate and invoice_now for cancelNow

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -837,9 +837,26 @@ class Subscription extends Model
      */
     public function cancelNow()
     {
-        $subscription = $this->asStripeSubscription();
+        $this->asStripeSubscription()->cancel([
+            'prorate' => $this->prorateBehavior() === 'create_prorations',
+        ]);
 
-        $subscription->cancel();
+        $this->markAsCancelled();
+
+        return $this;
+    }
+
+    /**
+     * Cancel the subscription immediately.
+     *
+     * @return $this
+     */
+    public function cancelNowAndInvoice()
+    {
+        $this->asStripeSubscription()->cancel([
+            'invoice_now' => true,
+            'prorate' => $this->prorateBehavior() === 'create_prorations',
+        ]);
 
         $this->markAsCancelled();
 


### PR DESCRIPTION
At the moment `cancelNow` will immediately cancel the subscription and prevent any new invoices. These changes allow for two things:

Send a final invoice for any remaining used resources:

```php
$subscription->cancelNowAndInvoice();
```

Prorate any remaining time to the customer's balance:

```php
$subscription->prorate()->cancelNow();
```

Closes https://github.com/laravel/cashier-stripe/issues/974