### PR TITLE
[12.x] Fix coupon label on receipts

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -194,9 +194,9 @@
                         <tr>
                             <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
                                 @if ($invoice->discountIsPercentage())
-                                    {{ $invoice->coupon() }} ({{ $invoice->percentOff() }}% Off)
+                                    {{ $invoice->couponName() }} ({{ $invoice->percentOff() }}% Off)
                                 @else
-                                    {{ $invoice->coupon() }} ({{ $invoice->amountOff() }} Off)
+                                    {{ $invoice->couponName() }} ({{ $invoice->amountOff() }} Off)
                                 @endif
                             </td>
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -186,6 +186,18 @@ class Invoice
     }
 
     /**
+     * Get the coupon name applied to the invoice.
+     *
+     * @return string|null
+     */
+    public function couponName()
+    {
+        if (isset($this->invoice->discount)) {
+            return $this->invoice->discount->coupon->name ?: $this->invoice->discount->coupon->id;
+        }
+    }
+
+    /**
      * Determine if the discount is a percentage.
      *
      * @return bool


### PR DESCRIPTION
Uses the human readable description that's defined in the dashboard first before falling back on the coupon ID. This is also the default Stripe behavior on their receipts/invoices.

Implements https://github.com/laravel/cashier-stripe/issues/1117