### PR TITLE
[12.x] Replace entity with customer

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -67,7 +67,7 @@ class Cashier
     public static $subscriptionItemModel = SubscriptionItem::class;
 
     /**
-     * Get the billable entity instance by Stripe ID.
+     * Get the customer instance by Stripe ID.
      *
      * @param  string  $stripeId
      * @return \Laravel\Cashier\Billable|null

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -22,7 +22,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Determine if the entity has a Stripe customer ID.
+     * Determine if the customer has a Stripe customer ID.
      *
      * @return bool
      */
@@ -32,7 +32,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Determine if the entity has a Stripe customer ID and throw an exception if not.
+     * Determine if the customer has a Stripe customer ID and throw an exception if not.
      *
      * @return void
      *
@@ -128,7 +128,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Apply a coupon to the billable entity.
+     * Apply a coupon to the customer.
      *
      * @param  string  $coupon
      * @return void
@@ -145,7 +145,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Get the Stripe supported currency used by the entity.
+     * Get the Stripe supported currency used by the customer.
      *
      * @return string
      */

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -58,7 +58,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Invoice the billable entity outside of the regular billing cycle.
+     * Invoice the customer outside of the regular billing cycle.
      *
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|bool
@@ -98,7 +98,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Get the entity's upcoming invoice.
+     * Get the customer's upcoming invoice.
      *
      * @return \Laravel\Cashier\Invoice|null
      */
@@ -178,7 +178,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Get a collection of the entity's invoices.
+     * Get a collection of the customer's invoices.
      *
      * @param  bool  $includePending
      * @param  array  $parameters
@@ -214,7 +214,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Get an array of the entity's invoices.
+     * Get an array of the customer's invoices.
      *
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -46,7 +46,7 @@ trait ManagesPaymentMethods
     }
 
     /**
-     * Get a collection of the entity's payment methods.
+     * Get a collection of the customer's payment methods.
      *
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\PaymentMethod[]
@@ -123,7 +123,7 @@ trait ManagesPaymentMethods
     }
 
     /**
-     * Get the default payment method for the entity.
+     * Get the default payment method for the customer.
      *
      * @return \Laravel\Cashier\PaymentMethod|\Stripe\Card|\Stripe\BankAccount|null
      */
@@ -251,7 +251,7 @@ trait ManagesPaymentMethods
     }
 
     /**
-     * Deletes the entity's payment methods.
+     * Deletes the customer's payment methods.
      *
      * @return void
      */

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -146,7 +146,7 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Determine if the entity has a valid subscription on the given plan.
+     * Determine if the customer has a valid subscription on the given plan.
      *
      * @param  string  $plan
      * @return bool

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -281,7 +281,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Get the billable entity instance by Stripe ID.
+     * Get the customer instance by Stripe ID.
      *
      * @param  string|null  $stripeId
      * @return \Laravel\Cashier\Billable|null

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -255,7 +255,7 @@ class SubscriptionsTest extends FeatureTestCase
             // Assert that the payment needs a valid payment method.
             $this->assertTrue($e->payment->requiresPaymentMethod());
 
-            // Assert subscription was added to the billable entity.
+            // Assert subscription was added to the customer.
             $this->assertInstanceOf(Subscription::class, $subscription = $user->subscription('main'));
 
             // Assert subscription is incomplete.
@@ -275,7 +275,7 @@ class SubscriptionsTest extends FeatureTestCase
             // Assert that the payment needs an extra action.
             $this->assertTrue($e->payment->requiresAction());
 
-            // Assert subscription was added to the billable entity.
+            // Assert subscription was added to the customer.
             $this->assertInstanceOf(Subscription::class, $subscription = $user->subscription('main'));
 
             // Assert subscription is incomplete.


### PR DESCRIPTION
Replaces the word "entity" with the more appropriate "customer" phrasing.