### PR TITLE
[13.x] Refactor model config option

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -48,19 +48,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cashier Model
-    |--------------------------------------------------------------------------
-    |
-    | This is the model in your application that implements the Billable trait
-    | provided by Cashier. It will serve as the primary model you use while
-    | interacting with Cashier related methods, subscriptions, and so on.
-    |
-    */
-
-    'model' => env('CASHIER_MODEL', class_exists(App\Models\User::class) ? App\Models\User::class : App\User::class),
-
-    /*
-    |--------------------------------------------------------------------------
     | Currency
     |--------------------------------------------------------------------------
     |

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Database\Factories;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Subscription;
 use Stripe\Subscription as StripeSubscription;
 
@@ -24,7 +25,7 @@ class SubscriptionFactory extends Factory
      */
     public function definition()
     {
-        $model = config('cashier.model');
+        $model = Cashier::$customerModel;
 
         return [
             (new $model)->getForeignKey() => ($model)::factory(),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,6 @@
     </testsuites>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
-        <env name="CASHIER_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
         <env name="CASHIER_PAYMENT_NOTIFICATION" value="Laravel\Cashier\Notifications\ConfirmPayment"/>
     </php>
 </phpunit>

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -53,6 +53,13 @@ class Cashier
     public static $deactivatePastDue = true;
 
     /**
+     * The default customer model class name.
+     *
+     * @var string
+     */
+    public static $customerModel = 'App\\Models\\User';
+
+    /**
      * The subscription model class name.
      *
      * @var string
@@ -67,7 +74,7 @@ class Cashier
     public static $subscriptionItemModel = SubscriptionItem::class;
 
     /**
-     * Get the customer instance by Stripe ID.
+     * Get the customer instance by its Stripe ID.
      *
      * @param  string  $stripeId
      * @return \Laravel\Cashier\Billable|null
@@ -78,9 +85,7 @@ class Cashier
             return;
         }
 
-        $model = config('cashier.model');
-
-        return (new $model)->where('stripe_id', $stripeId)->first();
+        return (new static::$customerModel)->where('stripe_id', $stripeId)->first();
     }
 
     /**
@@ -166,6 +171,17 @@ class Cashier
         static::$deactivatePastDue = false;
 
         return new static;
+    }
+
+    /**
+     * Set the customer model class name.
+     *
+     * @param  string  $customerModel
+     * @return void
+     */
+    public static function useCustomerModel($customerModel)
+    {
+        static::$customerModel = $customerModel;
     }
 
     /**

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -217,7 +217,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Get the default Stripe API options for the current Billable model.
+     * Get the default Stripe API options for the current customer model.
      *
      * @param  array  $options
      * @return array

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -82,7 +82,7 @@ class Subscription extends Model
      */
     public function owner()
     {
-        $model = config('cashier.model');
+        $model = Cashier::$customerModel;
 
         return $this->belongsTo($model, (new $model)->getForeignKey());
     }

--- a/tests/Feature/LoggerTest.php
+++ b/tests/Feature/LoggerTest.php
@@ -83,6 +83,8 @@ class LoggerTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        parent::getEnvironmentSetUp($app);
+
         $app['config']->set('cashier.logger', $this->channel);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,18 @@
 
 namespace Laravel\Cashier\Tests;
 
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\CashierServiceProvider;
+use Laravel\Cashier\Tests\Fixtures\User;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    protected function getEnvironmentSetUp($app)
+    {
+        Cashier::useCustomerModel(User::class);
+    }
+
     protected function getPackageProviders($app)
     {
         return [CashierServiceProvider::class];


### PR DESCRIPTION
This will remove the model config option in favor of setting a static property on the Cashier class. This will make setting the custom model for the billable entity the same as we do it in the rest of Cashier and the same as we do it in all our other first party packages. It also makes the new Models namespace of Laravel 8 the default one.