### PR TITLE
[13.x] Add PaymentMethod type parameter to ManagesPaymentMethods

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -38,7 +38,7 @@ trait ManagesPaymentMethods
     /**
      * Determines if the customer currently has at least one payment method of the given type.
      *
-     * @param String $type
+     * @param string $type
      * @return bool
      */
     public function hasPaymentMethod($type = 'card')
@@ -50,7 +50,7 @@ trait ManagesPaymentMethods
      * Get a collection of the entity's payment methods.
      *
      * @param  array  $parameters
-     * @param  String $type
+     * @param  string $type
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\PaymentMethod[]
      */
     public function paymentMethods($parameters = [], $type = 'card')
@@ -259,7 +259,7 @@ trait ManagesPaymentMethods
     /**
      * Deletes the entity's payment methods of the given type.
      *
-     * @param String $type
+     * @param string $type
      * @return void
      */
     public function deletePaymentMethods($type = 'card')

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -85,7 +85,9 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
         $this->assertEquals('visa', $paymentMethod->card->brand);
+        $this->assertEquals('card', $user->card_brand);
         $this->assertEquals('4242', $paymentMethod->card->last4);
+        $this->assertEquals('4242', $user->card_last_four);
     }
 
     public function test_legacy_we_can_retrieve_an_old_default_source_as_a_default_payment_method()
@@ -141,7 +143,7 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $user = $user->updateDefaultPaymentMethodFromStripe();
 
-        $this->assertEquals('visa', $user->card_brand);
+        $this->assertEquals('card', $user->card_brand);
         $this->assertEquals('4242', $user->card_last_four);
     }
 


### PR DESCRIPTION
I added a `$type` parameter to have the possibility to retrieve other payment methods from Stripe than card.

Should fix #507

I changed the `card_brand` field a bit to hold the PaymenMethods type. So instead of only `visa`, `mastercard` or `Bank Account` it now contains for example `card` or `sepa_debit`. The `card_last_four` field is filled if the given type has the `last4` attribute. So it would probably be a good idea to rename it to `card_type`.