### PR TITLE
[12.x] Allow Stripe dashboard subscriptions

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -76,7 +76,7 @@ class WebhookController extends Controller
                 }
 
                 $subscription = $user->subscriptions()->create([
-                    'name' => $data['metadata']['name'] ?? $this->newSubscriptionName(),
+                    'name' => $data['metadata']['name'] ?? $this->newSubscriptionName($payload),
                     'stripe_id' => $data['id'],
                     'stripe_status' => $data['status'],
                     'stripe_plan' =>  $data['plan']['id'] ?? null,
@@ -101,9 +101,10 @@ class WebhookController extends Controller
     /**
      * Determines the name that should be used when new subscriptions are created from the Stripe dashboard.
      *
+     * @param  array  $payload
      * @return string
      */
-    protected function newSubscriptionName()
+    protected function newSubscriptionName(array $payload)
     {
         return 'default';
     }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -76,7 +76,7 @@ class WebhookController extends Controller
                 }
 
                 $subscription = $user->subscriptions()->create([
-                    'name' => $data['metadata']['name'],
+                    'name' => $data['metadata']['name'] ?? $this->newSubscriptionName(),
                     'stripe_id' => $data['id'],
                     'stripe_status' => $data['status'],
                     'stripe_plan' =>  $data['plan']['id'] ?? null,
@@ -96,6 +96,16 @@ class WebhookController extends Controller
         }
 
         return $this->successMethod();
+    }
+
+    /**
+     * Determines the name that should be used when new subscriptions are created from the Stripe dashboard.
+     *
+     * @return string
+     */
+    protected function newSubscriptionName()
+    {
+        return 'default';
     }
 
     /**

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -94,6 +94,62 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
+    public function test_subscriptions_are_updated()
+    {
+        $user = $this->createCustomer('subscriptions_are_updated', ['stripe_id' => 'cus_foo']);
+
+        $subscription = $user->subscriptions()->create([
+            'name' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_plan' => 'plan_foo',
+            'stripe_status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $item = $subscription->items()->create([
+            'stripe_id' => 'it_foo',
+            'stripe_plan' => 'plan_bar',
+            'quantity' => 1,
+        ]);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.updated',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'quantity' => 5,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'plan' => ['id' => 'plan_foo'],
+                            'quantity' => 10,
+                        ]],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'user_id' => $user->id,
+            'stripe_id' => 'sub_foo',
+            'quantity' => 5,
+        ]);
+
+        $this->assertDatabaseHas('subscription_items', [
+            'subscription_id' => $subscription->id,
+            'stripe_id' => 'bar',
+            'stripe_plan' => 'plan_foo',
+            'quantity' => 10,
+        ]);
+
+        $this->assertDatabaseMissing('subscription_items', [
+            'id' => $item->id,
+        ]);
+    }
+
     public function test_cancelled_subscription_is_properly_reactivated()
     {
         $user = $this->createCustomer('cancelled_subscription_is_properly_reactivated');


### PR DESCRIPTION
Allows subscriptions to be created from the Stripe dashboard. The `newSubscriptionName` allows users to configure a different default key when overriding the `WebhookController`. 

The only limitation with this PR is that it won't work in situations where you have more than one type of subscription and need to differentiate between the names.