### PR TITLE
Move user model to directory

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -57,7 +57,7 @@ return [
     |
     */
 
-    'model' => env('CASHIER_MODEL', App\User::class),
+    'model' => env('CASHIER_MODEL', App\Models\User::class),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
As Laravel 8 moved the models to its own directory.

Only downside is that old installations will need to keep the exported config or specify the model on the env.