### PR TITLE
[13.x] Support more payment method types

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customer_columns.php
+++ b/database/migrations/2019_05_03_000001_create_customer_columns.php
@@ -15,8 +15,8 @@ class CreateCustomerColumns extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->string('stripe_id')->nullable()->index();
-            $table->string('card_brand')->nullable();
-            $table->string('card_last_four', 4)->nullable();
+            $table->string('pm_type')->nullable();
+            $table->string('pm_last_four', 4)->nullable();
             $table->timestamp('trial_ends_at')->nullable();
         });
     }
@@ -31,8 +31,8 @@ class CreateCustomerColumns extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn([
                 'stripe_id',
-                'card_brand',
-                'card_last_four',
+                'pm_type',
+                'pm_last_four',
                 'trial_ends_at',
             ]);
         });

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -32,7 +32,7 @@ trait ManagesPaymentMethods
      */
     public function hasDefaultPaymentMethod()
     {
-        return (bool) $this->card_brand;
+        return (bool) $this->pm_type;
     }
 
     /**
@@ -51,7 +51,6 @@ trait ManagesPaymentMethods
      *
      * @param  string  $type
      * @param  array  $parameters
-     * @param  string $type
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\PaymentMethod[]
      */
     public function paymentMethods($type = 'card', $parameters = [])
@@ -119,8 +118,8 @@ trait ManagesPaymentMethods
         // If the payment method was the default payment method, we'll remove it manually...
         if ($stripePaymentMethod->id === $defaultPaymentMethod) {
             $this->forceFill([
-                'card_brand' => null,
-                'card_last_four' => null,
+                'pm_type' => null,
+                'pm_last_four' => null,
             ])->save();
         }
     }
@@ -208,8 +207,8 @@ trait ManagesPaymentMethods
             }
         } else {
             $this->forceFill([
-                'card_brand' => null,
-                'card_last_four' => null,
+                'pm_type' => null,
+                'pm_last_four' => null,
             ])->save();
         }
 
@@ -225,11 +224,11 @@ trait ManagesPaymentMethods
     protected function fillPaymentMethodDetails($paymentMethod)
     {
         if ($paymentMethod->type === 'card') {
-            $this->card_brand = $paymentMethod->card->brand;
-            $this->card_last_four = $paymentMethod->card->last4;
+            $this->pm_type = $paymentMethod->card->brand;
+            $this->pm_last_four = $paymentMethod->card->last4;
         } else {
-            $this->card_brand = $type = $paymentMethod->type;
-            $this->card_last_four = optional($paymentMethod)->$type->last4;
+            $this->pm_type = $type = $paymentMethod->type;
+            $this->pm_last_four = optional($paymentMethod)->$type->last4;
         }
 
         return $this;
@@ -246,11 +245,11 @@ trait ManagesPaymentMethods
     protected function fillSourceDetails($source)
     {
         if ($source instanceof StripeCard) {
-            $this->card_brand = $source->brand;
-            $this->card_last_four = $source->last4;
+            $this->pm_type = $source->brand;
+            $this->pm_last_four = $source->last4;
         } elseif ($source instanceof StripeBankAccount) {
-            $this->card_brand = 'Bank Account';
-            $this->card_last_four = $source->last4;
+            $this->pm_type = 'Bank Account';
+            $this->pm_last_four = $source->last4;
         }
 
         return $this;

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -38,7 +38,7 @@ trait ManagesPaymentMethods
     /**
      * Determines if the customer currently has at least one payment method of the given type.
      *
-     * @param String $type
+     * @param string $type
      * @return bool
      */
     public function hasPaymentMethod($type = 'card')
@@ -50,7 +50,7 @@ trait ManagesPaymentMethods
      * Get a collection of the entity's payment methods.
      *
      * @param  array  $parameters
-     * @param  String $type
+     * @param  string $type
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\PaymentMethod[]
      */
     public function paymentMethods($parameters = [], $type = 'card')
@@ -259,7 +259,7 @@ trait ManagesPaymentMethods
     /**
      * Deletes the entity's payment methods of the given type.
      *
-     * @param String $type
+     * @param string $type
      * @return void
      */
     public function deletePaymentMethods($type = 'card')

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -246,8 +246,8 @@ class WebhookController extends Controller
             $user->forceFill([
                 'stripe_id' => null,
                 'trial_ends_at' => null,
-                'card_brand' => null,
-                'card_last_four' => null,
+                'pm_type' => null,
+                'pm_last_four' => null,
             ])->save();
         }
 

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -85,7 +85,9 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
         $this->assertEquals('visa', $paymentMethod->card->brand);
+        $this->assertEquals('card', $user->card_brand);
         $this->assertEquals('4242', $paymentMethod->card->last4);
+        $this->assertEquals('4242', $user->card_last_four);
     }
 
     public function test_legacy_we_can_retrieve_an_old_default_source_as_a_default_payment_method()
@@ -141,7 +143,7 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $user = $user->updateDefaultPaymentMethodFromStripe();
 
-        $this->assertEquals('visa', $user->card_brand);
+        $this->assertEquals('card', $user->card_brand);
         $this->assertEquals('4242', $user->card_last_four);
     }
 

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -55,8 +55,8 @@ class PaymentMethodsTest extends FeatureTestCase
         $paymentMethod = $user->updateDefaultPaymentMethod($paymentMethod);
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
-        $this->assertEquals('sepa_debit', $user->card_brand);
-        $this->assertEquals('7061', $user->card_last_four);
+        $this->assertEquals('sepa_debit', $user->pm_type);
+        $this->assertEquals('7061', $user->pm_last_four);
         $this->assertEquals('sepa_debit', $paymentMethod->type);
         $this->assertEquals('7061', $paymentMethod->sepa_debit->last4);
         $this->assertTrue($user->hasPaymentMethod('sepa_debit'));
@@ -94,8 +94,8 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $this->assertCount(0, $user->paymentMethods());
         $this->assertNull($user->defaultPaymentMethod());
-        $this->assertNull($user->card_brand);
-        $this->assertNull($user->card_last_four);
+        $this->assertNull($user->pm_type);
+        $this->assertNull($user->pm_last_four);
         $this->assertFalse($user->hasPaymentMethod());
         $this->assertFalse($user->hasDefaultPaymentMethod());
     }
@@ -116,9 +116,9 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
         $this->assertEquals('visa', $paymentMethod->card->brand);
-        $this->assertEquals('visa', $user->card_brand);
+        $this->assertEquals('visa', $user->pm_type);
         $this->assertEquals('4242', $paymentMethod->card->last4);
-        $this->assertEquals('4242', $user->card_last_four);
+        $this->assertEquals('4242', $user->pm_last_four);
     }
 
     public function test_legacy_we_can_retrieve_an_old_default_source_as_a_default_payment_method()
@@ -169,13 +169,13 @@ class PaymentMethodsTest extends FeatureTestCase
 
         $user->refresh();
 
-        $this->assertNull($user->card_brand);
-        $this->assertNull($user->card_last_four);
+        $this->assertNull($user->pm_type);
+        $this->assertNull($user->pm_last_four);
 
         $user = $user->updateDefaultPaymentMethodFromStripe();
 
-        $this->assertEquals('visa', $user->card_brand);
-        $this->assertEquals('4242', $user->card_last_four);
+        $this->assertEquals('visa', $user->pm_type);
+        $this->assertEquals('4242', $user->pm_last_four);
     }
 
     public function test_we_delete_all_payment_methods()

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -559,7 +559,6 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($subscription->onTrial());
     }
 
-    /** @group FOO */
     public function test_trial_on_swap_is_skipped_when_explicitly_asked_to()
     {
         $user = $this->createCustomer('trial_on_swap_is_skipped_when_explicitly_asked_to');

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -28,7 +28,7 @@ class CustomerTest extends TestCase
     public function test_we_can_determine_if_it_has_a_payment_method()
     {
         $user = new User;
-        $user->card_brand = 'visa';
+        $user->pm_type = 'visa';
 
         $this->assertTrue($user->hasDefaultPaymentMethod());
 


### PR DESCRIPTION
This PR provides support for all payment methods provided by Stripe. Thanks to @simonhir. 

By allowing people to choose the type when calling the payment methods methods (phew!) they can cycle through the ones they need. Payment method types will be set as the `card_brand` on the customer record unless it's a card. In that case it will be the actual card brand. If a payment method type have a `last4` param it'll be synced to the `card_last_four`.

```php
$cards = $user->paymentMethods('card');
$sepaDebits = $user->paymentMethods('sepa_debit');
```

This does not include changes needed to be payment page which will need to be tackled in a different PR. There's already a PR from the past by @lsmith77 that looks promising: https://github.com/laravel/cashier-stripe/pull/893

Fixes #507