### PR TITLE
[12.x] Stripe Checkout Support

### DIFF
--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -15,7 +15,7 @@
 
         checkoutButton.addEventListener('click', function () {
             // When the customer clicks on the button, redirect them to Checkout.
-            Stripe('{{ config('cashier.key') }}').redirectToCheckout({
+            Stripe('{{ $stripeKey }}').redirectToCheckout({
                 sessionId: '{{ $sessionId }}'
             }).then(function (result) {
                 // If `redirectToCheckout` fails due to a browser or network

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,0 +1,27 @@
+<button
+    id="checkout-{{ $sessionId }}"
+    role="link"
+    style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em"
+>
+    {{ $label }}
+</button>
+
+<div id="error-message"></div>
+
+<script>
+    const checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
+
+    checkoutButton.addEventListener('click', function () {
+        // When the customer clicks on the button, redirect them to Checkout.
+        Stripe('{{ config('cashier.key') }}').redirectToCheckout({
+            sessionId: '{{ $sessionId }}'
+        }).then(function (result) {
+            // If `redirectToCheckout` fails due to a browser or network
+            // error, display the localized error message to your customer
+            // using `result.error.message`.
+            if (result.error) {
+                document.getElementById('error-message').innerText = result.error.message;
+            }
+        });
+    });
+</script>

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -9,19 +9,21 @@
 <div id="error-message"></div>
 
 <script>
-    const checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
+    (() => {
+        const checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
 
-    checkoutButton.addEventListener('click', function () {
-        // When the customer clicks on the button, redirect them to Checkout.
-        Stripe('{{ config('cashier.key') }}').redirectToCheckout({
-            sessionId: '{{ $sessionId }}'
-        }).then(function (result) {
-            // If `redirectToCheckout` fails due to a browser or network
-            // error, display the localized error message to your customer
-            // using `result.error.message`.
-            if (result.error) {
-                document.getElementById('error-message').innerText = result.error.message;
-            }
+        checkoutButton.addEventListener('click', function () {
+            // When the customer clicks on the button, redirect them to Checkout.
+            Stripe('{{ config('cashier.key') }}').redirectToCheckout({
+                sessionId: '{{ $sessionId }}'
+            }).then(function (result) {
+                // If `redirectToCheckout` fails due to a browser or network
+                // error, display the localized error message to your customer
+                // using `result.error.message`.
+                if (result.error) {
+                    document.getElementById('error-message').innerText = result.error.message;
+                }
+            });
         });
-    });
+    })()
 </script>

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,8 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em"
+    style="{{ isset($style) && ! isset($class) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
+    @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}
 </button>

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -75,6 +75,7 @@ class Checkout
         return View::make('cashier::checkout', array_merge([
             'label' => $label,
             'sessionId' => $this->session->id,
+            'stripeKey' => config('cashier.key'),
         ], $options));
     }
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Support\Facades\View;
+use Stripe\Checkout\Session;
+
+class Checkout
+{
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $owner;
+
+    /**
+     * @var \Stripe\Checkout\Session
+     */
+    protected $session;
+
+    /**
+     * Create a new Checkout instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  \Stripe\Checkout\Session  $session
+     * @return void
+     */
+    public function __construct($owner, Session $session)
+    {
+        $this->owner = $owner;
+        $this->session = $session;
+    }
+
+    /**
+     * Get the Checkout Session ID.
+     *
+     * @return string
+     */
+    public function sessionId()
+    {
+        return $this->session->id;
+    }
+
+    /**
+     * Begin a new Checkout Session.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public static function create($owner, array $sessionOptions = [], array $customerOptions = [])
+    {
+        $customer = $owner->createOrGetStripeCustomer($customerOptions);
+
+        $session = Session::create(array_merge([
+            'customer' => $customer->id,
+            'mode' => 'payment',
+            'success_url' => route('home').'?checkout=success',
+            'cancel_url' => route('home').'?checkout=cancelled',
+            'payment_method_types' => ['card'],
+        ], $sessionOptions), Cashier::stripeOptions());
+
+        return new static($customer, $session);
+    }
+
+    /**
+     * Get the View instance for the button.
+     *
+     * @param  string  $label
+     * @param  array  $options
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function button($label = 'Check out', array $options = [])
+    {
+        return View::make('cashier::checkout', array_merge([
+            'label' => $label,
+            'sessionId' => $this->session->id,
+        ], $options));
+    }
+
+    /**
+     * @return \Stripe\Checkout\Session
+     */
+    public function asStripeCheckoutSession()
+    {
+        return $this->session;
+    }
+}

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -8,17 +8,21 @@ use Stripe\Checkout\Session;
 class Checkout
 {
     /**
+     * The Stripe model instance.
+     *
      * @var \Illuminate\Database\Eloquent\Model
      */
     protected $owner;
 
     /**
+     * The Stripe Checkout Session instance.
+     *
      * @var \Stripe\Checkout\Session
      */
     protected $session;
 
     /**
-     * Create a new Checkout instance.
+     * Create a new Checkout Session instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $owner
      * @param  \Stripe\Checkout\Session  $session
@@ -28,16 +32,6 @@ class Checkout
     {
         $this->owner = $owner;
         $this->session = $session;
-    }
-
-    /**
-     * Get the Checkout Session ID.
-     *
-     * @return string
-     */
-    public function sessionId()
-    {
-        return $this->session->id;
     }
 
     /**
@@ -55,8 +49,8 @@ class Checkout
         $session = Session::create(array_merge([
             'customer' => $customer->id,
             'mode' => 'payment',
-            'success_url' => route('home').'?checkout=success',
-            'cancel_url' => route('home').'?checkout=cancelled',
+            'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
+            'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
             'payment_method_types' => ['card'],
         ], $sessionOptions), Cashier::stripeOptions());
 
@@ -80,10 +74,23 @@ class Checkout
     }
 
     /**
+     * Get the Checkout Session as a Stripe Checkout Session object.
+     *
      * @return \Stripe\Checkout\Session
      */
     public function asStripeCheckoutSession()
     {
         return $this->session;
+    }
+
+    /**
+     * Dynamically get values from the Stripe Checkout Session.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->session->{$key};
     }
 }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -60,7 +60,26 @@ trait PerformsCharges
     }
 
     /**
-     * Begin a new Checkout Session.
+     * Begin a new Checkout Session for an existing Price ID.
+     *
+     * @param  string  $price
+     * @param  int  $quantity
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public function checkout($price, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    {
+        return Checkout::create($this, array_merge([
+            'line_items' => [[
+                'price' => $price,
+                'quantity' => $quantity,
+            ]],
+        ], $sessionOptions), $customerOptions);
+    }
+
+    /**
+     * Begin a new Checkout Session for a "one-off" charge.
      *
      * @param  int  $amount
      * @param  string  $name
@@ -69,7 +88,7 @@ trait PerformsCharges
      * @param  array  $customerOptions
      * @return \Laravel\Cashier\Checkout
      */
-    public function checkout($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
     {
         return Checkout::create($this, array_merge([
             'line_items' => [[
@@ -80,25 +99,6 @@ trait PerformsCharges
                     ],
                     'unit_amount' => $amount,
                 ],
-                'quantity' => $quantity,
-            ]],
-        ], $sessionOptions), $customerOptions);
-    }
-
-    /**
-     * Begin a new Checkout Session.
-     *
-     * @param  string  $price
-     * @param  int  $quantity
-     * @param  array  $sessionOptions
-     * @param  array  $customerOptions
-     * @return \Laravel\Cashier\Checkout
-     */
-    public function checkoutProduct($price, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
-    {
-        return Checkout::create($this, array_merge([
-            'line_items' => [[
-                'price' => $price,
                 'quantity' => $quantity,
             ]],
         ], $sessionOptions), $customerOptions);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
 use Stripe\PaymentIntent as StripePaymentIntent;
 use Stripe\Refund as StripeRefund;
@@ -56,5 +57,50 @@ trait PerformsCharges
             ['payment_intent' => $paymentIntent] + $options,
             $this->stripeOptions()
         );
+    }
+
+    /**
+     * Begin a new Checkout Session.
+     *
+     * @param  int  $amount
+     * @param  string  $name
+     * @param  int  $quantity
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public function checkout($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    {
+        return Checkout::create($this, array_merge([
+            'line_items' => [[
+                'price_data' => [
+                    'currency' => $this->preferredCurrency(),
+                    'product_data' => [
+                        'name' => $name,
+                    ],
+                    'unit_amount' => $amount,
+                ],
+                'quantity' => $quantity,
+            ]],
+        ], $sessionOptions), $customerOptions);
+    }
+
+    /**
+     * Begin a new Checkout Session.
+     *
+     * @param  string  $price
+     * @param  int  $quantity
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public function checkoutProduct($price, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    {
+        return Checkout::create($this, array_merge([
+            'line_items' => [[
+                'price' => $price,
+                'quantity' => $quantity,
+            ]],
+        ], $sessionOptions), $customerOptions);
     }
 }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -10,6 +10,13 @@ use Stripe\Refund as StripeRefund;
 trait PerformsCharges
 {
     /**
+     * Determines if user redeemable promotion codes are available in Stripe Checkout.
+     *
+     * @var bool
+     */
+    protected $allowPromotionCodes = false;
+
+    /**
      * Make a "one off" charge on the customer for the given amount.
      *
      * @param  int  $amount
@@ -71,6 +78,7 @@ trait PerformsCharges
     public function checkout($price, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
     {
         return Checkout::create($this, array_merge([
+            'allow_promotion_codes' => $this->allowPromotionCodes,
             'line_items' => [[
                 'price' => $price,
                 'quantity' => $quantity,
@@ -91,6 +99,7 @@ trait PerformsCharges
     public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
     {
         return Checkout::create($this, array_merge([
+            'allow_promotion_codes' => $this->allowPromotionCodes,
             'line_items' => [[
                 'price_data' => [
                     'currency' => $this->preferredCurrency(),
@@ -102,5 +111,17 @@ trait PerformsCharges
                 'quantity' => $quantity,
             ]],
         ], $sessionOptions), $customerOptions);
+    }
+
+    /**
+     * Enables user redeemable promotion codes.
+     *
+     * @return $this
+     */
+    public function allowPromotionCodes()
+    {
+        $this->allowPromotionCodes = true;
+
+        return $this;
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -56,6 +56,49 @@ class WebhookController extends Controller
     }
 
     /**
+     * Handle customer subscription created.
+     *
+     * @param  array $payload
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function handleCustomerSubscriptionCreated(array $payload)
+    {
+        $user = $this->getUserByStripeId($payload['data']['object']['customer']);
+
+        if ($user) {
+            $data = $payload['data']['object'];
+
+            if (! $user->subscriptions->contains('stripe_id', $data['id'])) {
+                if (isset($data['trial_end'])) {
+                    $trialEndsAt = Carbon::createFromTimestamp($data['trial_end']);
+                } else {
+                    $trialEndsAt = null;
+                }
+
+                $subscription = $user->subscriptions()->create([
+                    'name' => $data['metadata']['name'],
+                    'stripe_id' => $data['id'],
+                    'stripe_status' => $data['status'],
+                    'stripe_plan' =>  $data['plan']['id'] ?? null,
+                    'quantity' => $data['quantity'],
+                    'trial_ends_at' => $trialEndsAt,
+                    'ends_at' => null,
+                ]);
+
+                foreach ($data['items']['data'] as $item) {
+                    $subscription->items()->create([
+                        'stripe_id' => $item['id'],
+                        'stripe_plan' => $item['plan']['id'],
+                        'quantity' => $item['quantity'],
+                    ]);
+                }
+            }
+        }
+
+        return new Response('Webhook Handled', 200);
+    }
+
+    /**
      * Handle customer subscription updated.
      *
      * @param  array  $payload

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -95,7 +95,7 @@ class WebhookController extends Controller
             }
         }
 
-        return new Response('Webhook Handled', 200);
+        return $this->successMethod();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -49,8 +49,10 @@ class Subscription extends Model
      * @var array
      */
     protected $dates = [
-        'trial_ends_at', 'ends_at',
-        'created_at', 'updated_at',
+        'created_at',
+        'ends_at',
+        'trial_ends_at',
+        'updated_at',
     ];
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -72,6 +72,14 @@ class SubscriptionBuilder
     protected $promotionCode;
 
     /**
+     * Determines if user redeemable promotion codes are available in Stripe Checkout.
+     *
+     * @var bool
+     */
+    protected $allowPromotionCodes = false;
+
+
+    /**
      * The metadata to apply to the subscription.
      *
      * @var array
@@ -221,6 +229,18 @@ class SubscriptionBuilder
     }
 
     /**
+     * Enables user redeemable promotion codes.
+     *
+     * @return $this
+     */
+    public function allowPromotionCodes()
+    {
+        $this->allowPromotionCodes = true;
+
+        return $this;
+    }
+
+    /**
      * The metadata to apply to a new subscription.
      *
      * @param  array  $metadata
@@ -332,9 +352,12 @@ class SubscriptionBuilder
         return Checkout::create($this->owner, array_merge([
             'mode' => 'subscription',
             'line_items' => collect($this->items)->values()->all(),
+            'allow_promotion_codes' => $this->allowPromotionCodes,
+            'discounts' => [
+                'coupon' => $this->coupon,
+            ],
             'default_tax_rates' => $this->getTaxRatesForPayload(),
             'subscription_data' => [
-                'coupon' => $this->coupon,
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ],

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -78,7 +78,6 @@ class SubscriptionBuilder
      */
     protected $allowPromotionCodes = false;
 
-
     /**
      * The metadata to apply to the subscription.
      *

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -56,12 +56,15 @@ class CheckoutTest extends FeatureTestCase
             'unit_amount' => 1500,
         ]);
 
-        $checkout = $user->newSubscription('default', $price->id)->checkout([
-            'success_url' => 'http://example.com',
-            'cancel_url' => 'http://example.com',
-        ]);
+        $checkout = $user->newSubscription('default', $price->id)
+            ->allowPromotionCodes()
+            ->checkout([
+                'success_url' => 'http://example.com',
+                'cancel_url' => 'http://example.com',
+            ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
+        $this->assertInstanceOf(StripeCheckoutSession::class, $session = $checkout->asStripeCheckoutSession());
+        $this->assertTrue($session->allow_promotion_codes);
     }
 }

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -8,19 +8,6 @@ use Stripe\Price as StripePrice;
 
 class CheckoutTest extends FeatureTestCase
 {
-    public function test_customers_can_start_a_checkout_session()
-    {
-        $user = $this->createCustomer('customers_can_start_a_checkout_session');
-
-        $checkout = $user->checkout(1200, 'T-shirt', 1, [
-            'success_url' => 'http://example.com',
-            'cancel_url' => 'http://example.com',
-        ]);
-
-        $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
-    }
-
     public function test_customers_can_start_a_product_checkout_session()
     {
         $user = $this->createCustomer('customers_can_start_a_product_checkout_session');
@@ -33,7 +20,20 @@ class CheckoutTest extends FeatureTestCase
             'unit_amount' => 1500,
         ]);
 
-        $checkout = $user->checkoutProduct($price->id, 1, [
+        $checkout = $user->checkout($price->id, 1, [
+            'success_url' => 'http://example.com',
+            'cancel_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
+    }
+
+    public function test_customers_can_start_a_one_off_charge_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_a_one_off_charge_checkout_session');
+
+        $checkout = $user->checkoutCharge(1200, 'T-shirt', 1, [
             'success_url' => 'http://example.com',
             'cancel_url' => 'http://example.com',
         ]);

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use Laravel\Cashier\Checkout;
+use Stripe\Checkout\Session as StripeCheckoutSession;
+use Stripe\Price as StripePrice;
+
+class CheckoutTest extends FeatureTestCase
+{
+    public function test_customers_can_start_a_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_a_checkout_session');
+
+        $checkout = $user->checkout(1200, 'T-shirt', 1, [
+            'success_url' => 'http://example.com',
+            'cancel_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
+    }
+
+    public function test_customers_can_start_a_product_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_a_product_checkout_session');
+
+        $price = StripePrice::create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $checkout = $user->checkoutProduct($price->id, 1, [
+            'success_url' => 'http://example.com',
+            'cancel_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
+    }
+
+    public function test_customers_can_start_a_subscription_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_a_subscription_checkout_session');
+
+        $price = StripePrice::create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'Forge',
+            ],
+            'nickname' => 'Forge Hobby',
+            'recurring' => ['interval' => 'year'],
+            'unit_amount' => 1500,
+        ]);
+
+        $checkout = $user->newSubscription('default', $price->id)->checkout([
+            'success_url' => 'http://example.com',
+            'cancel_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
+    }
+}

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -12,7 +12,7 @@ class CheckoutTest extends FeatureTestCase
     {
         $user = $this->createCustomer('customers_can_start_a_product_checkout_session');
 
-        $price = StripePrice::create([
+        $shirtPrice = StripePrice::create([
             'currency' => 'USD',
             'product_data' => [
                 'name' => 'T-shirt',
@@ -20,7 +20,17 @@ class CheckoutTest extends FeatureTestCase
             'unit_amount' => 1500,
         ]);
 
-        $checkout = $user->checkout($price->id, 1, [
+        $carPrice = StripePrice::create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'Car',
+            ],
+            'unit_amount' => 30000,
+        ]);
+
+        $items = [$shirtPrice->id => 5, $carPrice->id];
+
+        $checkout = $user->checkout($items, [
             'success_url' => 'http://example.com',
             'cancel_url' => 'http://example.com',
         ]);


### PR DESCRIPTION
This PR adds functionality for Stripe checkout and is a continuation of https://github.com/laravel/cashier-stripe/pull/652. All concerns on the original PR have been resolved since.

Docs: https://github.com/laravel/docs/pull/6465

### Usage

Checking out a single priced product:

```php
$checkout = Auth::user()->checkout('price_xxx');

return view('checkout', compact('checkout'));
```

Checking out a single priced product with a specific quantity:

```php
$checkout = Auth::user()->checkout(['price_xxx' => 5]);

return view('checkout', compact('checkout'));
```

Checking out multiple priced products and optionally assign quantities to some:

```php
$checkout = Auth::user()->checkout(['price_xxx' => 5, 'price_yyy']);

return view('checkout', compact('checkout'));
```

Checking out a single priced product and allow promotional codes to be applied:

```php
$checkout = Auth::user()->allowPromotionCodes()->checkout('price_xxx');

return view('checkout', compact('checkout'));
```

Checking out a new $12 priced product (this will create a new product in the dashboard):

```php
$checkout = Auth::user()->checkoutCharge(1200, 'T-shirt');

return view('checkout', compact('checkout'));
```

Checking out a new $12 priced product together with a Price ID product:

```php
$checkout = Auth::user()->checkout([
    'price_xxx', 
    [
        'price_data' => [
            'currency' => Auth::user()->preferredCurrency(),
            'product_data' => [
                'name' => 'T-Shirt',
            ],
            'unit_amount' => 1200,
        ],
    ],
]);

return view('checkout', compact('checkout'));
```

Check out a subscription:

```php
$checkout = Auth::user()->newSubscription('default', 'price_xxx')->checkout();

return view('checkout', compact('checkout'));
```

Check out a subscription and allow promotional codes to be applied:

```php
$checkout = Auth::user()->newSubscription('default', 'price_xxx')
    ->allowPromotionCodes()
    ->checkout();

return view('checkout', compact('checkout'));
```

Then place any of these in a view:

```php
{!! $checkout->button() !!}
```

#### Button Styling

By default a generated checkout button will have the following styling:

![Screenshot 2020-10-05 at 18 00 30](https://user-images.githubusercontent.com/594614/95103379-d0efc380-0734-11eb-87cf-69632cedcd20.png)

It's however easy to style this. Pass either a custom `style` or `class` attribute:

```php
{!! $checkout->button('Buy', ['class' => 'text-white bg-blue-500 p-4']) !!}
```

### Todos

- [x] Subscribing to plans
- [x] Charging products
- [x] Single charges
- [x] Webhooks
- [x] Style button
- [x] Tests
- [x] Write documentation

Closes https://github.com/laravel/cashier-stripe/issues/637