### PR TITLE
[12.x] Update description on receipt

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -155,7 +155,7 @@
                     <!-- Display The Subscriptions -->
                     @foreach ($invoice->subscriptions() as $subscription)
                         <tr class="row">
-                            <td>Subscription ({{ $subscription->quantity }})</td>
+                            <td>{{ $subscription->description }}</td>
                             <td>
                                 {{ $subscription->startDateAsCarbon()->formatLocalized('%B %e, %Y') }} -
                                 {{ $subscription->endDateAsCarbon()->formatLocalized('%B %e, %Y') }}


### PR DESCRIPTION
This updates the default shipped receipt with the invoice line item description rather than what we roll of our own. It duplicates the amount paid a bit but overall more properly displays the bought product. 

There could be a breaking change here in the sense that a product description in Stripe might differ from a product description in your app. In that sense we could also target this change to master. 

I'd argue that with the current support of multi plan subscriptions it's best to make this change as it's otherwise not possible to know about which product the invoice is about wen you're subscribed to multiple products.

Before:

![Screenshot 2021-03-15 at 10 01 23](https://user-images.githubusercontent.com/594614/111129555-82adde80-8576-11eb-8b21-6aa479d7a563.jpg)

After:

![Screenshot 2021-03-15 at 10 01 10](https://user-images.githubusercontent.com/594614/111129567-85a8cf00-8576-11eb-9139-4f0007b6ccf8.jpg)