### PR TITLE
[11.x] Fail url checking when url is invalid (#984)

### DIFF
--- a/src/Http/Middleware/VerifyRedirectUrl.php
+++ b/src/Http/Middleware/VerifyRedirectUrl.php
@@ -20,7 +20,9 @@ class VerifyRedirectUrl
     {
         $redirect = $request->get('redirect');
 
-        if ($redirect && parse_url($redirect)['host'] !== $request->getHost()) {
+        $url = parse_url($redirect);
+
+        if ($redirect && (! isset($url['host']) || $url['host'] !== $request->getHost())) {
             throw new AccessDeniedHttpException('Redirect host mismatch.');
         }
 

--- a/tests/Unit/VerifyRedirectUrlTest.php
+++ b/tests/Unit/VerifyRedirectUrlTest.php
@@ -33,6 +33,18 @@ class VerifyRedirectUrlTest extends TestCase
         });
     }
 
+    public function test_it_fails_when_the_url_is_invalid()
+    {
+        $request = Request::create('http://baz.com/stripe/payment', 'GET', ['redirect' => 'foo/bar']);
+        $middleware = new VerifyRedirectUrl;
+
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $middleware->handle($request, function () {
+            //
+        });
+    }
+
     public function test_it_is_skipped_when_no_redirect_is_present()
     {
         $request = Request::create('http://baz.com/stripe/payment', 'GET');


### PR DESCRIPTION
This PR is to copy a bug fix that was committed to the `12.x` branch into the `11.x` branch.
See https://github.com/laravel/cashier-stripe/pull/984/

The current version of `laravel/spark-aurelius` (11.0) currently requires `"laravel/cashier": "^11.0"`, in which this bug is still present.

I am aware that the Laravel Contribution guide specifies that all bug fixes should only be committed in the latest stable branch. However, since the latest stable branch of `laravel/spark-aurelius` requires an older version of `laravel/cashier`, I believe that it would be appropriate to perform this patch on the older branch.