### PR TITLE
[12.x] Fix double payment method

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -139,7 +139,7 @@
 
             @if (! $payment->isSucceeded() && ! $payment->isCancelled() && ! $payment->requiresAction())
                 mounted: function () {
-                    this.configStripe();
+                    this.configureStripe();
                 },
             @endif
 
@@ -206,18 +206,18 @@
                     });
                 },
 
-                configStripe: function () {
+                requestPaymentMethod: function () {
+                    this.configureStripe();
+
+                    this.requiresPaymentMethod = true;
+                    this.requiresAction = false;
+                },
+
+                configureStripe: function () {
                     const elements = stripe.elements();
 
                     this.cardElement = elements.create('card');
                     this.cardElement.mount('#card-element');
-                },
-
-                requestPaymentMethod: function () {
-                    this.configStripe();
-
-                    this.requiresPaymentMethod = true;
-                    this.requiresAction = false;
                 },
 
                 goBack: function () {

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -129,22 +129,7 @@
             @endif
 
             methods: {
-                configStripe: function () {
-                    const elements = stripe.elements();
-
-                    this.cardElement = elements.create('card');
-                    this.cardElement.mount('#card-element');
-                },
-
-                requestingNewPaymentMethod: function () {
-                    this.configStripe();
-
-
-                    this.requiresPaymentMethod = true;
-                    this.requiresAction = false;
-                },
-
-                addNewPaymentMethod: function () {
+                addPaymentMethod: function () {
                     var self = this;
 
                     this.paymentProcessing = true;
@@ -194,7 +179,7 @@
                         
                         if (result.error) {
                             if (result.error.code === 'payment_intent_authentication_failure') {
-                                self.requestingNewPaymentMethod()
+                                self.requestPaymentMethod()
                             } else {
                                 self.errorMessage = result.error.message;
                             }
@@ -204,6 +189,21 @@
                             self.successMessage = '{{ __('The payment was successful.') }}';
                         }
                     });
+                },
+
+                configStripe: function () {
+                    const elements = stripe.elements();
+
+                    this.cardElement = elements.create('card');
+                    this.cardElement.mount('#card-element');
+                },
+
+                requestPaymentMethod: function () {
+                    this.configStripe();
+
+
+                    this.requiresPaymentMethod = true;
+                    this.requiresAction = false;
                 },
 
                 goBack: function () {

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -48,48 +48,48 @@
                     <p class="mb-6">{{ __('This payment was cancelled.') }}</p>
                 @else
                     <div id="payment-elements" v-if="! paymentProcessed">
-                            <!-- Payment Method Form -->
-                            <div v-show="requiresPaymentMethod">
-                                <!-- Instructions -->
-                                <h1 class="text-xl mt-2 mb-4 text-gray-700">
-                                    {{ __('Confirm your :amount payment', ['amount' => $payment->amount()]) }}
-                                </h1>
+                        <!-- Payment Method Form -->
+                        <div v-show="requiresPaymentMethod">
+                            <!-- Instructions -->
+                            <h1 class="text-xl mt-2 mb-4 text-gray-700">
+                                {{ __('Confirm your :amount payment', ['amount' => $payment->amount()]) }}
+                            </h1>
 
-                                <p class="mb-6">
-                                    {{ __('Extra confirmation is needed to process your payment. Please confirm your payment by filling out your payment details below.') }}
-                                </p>
+                            <p class="mb-6">
+                                {{ __('Extra confirmation is needed to process your payment. Please confirm your payment by filling out your payment details below.') }}
+                            </p>
 
-                                <!-- Name -->
-                                <label for="cardholder-name" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Full name') }}</label>
+                            <!-- Name -->
+                            <label for="cardholder-name" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Full name') }}</label>
 
-                                <input id="cardholder-name" type="text" placeholder="{{ __('Jane Doe') }}" required
-                                    class="inline-block bg-gray-200 border border-gray-400 rounded-lg w-full px-4 py-3 mb-3 focus:outline-none"
-                                    v-model="name">
+                            <input id="cardholder-name" type="text" placeholder="{{ __('Jane Doe') }}" required
+                                class="inline-block bg-gray-200 border border-gray-400 rounded-lg w-full px-4 py-3 mb-3 focus:outline-none"
+                                v-model="name">
 
-                                <!-- Card -->
-                                <label for="card-element" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Card') }}</label>
+                            <!-- Card -->
+                            <label for="card-element" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Card') }}</label>
 
-                                <div id="card-element" class="bg-gray-200 border border-gray-400 rounded-lg p-4 mb-6"></div>
+                            <div id="card-element" class="bg-gray-200 border border-gray-400 rounded-lg p-4 mb-6"></div>
 
-                                <!-- Pay Button -->
-                                <button id="card-button"
-                                        class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
-                                        :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
-                                        @click="addNewPaymentMethod"
-                                        :disabled="paymentProcessing">
-                                    {{ __('Pay :amount', ['amount' => $payment->amount()]) }}
-                                </button>
-                            </div>
-
-                            <!-- Confirm Payment Method Button -->
+                            <!-- Pay Button -->
                             <button id="card-button"
                                     class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
                                     :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
-                                    @click="confirmPaymentMethod"
-                                    :disabled="paymentProcessing"
-                                    v-show="requiresAction">
-                                {{ __('Confirm Pay :amount', ['amount' => $payment->amount()]) }}
+                                    @click="addNewPaymentMethod"
+                                    :disabled="paymentProcessing">
+                                {{ __('Pay :amount', ['amount' => $payment->amount()]) }}
                             </button>
+                        </div>
+
+                        <!-- Confirm Payment Method Button -->
+                        <button id="card-button"
+                                class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
+                                :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
+                                @click="confirmPaymentMethod"
+                                :disabled="paymentProcessing"
+                                v-show="requiresAction">
+                            {{ __('Confirm Pay :amount', ['amount' => $payment->amount()]) }}
+                        </button>
                     </div>
                 @endif
 
@@ -176,7 +176,7 @@
                         }
                     ).then(function (result) {
                         self.paymentProcessing = false;
-                        
+
                         if (result.error) {
                             if (result.error.code === 'payment_intent_authentication_failure') {
                                 self.requestPaymentMethod()

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -48,35 +48,48 @@
                     <p class="mb-6">{{ __('This payment was cancelled.') }}</p>
                 @else
                     <div id="payment-elements" v-if="! paymentProcessed">
-                        <!-- Instructions -->
-                        <h1 class="text-xl mt-2 mb-4 text-gray-700">
-                            {{ __('Confirm your :amount payment', ['amount' => $payment->amount()]) }}
-                        </h1>
+                            <!-- Payment Method Form -->
+                            <div v-show="requiresPaymentMethod">
+                                <!-- Instructions -->
+                                <h1 class="text-xl mt-2 mb-4 text-gray-700">
+                                    {{ __('Confirm your :amount payment', ['amount' => $payment->amount()]) }}
+                                </h1>
 
-                        <p class="mb-6">
-                            {{ __('Extra confirmation is needed to process your payment. Please confirm your payment by filling out your payment details below.') }}
-                        </p>
+                                <p class="mb-6">
+                                    {{ __('Extra confirmation is needed to process your payment. Please confirm your payment by filling out your payment details below.') }}
+                                </p>
 
-                        <!-- Name -->
-                        <label for="cardholder-name" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Full name') }}</label>
+                                <!-- Name -->
+                                <label for="cardholder-name" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Full name') }}</label>
 
-                        <input id="cardholder-name" type="text" placeholder="{{ __('Jane Doe') }}" required
-                               class="inline-block bg-gray-200 border border-gray-400 rounded-lg w-full px-4 py-3 mb-3 focus:outline-none"
-                               v-model="name">
+                                <input id="cardholder-name" type="text" placeholder="{{ __('Jane Doe') }}" required
+                                    class="inline-block bg-gray-200 border border-gray-400 rounded-lg w-full px-4 py-3 mb-3 focus:outline-none"
+                                    v-model="name">
 
-                        <!-- Card -->
-                        <label for="card-element" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Card') }}</label>
+                                <!-- Card -->
+                                <label for="card-element" class="inline-block text-sm text-gray-700 font-semibold mb-2">{{ __('Card') }}</label>
 
-                        <div id="card-element" class="bg-gray-200 border border-gray-400 rounded-lg p-4 mb-6"></div>
+                                <div id="card-element" class="bg-gray-200 border border-gray-400 rounded-lg p-4 mb-6"></div>
 
-                        <!-- Pay Button -->
-                        <button id="card-button"
-                                class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
-                                :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
-                                @click="confirmPayment"
-                                :disabled="paymentProcessing">
-                            {{ __('Pay :amount', ['amount' => $payment->amount()]) }}
-                        </button>
+                                <!-- Pay Button -->
+                                <button id="card-button"
+                                        class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
+                                        :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
+                                        @click="addNewPaymentMethod"
+                                        :disabled="paymentProcessing">
+                                    {{ __('Pay :amount', ['amount' => $payment->amount()]) }}
+                                </button>
+                            </div>
+
+                            <!-- Confirm Payment Method Button -->
+                            <button id="card-button"
+                                    class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500"
+                                    :class="{ 'bg-blue-400': paymentProcessing, 'bg-blue-600': ! paymentProcessing }"
+                                    @click="confirmPaymentMethod"
+                                    :disabled="paymentProcessing"
+                                    v-show="requiresAction">
+                                {{ __('Confirm Pay :amount', ['amount' => $payment->amount()]) }}
+                            </button>
                     </div>
                 @endif
 
@@ -103,21 +116,35 @@
                 cardElement: null,
                 paymentProcessing: false,
                 paymentProcessed: false,
+                requiresPaymentMethod: {{ $requiresPaymentMethod }},
+                requiresAction: {{ $requiresAction }},
                 successMessage: '',
                 errorMessage: ''
             },
 
-            @if (! $payment->isSucceeded() && ! $payment->isCancelled())
+            @if (! $payment->isSucceeded() && ! $payment->isCancelled() && ! $payment->requiresAction())
                 mounted: function () {
+                    this.configStripe();
+                },
+            @endif
+
+            methods: {
+                configStripe: function () {
                     const elements = stripe.elements();
 
                     this.cardElement = elements.create('card');
                     this.cardElement.mount('#card-element');
                 },
-            @endif
 
-            methods: {
-                confirmPayment: function () {
+                requestingNewPaymentMethod: function () {
+                    this.configStripe();
+
+
+                    this.requiresPaymentMethod = true;
+                    this.requiresAction = false;
+                },
+
+                addNewPaymentMethod: function () {
                     var self = this;
 
                     this.paymentProcessing = true;
@@ -139,6 +166,35 @@
                             if (result.error.code === 'parameter_invalid_empty' &&
                                 result.error.param === 'payment_method_data[billing_details][name]') {
                                 self.errorMessage = '{{ __('Please provide your name.') }}';
+                            } else {
+                                self.errorMessage = result.error.message;
+                            }
+                        } else {
+                            self.paymentProcessed = true;
+
+                            self.successMessage = '{{ __('The payment was successful.') }}';
+                        }
+                    });
+                },
+
+                confirmPaymentMethod: function () {
+                    var self = this;
+
+                    this.paymentProcessing = true;
+                    this.paymentProcessed = false;
+                    this.successMessage = '';
+                    this.errorMessage = '';
+
+                    stripe.confirmCardPayment(
+                        '{{ $payment->clientSecret() }}', {
+                            payment_method: '{{ $payment->payment_method }}'
+                        }
+                    ).then(function (result) {
+                        self.paymentProcessing = false;
+                        
+                        if (result.error) {
+                            if (result.error.code === 'payment_intent_authentication_failure') {
+                                self.requestingNewPaymentMethod()
                             } else {
                                 self.errorMessage = result.error.message;
                             }

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -102,7 +102,7 @@
                                 @click="confirmPaymentMethod"
                                 :disabled="paymentProcessing"
                             >
-                                {{ __('Confirm :amount payment', ['amount' => $payment->amount()]) }}
+                                {{ __('Confirm your :amount payment', ['amount' => $payment->amount()]) }}
                             </button>
                         </div>
                     </div>

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Cashier\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Http\Middleware\VerifyRedirectUrl;
@@ -29,15 +28,11 @@ class PaymentController extends Controller
      */
     public function show($id)
     {
-        $payment = new Payment(
-            StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
-        );
-
         return view('cashier::payment', [
             'stripeKey' => config('cashier.key'),
-            'requiresPaymentMethod' => json_encode($payment->requiresPaymentMethod()),
-            'requiresAction' => json_encode($payment->requiresAction()),
-            'payment' => $payment,
+            'payment' => new Payment(
+                StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
+            ),
             'redirect' => request('redirect'),
         ]);
     }

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -29,11 +29,15 @@ class PaymentController extends Controller
      */
     public function show($id)
     {
+        $payment = new Payment(
+            StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
+        );
+
         return view('cashier::payment', [
             'stripeKey' => config('cashier.key'),
-            'payment' => new Payment(
-                StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
-            ),
+            'requiresPaymentMethod' => json_encode($payment->requiresPaymentMethod()),
+            'requiresAction' => json_encode($payment->requiresAction()),
+            'payment' => $payment,
             'redirect' => request('redirect'),
         ]);
     }


### PR DESCRIPTION
Replaces https://github.com/laravel/cashier-stripe/pull/982 as I couldn't push to the OP's branch.

This PR fixes the issue where a payment confirmation would always add a new card. With the new behavior it differentiates between two possible failures: requires action (just confirmation of the payment) or requires payment method (new payment method needs to be set). Both are now properly handled.

Fixes https://github.com/laravel/cashier-stripe/issues/971