### PR TITLE
[13.x] Fix trialEndsAt more closely represents onTrial

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -60,6 +60,10 @@ trait ManagesSubscriptions
      */
     public function trialEndsAt($name = 'default')
     {
+        if (func_num_args() === 0 && $this->onGenericTrial()) {
+            return $this->trial_ends_at;
+        }
+
         if ($subscription = $this->subscription($name)) {
             return $subscription->trial_ends_at;
         }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -488,8 +488,11 @@ class SubscriptionsTest extends FeatureTestCase
         $user->newSubscription('main', static::$planId)
             ->create('pm_card_visa');
 
+        $subscription = $user->subscription('main');
+
         $this->assertTrue($user->onGenericTrial());
         $this->assertTrue($user->onTrial());
+        $this->assertFalse($subscription->onTrial());
         $this->assertSame($tomorrow, $user->trialEndsAt());
     }
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -480,6 +480,19 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame($tomorrow, $user->trialEndsAt());
     }
 
+    public function test_user_with_subscription_can_return_generic_trial_end_date()
+    {
+        $user = $this->createCustomer('creating_subscription_without_trial');
+        $user->trial_ends_at = $tomorrow = Carbon::tomorrow();
+
+        $user->newSubscription('main', static::$planId)
+            ->create('pm_card_visa');
+
+        $this->assertTrue($user->onGenericTrial());
+        $this->assertTrue($user->onTrial());
+        $this->assertSame($tomorrow, $user->trialEndsAt());
+    }
+
     public function test_creating_subscription_with_explicit_trial()
     {
         $user = $this->createCustomer('creating_subscription_with_explicit_trial');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #1128 

The `trialEndsAt` returns the `trial_ends_at` attribute by default if there are no arguments passed through and the user is indeed on a generic trial. Without the `onGenericTrial` check, the function will always return `trial_ends_at` if no arguments were passed through.

The `trialEndsAt` function also returns `trial_ends_at` as a fallback because there may be a use case that an application expects a historical date from `trialEndsAt`.
