### PR TITLE
[12.x] Extract creating subscription to a separate method

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -310,6 +310,25 @@ class SubscriptionBuilder
             $this->owner->stripeOptions()
         );
 
+        $subscription = $this->createSubscription($stripeSubscription);
+
+        if ($subscription->hasIncompletePayment()) {
+            (new Payment(
+                $stripeSubscription->latest_invoice->payment_intent
+            ))->validate();
+        }
+
+        return $subscription;
+    }
+
+    /**
+     * Create the Eloquent Subscription.
+     *
+     * @param  \Stripe\Subscription  $stripeSubscription
+     * @return \Laravel\Cashier\Subscription
+     */
+    protected function createSubscription(StripeSubscription $stripeSubscription)
+    {
         /** @var \Stripe\SubscriptionItem $firstItem */
         $firstItem = $stripeSubscription->items->first();
         $isSinglePlan = $stripeSubscription->items->count() === 1;
@@ -332,12 +351,6 @@ class SubscriptionBuilder
                 'stripe_plan' => $item->plan->id,
                 'quantity' => $item->quantity,
             ]);
-        }
-
-        if ($subscription->hasIncompletePayment()) {
-            (new Payment(
-                $stripeSubscription->latest_invoice->payment_intent
-            ))->validate();
         }
 
         return $subscription;


### PR DESCRIPTION
This PR extracts the portion that creates the Eloquent Subscription model and the SubscriptionItem models into a separate method. This is useful if people want to overwrite this to, for example, add extra fields upon creation.

Implements https://github.com/laravel/cashier-stripe/issues/1122