### PR TITLE
[1.x] Update the badges to use shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <p align="center">
 <a href="https://github.com/laravel/cashier/actions"><img src="https://github.com/laravel/cashier/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/cashier"><img src="https://poser.pugx.org/laravel/cashier/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/cashier"><img src="https://poser.pugx.org/laravel/cashier/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/cashier"><img src="https://poser.pugx.org/laravel/cashier/license.svg" alt="License"></a>
+<a href="https://packagist.org/packages/laravel/cashier"><img src="https://img.shields.io/packagist/dt/laravel/cashier" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/laravel/cashier"><img src="https://img.shields.io/packagist/v/laravel/cashier" alt="Latest Stable Version"></a>
+<a href="https://packagist.org/packages/laravel/cashier"><img src="https://img.shields.io/packagist/l/laravel/cashier" alt="License"></a>
 </p>
 
 ## Introduction


### PR DESCRIPTION
Shields.io works a lot better than the old pugx.org.