### PR TITLE
[12.x] Verify trial ends in the future

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -321,7 +321,7 @@ class SubscriptionBuilder
             'stripe_status' => $stripeSubscription->status,
             'stripe_plan' => $isSinglePlan ? $firstItem->plan->id : null,
             'quantity' => $isSinglePlan ? $firstItem->quantity : null,
-            'trial_ends_at' => ! $this->skipTrial ? $this->trialExpires : null,
+            'trial_ends_at' => ! $this->skipTrial && $this->trialExpires->isFuture() ? $this->trialExpires : null,
             'ends_at' => null,
         ]);
 
@@ -440,7 +440,7 @@ class SubscriptionBuilder
             return 'now';
         }
 
-        if ($this->trialExpires) {
+        if ($this->trialExpires && $this->trialExpires->isFuture()) {
             return $this->trialExpires->getTimestamp();
         }
     }


### PR DESCRIPTION
Not sure if this constitutes a breaking change or not, I've sent to 12.x though.

Stripe will throw a `Stripe\Exception\InvalidRequestException` with the following message if the trial_end field is in the past.

> Invalid timestamp: must be an integer Unix timestamp in the future

This PR checks to see if the `trialExpires` property is in the future before setting trial fields. It could be argued that it should throw an exception, however I think it's much more elegant and removes a bit of boilerplate checking from the consuming app if this check is done for the user within the package.