### PR TITLE
[13.x] Remove legacy sources support

### DIFF
--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -4,7 +4,6 @@ namespace Laravel\Cashier\Tests\Feature;
 
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\PaymentMethod;
-use Stripe\Card as StripeCard;
 use Stripe\PaymentMethod as StripePaymentMethod;
 use Stripe\SetupIntent as StripeSetupIntent;
 use Stripe\StripeClient;

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -121,22 +121,6 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertEquals('4242', $user->pm_last_four);
     }
 
-    public function test_legacy_we_can_retrieve_an_old_default_source_as_a_default_payment_method()
-    {
-        $user = $this->createCustomer('we_can_retrieve_an_old_default_source_as_a_default_payment_method');
-        $customer = $user->createAsStripeCustomer(['expand' => ['sources']]);
-
-        $card = $customer->sources->create(['source' => 'tok_visa']);
-        $customer->default_source = $card->id;
-        $customer->save();
-
-        $paymentMethod = $user->defaultPaymentMethod();
-
-        $this->assertInstanceOf(StripeCard::class, $paymentMethod);
-        $this->assertEquals('Visa', $paymentMethod->brand);
-        $this->assertEquals('4242', $paymentMethod->last4);
-    }
-
     public function test_we_can_retrieve_all_payment_methods()
     {
         $user = $this->createCustomer('we_can_retrieve_all_payment_methods');


### PR DESCRIPTION
This PR removes all support for the legacy sources API. Cashier will from now on only use the new Payment Methods API. 