### PR TITLE
[12.x] Fix styles overwriting checkout button when class is set

### DIFF
--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    @isset($style) style="{{ $style }}" @elseif(! isset($style) && ! isset($class)) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em {{ $style }}" @endisset
+    @isset($style) style="{{ $style }}" @elseif(! isset($style) && ! isset($class)) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em" @endisset
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    style="{{ isset($style) && ! isset($class) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
+    style="{{ isset($style) && isset($class) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    style="{{ isset($style) && isset($class) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
+    style="{{ isset($style) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    @isset($style) style="{{ $style }}" @elseif(! isset($style) && ! isset($class)) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em" @endisset
+    @isset($style) style="{{ $style }}" @elseif (! isset($style) && ! isset($class)) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em" @endisset
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    style="{{ ! isset($style) && ! isset($class) ? 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' : ''; }}"
+    @isset($style) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em {{ $style }}" @endisset
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    style="{{ isset($style) ? $style : 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' }}"
+    style="{{ ! isset($style) && ! isset($class) ? 'background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em' : ''; }}"
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,7 +1,7 @@
 <button
     id="checkout-{{ $sessionId }}"
     role="link"
-    @isset($style) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em {{ $style }}" @endisset
+    @isset($style) style="{{ $style }}" @elseif(! isset($style) && ! isset($class)) style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em {{ $style }}" @endisset
     @isset($class) class="{{ $class }}" @endisset
 >
     {{ $label }}


### PR DESCRIPTION
Fixes #1069 

If the class is set, the styles would overwrite the class styles, because we're showing default styles because class isset.



Now you can do something like:

```
{{ $checkout->button('Pay For Job', [
    'class' => 'bg-blue-100 text-sm px-4 py-2',
    'styles' => 'other styles here that don't clash with classes.'
]) }}
```