### PR TITLE
[12.x] Fix return type for invoice line items

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -311,7 +311,7 @@ class Invoice
     /**
      * Get all of the "invoice item" line items.
      *
-     * @return \Illuminate\Support\Collection|\Laravel\Cashier\InvoiceLineItem[]
+     * @return \Laravel\Cashier\InvoiceLineItem[]
      */
     public function invoiceItems()
     {
@@ -321,7 +321,7 @@ class Invoice
     /**
      * Get all of the "subscription" line items.
      *
-     * @return \Illuminate\Support\Collection|\Laravel\Cashier\InvoiceLineItem[]
+     * @return \Laravel\Cashier\InvoiceLineItem[]
      */
     public function subscriptions()
     {
@@ -332,7 +332,7 @@ class Invoice
      * Get all of the invoice items by a given type.
      *
      * @param  string  $type
-     * @return \Illuminate\Support\Collection|\Laravel\Cashier\InvoiceLineItem[]
+     * @return \Laravel\Cashier\InvoiceLineItem[]
      */
     public function invoiceLineItemsByType($type)
     {


### PR DESCRIPTION
`invoiceLineItemsByType` actually returns an array and not a collection.