### PR TITLE
[12.x] requiresConfirmation status helper method

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -76,7 +76,6 @@ class Payment
         return $this->paymentIntent->status === StripePaymentIntent::STATUS_REQUIRES_ACTION;
     }
 
-
     /**
      * Determine if the payment needs to be confirmed.
      *

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -76,6 +76,17 @@ class Payment
         return $this->paymentIntent->status === StripePaymentIntent::STATUS_REQUIRES_ACTION;
     }
 
+
+    /**
+     * Determine if the payment needs to be confirmed.
+     *
+     * @return bool
+     */
+    public function requiresConfirmation()
+    {
+        return $this->paymentIntent->status === StripePaymentIntent::STATUS_REQUIRES_CONFIRMATION;
+    }
+
     /**
      * Determine if the payment was cancelled.
      *

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -93,7 +93,7 @@ class Payment
      */
     public function requiresCapture()
     {
-        return $this->paymentIntent->status === StripePaymentIntent::STATUS_REQUIRES_CAPTURE;
+        return $this->paymentIntent->status === 'requires_capture';
     }
 
     /**

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -117,6 +117,16 @@ class Payment
     }
 
     /**
+     * Determine if the payment is processing.
+     *
+     * @return bool
+     */
+    public function isProcessing()
+    {
+        return $this->paymentIntent->status === StripePaymentIntent::STATUS_PROCESSING;
+    }
+
+    /**
      * Validate if the payment intent was successful and throw an exception if not.
      *
      * @return void

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -87,6 +87,16 @@ class Payment
     }
 
     /**
+     * Determine if the payment needs to be captured.
+     *
+     * @return bool
+     */
+    public function requiresCapture()
+    {
+        return $this->paymentIntent->status === StripePaymentIntent::STATUS_REQUIRES_CAPTURE;
+    }
+
+    /**
      * Determine if the payment was cancelled.
      *
      * @return bool


### PR DESCRIPTION
In some cases, users needs to confirm a payment or setup intent. This is probably due to the Stripe customer account having a card added through the Stripe dashboard (Unconfirmed, only speculating).

You can currently just do
```php
$payment->status === \Stripe\PaymentIntent::STATUS_REQUIRES_CONFIRMATION
```

However, this `requiresConfirmation` method would bring this status inline with the other statuses