### PR TITLE
[13.x] Make plans optional for newSubscription

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -14,7 +14,7 @@ trait ManagesSubscriptions
      * @param  string|string[]  $plans
      * @return \Laravel\Cashier\SubscriptionBuilder
      */
-    public function newSubscription($name, $plans)
+    public function newSubscription($name, $plans = [])
     {
         return new SubscriptionBuilder($this, $name, $plans);
     }

--- a/tests/Feature/MeteredBillingTest.php
+++ b/tests/Feature/MeteredBillingTest.php
@@ -91,7 +91,7 @@ class MeteredBillingTest extends FeatureTestCase
     {
         $user = $this->createCustomer('report_usage_for_metered_price');
 
-        $subscription = $user->newSubscription('main', [])
+        $subscription = $user->newSubscription('main')
             ->meteredPlan(static::$meteredPrice)
             ->create('pm_card_visa');
 
@@ -155,7 +155,7 @@ class MeteredBillingTest extends FeatureTestCase
     {
         $user = $this->createCustomer('swap_metered_price_to_different_price');
 
-        $subscription = $user->newSubscription('main', [])
+        $subscription = $user->newSubscription('main')
             ->meteredPlan(static::$meteredPrice)
             ->create('pm_card_visa');
 
@@ -177,7 +177,7 @@ class MeteredBillingTest extends FeatureTestCase
     {
         $user = $this->createCustomer('swap_metered_price_to_different_price_with_a_multi_plan_subscription');
 
-        $subscription = $user->newSubscription('main', [])
+        $subscription = $user->newSubscription('main')
             ->meteredPlan(static::$meteredPrice)
             ->create('pm_card_visa');
 
@@ -220,7 +220,7 @@ class MeteredBillingTest extends FeatureTestCase
     {
         $user = $this->createCustomer('cancel_metered_subscription');
 
-        $subscription = $user->newSubscription('main', [])
+        $subscription = $user->newSubscription('main')
             ->meteredPlan(static::$meteredPrice)
             ->create('pm_card_visa');
 
@@ -237,7 +237,7 @@ class MeteredBillingTest extends FeatureTestCase
     {
         $user = $this->createCustomer('cancel_metered_subscription_immediately');
 
-        $subscription = $user->newSubscription('main', [])
+        $subscription = $user->newSubscription('main')
             ->meteredPlan(static::$meteredPrice)
             ->create('pm_card_visa');
 


### PR DESCRIPTION
In the next major Cashier version we can make plans optional for `newSubscription` because features like metered billing require a slightly different flow.