### PR TITLE
[12.x] Fail url checking when url is invalid

### DIFF
--- a/src/Http/Middleware/VerifyRedirectUrl.php
+++ b/src/Http/Middleware/VerifyRedirectUrl.php
@@ -19,6 +19,7 @@ class VerifyRedirectUrl
     public function handle($request, Closure $next)
     {
         $redirect = $request->get('redirect');
+
         $url = parse_url($redirect);
 
         if ($redirect && (! isset($url['host']) || $url['host'] !== $request->getHost())) {

--- a/src/Http/Middleware/VerifyRedirectUrl.php
+++ b/src/Http/Middleware/VerifyRedirectUrl.php
@@ -19,8 +19,9 @@ class VerifyRedirectUrl
     public function handle($request, Closure $next)
     {
         $redirect = $request->get('redirect');
+        $url = parse_url($redirect);
 
-        if ($redirect && parse_url($redirect)['host'] !== $request->getHost()) {
+        if ($redirect && (! isset($url['host']) || $url['host'] !== $request->getHost())) {
             throw new AccessDeniedHttpException('Redirect host mismatch.');
         }
 

--- a/tests/Unit/VerifyRedirectUrlTest.php
+++ b/tests/Unit/VerifyRedirectUrlTest.php
@@ -33,6 +33,18 @@ class VerifyRedirectUrlTest extends TestCase
         });
     }
 
+    public function test_it_fails_when_the_url_is_invalid()
+    {
+        $request = Request::create('http://baz.com/stripe/payment', 'GET', ['redirect' => 'foo/bar']);
+        $middleware = new VerifyRedirectUrl;
+
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $middleware->handle($request, function () {
+            //
+        });
+    }
+
     public function test_it_is_skipped_when_no_redirect_is_present()
     {
         $request = Request::create('http://baz.com/stripe/payment', 'GET');


### PR DESCRIPTION
Makes sure that the checking fails when an invalid url was passed.