### PR TITLE
[13.x] Drop Laravel 6 & 7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        laravel: [^6.0, ^7.0, ^8.0]
+        laravel: [^8.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,24 +17,24 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0",
-        "illuminate/log": "^6.0|^7.0|^8.0",
-        "illuminate/notifications": "^6.0|^7.0|^8.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/view": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^8.0",
+        "illuminate/database": "^8.0",
+        "illuminate/http": "^8.0",
+        "illuminate/log": "^8.0",
+        "illuminate/notifications": "^8.0",
+        "illuminate/routing": "^8.0",
+        "illuminate/support": "^8.0",
+        "illuminate/view": "^8.0",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^7.39",
-        "symfony/http-kernel": "^4.3|^5.0",
-        "symfony/intl": "^4.3|^5.0"
+        "symfony/http-kernel": "^5.0",
+        "symfony/intl": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.0"
     },
     "suggest": {
         "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."


### PR DESCRIPTION
Drop support for older Laravel versions in the next Cashier release.