### PR TITLE
[12.x] Fix image support in PDF invoices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
-        "dompdf/dompdf": "^0.8.4|^1.0",
+        "dompdf/dompdf": "^0.8.6|^1.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0",

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use Dompdf\Dompdf;
+use Dompdf\Options;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
 use Laravel\Cashier\Exceptions\InvalidInvoice;
@@ -413,7 +414,10 @@ class Invoice
             define('DOMPDF_ENABLE_AUTOLOAD', false);
         }
 
-        $dompdf = new Dompdf;
+        $options = new Options;
+        $options->setChroot(base_path());
+
+        $dompdf = new Dompdf($options);
         $dompdf->setPaper(config('cashier.paper', 'letter'));
         $dompdf->loadHtml($this->view($data)->render());
         $dompdf->render();


### PR DESCRIPTION
This PR fixes (local) image support when using the invoice PDF feature.

## Background

With the release of **Dompdf** [0.8.6](https://github.com/dompdf/dompdf/releases/tag/v0.8.6), a disclosure vulnerability was fixed. By doing so, a breaking change was introduced: when generating a PDF without the proper configuration, only resources within the dompdf folder itself are accessible. As a result, when using Cashier to generate a PDF invoice, the use of a local image (for example, a logo) is blocked.

## Example

Consider this example:

```php
// receipt.blade.php

...
<img src="{{ public_path('images/logo.png' }}" class="logo"/>
...

```

Before 0.8.6, this worked fine. As of 0.8.6, only resources in the vendor/dompdf directory are allowed, causing any file in `public_path` (or any other path in your Laravel app, for that matter) to be rejected.

## Solution

The solution is to configure Dompdf using the new [chroot setting](https://github.com/dompdf/dompdf/blob/v0.8.6/src/Options.php#L46..L61). This PR sets the chroot to `base_path`. As a side effect, the version constraint for dompdf has to be set to 0.8.6 - earlier versions lack this setting.

There's no test available for handling PDF's in general, so I refrained from writing one. If this is required, I am willing to take a stab at it.

## Workarounds

- You can use a remote image instead of a local one, but that's not an option for everyone.
- You can lock dompdf to 0.8.4 in your application, which doesn't come with the restriction (but also lacks PHP 8 support and obviously, the security fix).
 