### PR TITLE
[12.x] Implement trialEndsAt

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -52,6 +52,21 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Get the ending date of the trial.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function trialEndsAt($name = 'default')
+    {
+        if ($this->onGenericTrial()) {
+            return $this->trial_ends_at;
+        }
+
+        return $this->subscription($name)->trial_ends_at;
+    }
+
+    /**
      * Determine if the Stripe model has a given subscription.
      *
      * @param  string  $name

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -447,7 +447,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($subscription->onTrial());
         $this->assertFalse($subscription->recurring());
         $this->assertFalse($subscription->ended());
-        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
+        $this->assertEquals(Carbon::today()->addDays(7)->day, $user->trialEndsAt('main')->day);
 
         // Cancel Subscription
         $subscription->cancel();

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -16,9 +16,10 @@ class CustomerTest extends TestCase
 
         $this->assertFalse($user->onGenericTrial());
 
-        $user->trial_ends_at = Carbon::tomorrow();
+        $user->trial_ends_at = $tomorrow = Carbon::tomorrow();
 
         $this->assertTrue($user->onGenericTrial());
+        $this->assertSame($tomorrow, $user->trialEndsAt());
 
         $user->trial_ends_at = Carbon::today()->subDays(5);
 


### PR DESCRIPTION
Port of https://github.com/laravel/cashier-paddle/pull/69 for Cashier Stripe. Credits to @yoeriboven.

Tests are failing because of rate limiting. Passing locally.