### PR TITLE
[12.x] Use DejaVu Sans for receipts

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -9,6 +9,7 @@
     <style>
         body {
             background: #fff none;
+            font-family: DejaVu Sans, 'sans-serif';
             font-size: 12px;
         }
 


### PR DESCRIPTION
This PR fixes an issue with the generated receipts using DomPdf to properly display UTF-8 characters. It introduces the DejaVu Sans font that ships with DomPdf. It was specifically added to DomPdf to display UTF-8 characters. The receipts will, however, have a different look and feel because of this. Personally I think they look better.

More info: https://github.com/dompdf/dompdf/wiki/About-Fonts-and-Character-Encoding

Before:

![Screenshot 2021-03-05 at 18 27 25](https://user-images.githubusercontent.com/594614/110151227-83a97800-7de0-11eb-8c4f-9eabd8c65317.jpg)

After:

![Screenshot 2021-03-05 at 18 23 45](https://user-images.githubusercontent.com/594614/110151221-82784b00-7de0-11eb-8101-cb8510c296a7.jpg)