### PR TITLE
[12.x] Add withPromotionCode method

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -58,11 +58,18 @@ class SubscriptionBuilder
     protected $billingCycleAnchor = null;
 
     /**
-     * The coupon code being applied to the customer.
+     * The coupon being applied to the subscription.
      *
      * @var string|null
      */
     protected $coupon;
+
+    /**
+     * The promotion code being applied to the subscription.
+     *
+     * @var string|null
+     */
+    protected $promotionCode;
 
     /**
      * The metadata to apply to the subscription.
@@ -201,6 +208,19 @@ class SubscriptionBuilder
     }
 
     /**
+     * The promotion code to apply to a new subscription.
+     *
+     * @param  string  $promotionCode
+     * @return $this
+     */
+    public function withPromotionCode($promotionCode)
+    {
+        $this->promotionCode = $promotionCode;
+
+        return $this;
+    }
+
+    /**
      * The metadata to apply to a new subscription.
      *
      * @param  array  $metadata
@@ -321,6 +341,7 @@ class SubscriptionBuilder
             'metadata' => $this->metadata,
             'items' => collect($this->items)->values()->all(),
             'payment_behavior' => $this->paymentBehavior(),
+            'promotion_code' => $this->promotionCode,
             'proration_behavior' => $this->prorateBehavior(),
             'trial_end' => $this->getTrialEndForPayload(),
             'off_session' => true,


### PR DESCRIPTION
This adds a `withPromotionCode` method to the subscription builder in addition to the `withCoupon` method in order to provide for Stripe's new promotion codes. When using this method, the API ID for the promotion code needs to be passed, not the promotion code itself.

```php
$subscription = Auth::user()->newSubscription('default', 'price_xxx')
    ->withPromotionCode('promo_xxx')
    ->create($paymentMethod);
```