### PR TITLE
[12.x] Replace super heavy symfony/intl dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^7.39",
         "symfony/http-kernel": "^4.3|^5.0",
-        "symfony/intl": "^4.3|^5.0"
+        "symfony/polyfill-intl-icu": "^1.22.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
`symfony/intl` is 16MB and is not even used by this package code or any of its dependencies. In 13.x, we should probably remove this entirely, since `ext-intl` is already suggested.