### PR TITLE
[12.x] End trial method

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -577,6 +577,29 @@ class Subscription extends Model
     }
 
     /**
+     * Force the trial to end immediately.
+     * Similar to skipTrial(), however this method cannot be combined with swap, resume, etc. and immediately updates the Stripe subscription.
+     *
+     * This method must be combined with swap, resume, etc.
+     *
+     * @return $this
+     */
+    public function endTrial()
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->trial_end = 'now';
+
+        $subscription->save();
+
+        $this->trial_ends_at = null;
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
      * Extend an existing subscription's trial period.
      *
      * @param  \Carbon\CarbonInterface  $date

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -578,7 +578,7 @@ class Subscription extends Model
 
     /**
      * Force the trial to end immediately.
-     * Similar to skipTrial(), however this method cannot be combined with swap, resume, etc. and immediately updates the Stripe subscription.
+     * Similar to skipTrial(), however this method immediately updates the Stripe subscription.
      *
      * This method must be combined with swap, resume, etc.
      *

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -586,17 +586,9 @@ class Subscription extends Model
      */
     public function endTrial()
     {
-        $subscription = $this->asStripeSubscription();
+        $this->setStripeSubscriptionTrialEnd('now');
 
-        $subscription->trial_end = 'now';
-
-        $subscription->save();
-
-        $this->trial_ends_at = null;
-
-        $this->save();
-
-        return $this;
+        return tap($this->skipTrial())->save();
     }
 
     /**
@@ -611,17 +603,28 @@ class Subscription extends Model
             throw new InvalidArgumentException("Extending a subscription's trial requires a date in the future.");
         }
 
-        $subscription = $this->asStripeSubscription();
-
-        $subscription->trial_end = $date->getTimestamp();
-
-        $subscription->save();
+        $this->setStripeSubscriptionTrialEnd($date->getTimestamp());
 
         $this->trial_ends_at = $date;
 
         $this->save();
 
         return $this;
+    }
+
+    /**
+     * Sets the Stripe subscription trial end date.
+     *
+     * @param string|int $timestamp
+     * @return void
+     */
+    protected function setStripeSubscriptionTrialEnd($timestamp)
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->trial_end = $timestamp;
+
+        $subscription->save();
     }
 
     /**

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -602,6 +602,19 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals($subscription->asStripeSubscription()->trial_end, $trialEndsAt->getTimestamp());
     }
 
+    public function test_trials_can_be_ended()
+    {
+        $user = $this->createCustomer('trials_can_be_ended');
+
+        $subscription = $user->newSubscription('main', static::$planId)
+            ->trialDays(10)
+            ->create('pm_card_visa');
+
+        $subscription->endTrial();
+
+        $this->assertNull($subscription->trial_ends_at);
+    }
+
     public function test_applying_coupons_to_existing_customers()
     {
         $user = $this->createCustomer('applying_coupons_to_existing_customers');


### PR DESCRIPTION
Does what it says on the tin
```php

$subscription = $user->newSubscription('main', 'plan_123')
    ->trialDays(10)
    ->create($paymentMethod);

$subscription->endTrial();

```
