### PR TITLE
[12.x] Implement cancelAt

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -916,6 +916,35 @@ class Subscription extends Model
     }
 
     /**
+     * Cancel the subscription at a specific moment in time.
+     *
+     * @param  \DateTimeInterface|int  $endsAt
+     * @return $this
+     */
+    public function cancelAt($endsAt)
+    {
+        if ($endsAt instanceof DateTimeInterface) {
+            $endsAt = $endsAt->getTimestamp();
+        }
+
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->proration_behavior = $this->prorateBehavior();
+
+        $subscription->cancel_at = $endsAt;
+
+        $subscription = $subscription->save();
+
+        $this->stripe_status = $subscription->status;
+
+        $this->ends_at = Carbon::createFromTimestamp($subscription->cancel_at);
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
      * Cancel the subscription immediately without invoicing.
      *
      * @return $this

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -559,7 +559,6 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($subscription->onTrial());
     }
 
-    /** @group FOO */
     public function test_trial_on_swap_is_skipped_when_explicitly_asked_to()
     {
         $user = $this->createCustomer('trial_on_swap_is_skipped_when_explicitly_asked_to');
@@ -831,5 +830,18 @@ class SubscriptionsTest extends FeatureTestCase
         ]);
 
         $this->assertTrue($user->refresh()->subscribed());
+    }
+
+    public function test_subscriptions_can_be_cancelled_at_a_specific_time()
+    {
+        $user = $this->createCustomer('subscriptions_can_be_cancelled_at_a_specific_time');
+
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
+
+        $subscription = $subscription->cancelAt($endsAt = now()->addMonths(3));
+
+        $this->assertTrue($subscription->active());
+        $this->assertSame($endsAt->timestamp, $subscription->ends_at->timestamp);
+        $this->assertSame($endsAt->timestamp, $subscription->asStripeSubscription()->cancel_at);
     }
 }


### PR DESCRIPTION
This implements a `cancelAt` method on the `Subscription` model in a similar fashion as we did for Cashier Paddle. It'll allow subscriptions to be cancelled at an exact moment in the future.

```php
$subscription->cancelAt(now()->addDays(10));
```

Implements https://github.com/laravel/cashier-stripe/issues/1105