### PR TITLE
[12.x] Fix quantity preserving

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -644,7 +644,7 @@ class Subscription extends Model
 
             return [$plan => array_merge([
                 'plan' => $plan,
-                'quantity' => $isSinglePlanSwap ? $this->quantity: 1,
+                'quantity' => $isSinglePlanSwap ? $this->quantity : 1,
                 'tax_rates' => $this->getPlanTaxRatesForPayload($plan),
             ], $options)];
         });

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -633,13 +633,11 @@ class Subscription extends Model
      */
     protected function parseSwapPlans(array $plans)
     {
-        // When the subscription is a single plan subscription,
-        // we need to make sure that the new subscription item
-        // will get the same quantity as the previous one.
         $isSinglePlanSwap = $this->hasSinglePlan() && count($plans) === 1;
 
         return collect($plans)->mapWithKeys(function ($options, $plan) use ($isSinglePlanSwap) {
             $plan = is_string($options) ? $options : $plan;
+
             $options = is_string($options) ? [] : $options;
 
             return [$plan => array_merge([

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -556,7 +556,7 @@ class Subscription extends Model
     /**
      * Swap the subscription to new Stripe plans.
      *
-     * @param  string|string[]  $plans
+     * @param  string|array  $plans
      * @param  array  $options
      * @return $this
      *
@@ -611,7 +611,7 @@ class Subscription extends Model
     /**
      * Swap the subscription to new Stripe plans, and invoice immediately.
      *
-     * @param  string|string[]  $plans
+     * @param  string|array  $plans
      * @param  array  $options
      * @return $this
      *
@@ -628,17 +628,23 @@ class Subscription extends Model
     /**
      * Parse the given plans for a swap operation.
      *
-     * @param  string|string[]  $plans
+     * @param  array  $plans
      * @return \Illuminate\Support\Collection
      */
-    protected function parseSwapPlans($plans)
+    protected function parseSwapPlans(array $plans)
     {
-        return collect($plans)->mapWithKeys(function ($options, $plan) {
+        // When the subscription is a single plan subscription,
+        // we need to make sure that the new subscription item
+        // will get the same quantity as the previous one.
+        $isSinglePlanSwap = $this->hasSinglePlan() && count($plans) === 1;
+
+        return collect($plans)->mapWithKeys(function ($options, $plan) use ($isSinglePlanSwap) {
             $plan = is_string($options) ? $options : $plan;
             $options = is_string($options) ? [] : $options;
 
             return [$plan => array_merge([
                 'plan' => $plan,
+                'quantity' => $isSinglePlanSwap ? $this->quantity: 1,
                 'tax_rates' => $this->getPlanTaxRatesForPayload($plan),
             ], $options)];
         });

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -213,6 +213,32 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals(static::$couponId, $subscription->asStripeSubscription()->discount->coupon->id);
     }
 
+    public function test_swapping_subscription_and_preserving_quantity()
+    {
+        $user = $this->createCustomer('swapping_subscription_and_preserving_quantity');
+        $subscription = $user->newSubscription('main', static::$planId)
+            ->quantity(5, static::$planId)
+            ->create('pm_card_visa');
+
+        $subscription = $subscription->swap(static::$otherPlanId);
+
+        $this->assertSame(5, $subscription->quantity);
+        $this->assertSame(5, $subscription->asStripeSubscription()->quantity);
+    }
+
+    public function test_swapping_subscription_and_adopting_new_quantity()
+    {
+        $user = $this->createCustomer('swapping_subscription_and_adopting_new_quantity');
+        $subscription = $user->newSubscription('main', static::$planId)
+            ->quantity(5, static::$planId)
+            ->create('pm_card_visa');
+
+        $subscription = $subscription->swap([static::$otherPlanId => ['quantity' => 3]]);
+
+        $this->assertSame(3, $subscription->quantity);
+        $this->assertSame(3, $subscription->asStripeSubscription()->quantity);
+    }
+
     public function test_declined_card_during_subscribing_results_in_an_exception()
     {
         $user = $this->createCustomer('declined_card_during_subscribing_results_in_an_exception');


### PR DESCRIPTION
This PR fixes the scenario for single plan subscriptions doing swaps but where the quantity may get lost during the swapping. It also fixes a scenario where you'd explicitly want to set a new quantity during swapping.

Fixes https://github.com/laravel/cashier-stripe/issues/990