### PR TITLE
[12.x] Allow relative urls for redirect

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: true
       matrix:

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -108,7 +108,7 @@
                     </div>
                 @endif
 
-                <button @click="goBack" ref="goBackButton" data-redirect="{{ $redirect ?? url('/') }}"
+                <button @click="goBack" ref="goBackButton" data-redirect="{{ $redirect }}"
                    class="inline-block w-full px-4 py-3 bg-gray-200 hover:bg-gray-300 text-center text-gray-700 rounded-lg">
                     {{ __('Go back') }}
                 </button>

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -24,7 +24,7 @@ class PaymentController extends Controller
      * Display the form to gather additional payment verification for the given payment.
      *
      * @param  string  $id
-     * @return \Illuminate\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function show($id)
     {
@@ -33,7 +33,7 @@ class PaymentController extends Controller
             'payment' => new Payment(
                 StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
             ),
-            'redirect' => request('redirect'),
+            'redirect' => url(request('redirect', '/')),
         ]);
     }
 }

--- a/src/Http/Middleware/VerifyRedirectUrl.php
+++ b/src/Http/Middleware/VerifyRedirectUrl.php
@@ -22,7 +22,7 @@ class VerifyRedirectUrl
 
         $url = parse_url($redirect);
 
-        if ($redirect && (! isset($url['host']) || $url['host'] !== $request->getHost())) {
+        if (isset($url['host']) && $url['host'] !== $request->getHost()) {
             throw new AccessDeniedHttpException('Redirect host mismatch.');
         }
 

--- a/tests/Unit/VerifyRedirectUrlTest.php
+++ b/tests/Unit/VerifyRedirectUrlTest.php
@@ -33,16 +33,16 @@ class VerifyRedirectUrlTest extends TestCase
         });
     }
 
-    public function test_it_fails_when_the_url_is_invalid()
+    public function test_it_passes_for_relative_urls()
     {
-        $request = Request::create('http://baz.com/stripe/payment', 'GET', ['redirect' => 'foo/bar']);
+        $request = Request::create('http://baz.com/stripe/payment', 'GET', ['redirect' => '/foo/bar']);
         $middleware = new VerifyRedirectUrl;
 
-        $this->expectException(AccessDeniedHttpException::class);
-
-        $middleware->handle($request, function () {
-            //
+        $response = $middleware->handle($request, function () {
+            return 'Hello World!';
         });
+
+        $this->assertSame('Hello World!', $response);
     }
 
     public function test_it_is_skipped_when_no_redirect_is_present()


### PR DESCRIPTION
This will allow relative urls for the redirect like we use in Spark: `?redirect=/billing`.

Also contains the ubuntu-18.04 env update for the CI builds.