### PR TITLE
[12.x] Subscription Update Webhook bugfix

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -160,7 +160,7 @@ class WebhookController extends Controller
                         $subscription->ends_at = $subscription->onTrial()
                             ? $subscription->trial_ends_at
                             : Carbon::createFromTimestamp($data['current_period_end']);
-                    } elseif($data['cancel_at']) {
+                    } elseif ($data['cancel_at']) {
                         $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at']);
                     } else {
                         $subscription->ends_at = null;

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -160,6 +160,8 @@ class WebhookController extends Controller
                         $subscription->ends_at = $subscription->onTrial()
                             ? $subscription->trial_ends_at
                             : Carbon::createFromTimestamp($data['current_period_end']);
+                    } elseif($data['cancel_at']) {
+                        $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at']);
                     } else {
                         $subscription->ends_at = null;
                     }

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Exceptions\PaymentActionRequired;
@@ -135,6 +136,64 @@ class WebhooksTest extends FeatureTestCase
             'user_id' => $user->id,
             'stripe_id' => 'sub_foo',
             'quantity' => 5,
+        ]);
+
+        $this->assertDatabaseHas('subscription_items', [
+            'subscription_id' => $subscription->id,
+            'stripe_id' => 'bar',
+            'stripe_plan' => 'plan_foo',
+            'quantity' => 5,
+        ]);
+
+        $this->assertDatabaseMissing('subscription_items', [
+            'id' => $item->id,
+        ]);
+    }
+
+    public function test_subscriptions_on_update_cancel_at_date_is_correct()
+    {
+        $user = $this->createCustomer('subscriptions_are_updated', ['stripe_id' => 'cus_foo']);
+        $cancelDate = Carbon::now()->addMonths(6);
+
+        $subscription = $user->subscriptions()->create([
+            'name' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_plan' => 'plan_foo',
+            'stripe_status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $item = $subscription->items()->create([
+            'stripe_id' => 'it_foo',
+            'stripe_plan' => 'plan_bar',
+            'quantity' => 1,
+        ]);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.updated',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => 'cus_foo',
+                    'cancel_at' => $cancelDate->timestamp,
+                    'cancel_at_period_end' => false,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'plan' => ['id' => 'plan_foo'],
+                            'quantity' => 5,
+                        ]],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'user_id' => $user->id,
+            'stripe_id' => 'sub_foo',
+            'quantity' => 5,
+            'ends_at' => $cancelDate->format('Y-m-d H:i:s')
         ]);
 
         $this->assertDatabaseHas('subscription_items', [

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -193,7 +193,7 @@ class WebhooksTest extends FeatureTestCase
             'user_id' => $user->id,
             'stripe_id' => 'sub_foo',
             'quantity' => 5,
-            'ends_at' => $cancelDate->format('Y-m-d H:i:s')
+            'ends_at' => $cancelDate->format('Y-m-d H:i:s'),
         ]);
 
         $this->assertDatabaseHas('subscription_items', [


### PR DESCRIPTION
Reproduction:
1. Add subscription to user
2. Cancel subscription with custom date on Stripe Dashboard

Expected:
- `ends_at` is set as in the stripe subscription model property `cancel_at`

Outcome:
- `ends_at` property in subscription model is null
