### PR TITLE
[12.x] Fix receipt comments

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -55,7 +55,7 @@
                 &nbsp;
             </td>
 
-            <!-- Organization Name / Image -->
+            <!-- Vendor Name / Image -->
             <td align="right">
                 <strong>{{ $header ?? $vendor }}</strong>
             </td>
@@ -65,7 +65,7 @@
                 Receipt
             </td>
 
-            <!-- Organization Name / Date -->
+            <!-- Customer Name / Invoice Date -->
             <td>
                 <br><br>
                 <strong>To:</strong> {{ $owner->stripeEmail() ?: $owner->name }}
@@ -74,7 +74,7 @@
             </td>
         </tr>
         <tr valign="top">
-            <!-- Organization Details -->
+            <!-- Vendor Details -->
             <td style="font-size:9px;">
                 {{ $vendor }}<br>
 


### PR DESCRIPTION
The current "Organization" is confusing and can lead users into believing they mean the same thing even though it indicates two very different things on the receipt (the vendor & the customer). I've updated the descriptions to make these more clear.