### PR TITLE
[12.x] Fix proration behaviour being forced when syncing tax rates

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -987,12 +987,16 @@ class Subscription extends Model
 
         $stripeSubscription->default_tax_rates = $this->user->taxRates();
 
+        $stripeSubscription->proration_behavior = $this->prorateBehavior();
+
         $stripeSubscription->save();
 
         foreach ($this->items as $item) {
             $stripeSubscriptionItem = $item->asStripeSubscriptionItem();
 
             $stripeSubscriptionItem->tax_rates = $this->getPlanTaxRatesForPayload($item->stripe_plan);
+
+            $stripeSubscriptionItem->proration_behavior = $this->prorateBehavior();
 
             $stripeSubscriptionItem->save();
         }


### PR DESCRIPTION
I recently updated my Cashier implementation to migrate customers from the `tax_percent` property to Stripe's [Tax Rates](https://stripe.com/docs/billing/taxes/tax-rates).

I tried using the `syncTaxRates()` function to update existing customer subscriptions, but found this would always prorate by default. The screenshot below from Stripe's dashboard shows what was happening to existing customers with existing subscriptions when `$user->subscription('default')->syncTaxRates();` was being called. A pair of "Remaining time" invoice items were being added unexpectedly:

<img width="813" alt="Screenshot 2020-11-12 at 16 24 08" src="https://user-images.githubusercontent.com/627533/98966768-95020800-2503-11eb-8f84-acd035b96f82.png">

This change now allows users to call `$user->subscription('default')->noProrate()->syncTaxRates();`, should they wish, to prevent prorating when syncing tax rates.

This shouldn't break existing code, as the default behaviour is to still prorate. This just allows proration behaviour to be overridden when needed.