### PR TITLE
[12.x] Support PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         exclude:
           - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "dompdf/dompdf": "^0.8.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
This adds support for PHP 8.

_Tests failing because of missing Stripe API Key; [see successful runs on my fork](https://github.com/mmachatschek/cashier-stripe/actions/runs/337253590)_