### PR TITLE
[13.x] Drop PHP 7.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
-        exclude:
-          - php: 7.2
-            laravel: ^8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/contracts": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
Drop support for PHP 7.2 in the next major Cashier release.