### PR TITLE
[13.x] Refactor receipts with more data from Stripe

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -48,6 +48,7 @@
     </style>
 </head>
 <body>
+
 <div class="container">
     <table style="margin-left: auto; margin-right: auto;" width="550">
         <tr>
@@ -67,38 +68,42 @@
                 </span><br><br>
 
                 <!-- Account Details -->
-                <strong>{{ $vendor ?? $invoice->account_name }}</strong><br>
+                {{ $vendor ?? $invoice->account_name }}<br>
 
-                @if (isset($street))
+                @isset($street)
                     {{ $street }}<br>
-                @endif
+                @endisset
 
-                @if (isset($location))
+                @isset($location)
                     {{ $location }}<br>
-                @endif
+                @endisset
 
-                @if (isset($phone))
-                    <strong>T</strong> {{ $phone }}<br>
-                @endif
+                @isset($phone)
+                    {{ $phone }}<br>
+                @endisset
 
-                @if (isset($url))
+                @isset($email)
+                    {{ $email }}<br>
+                @endisset
+
+                @isset($url)
                     <a href="{{ $url }}">{{ $url }}</a><br>
-                @endif
+                @endisset
 
-                @if (isset($vendorTaxId))
-                    {{ $vendorTaxId }}<br>
+                @isset($vendorVat)
+                    {{ $vendorVat }}<br>
                 @else
                     @foreach ($invoice->accountTaxIds() as $taxId)
                         {{ $taxId->value }}<br>
                     @endforeach
-                @endif
+                @endisset
 
                 <br><br>
 
                 <!-- Customer Details -->
-                Billed to:<br><br>
+                <strong>Bill to:</strong><br>
 
-                <strong>{{ $invoice->customer_name ?? $invoice->customer_email }}</strong><br>
+                {{ $invoice->customer_name ?? $invoice->customer_email }}<br>
 
                 @if ($address = $invoice->customer_address)
                     @if ($address->line1)
@@ -109,12 +114,12 @@
                         {{ $address->line2 }}<br>
                     @endif
 
-                    @if ($address->state)
-                        {{ $address->state }}<br>
+                    @if ($address->city)
+                        {{ $address->city }}<br>
                     @endif
 
-                    @if ($address->postal_code || $address->city)
-                        {{ implode('', [$address->postal_code, $address->city]) }}<br>
+                    @if ($address->state || $address->postal_code)
+                        {{ implode(' ', [$address->state, $address->postal_code]) }}<br>
                     @endif
 
                     @if ($address->country)
@@ -122,12 +127,12 @@
                     @endif
                 @endif
 
-                @if ($invoice->customer_name)
-                    <strong>E</strong> {{ $invoice->customer_email }}<br>
+                @if ($invoice->customer_phone)
+                    {{ $invoice->customer_phone }}<br>
                 @endif
 
-                @if ($invoice->customer_phone)
-                    <strong>T</strong> {{ $invoice->customer_phone }}<br>
+                @if ($invoice->customer_name)
+                    {{ $invoice->customer_email }}<br>
                 @endif
 
                 @foreach ($invoice->customerTaxIds() as $taxId)
@@ -137,10 +142,25 @@
             <td>
                 <!-- Invoice Info -->
                 <p>
+                    @isset ($product)
+                        <strong>Product:</strong> {{ $product }}<br>
+                    @endisset
+
                     <strong>Date:</strong> {{ $invoice->date()->toFormattedDateString() }}<br>
-                    <strong>Product:</strong> {{ $product }}<br>
+
+                    @if ($dueDate = $invoice->dueDate())
+                        <strong>Due date:</strong> {{ $dueDate->toFormattedDateString() }}<br>
+                    @endif
+
                     <strong>Invoice Number:</strong> {{ $id ?? $invoice->number }}<br>
                 </p>
+
+                <!-- Memo / Description -->
+                @if ($invoice->description)
+                    <p>
+                        {{ $invoice->description }}
+                    </p>
+                @endif
 
                 <!-- Extra / VAT Information -->
                 @if (isset($vat))
@@ -289,5 +309,6 @@
         </tr>
     </table>
 </div>
+
 </body>
 </html>

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -61,12 +61,12 @@
             </td>
         </tr>
         <tr valign="top">
-            <!-- Account Details -->
             <td style="font-size:9px;">
                 <span style="font-size: 28px; color: #ccc;">
                     Receipt
                 </span><br><br>
 
+                <!-- Account Details -->
                 <strong>{{ $vendor ?? $invoice->account_name }}</strong><br>
 
                 @if (isset($street))
@@ -95,6 +95,7 @@
 
                 <br><br>
 
+                <!-- Customer Details -->
                 Billed to:<br><br>
 
                 <strong>{{ $invoice->customer_name ?? $invoice->customer_email }}</strong><br>

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -55,28 +55,19 @@
                 &nbsp;
             </td>
 
-            <!-- Organization Name / Image -->
+            <!-- Account Name / Header Image -->
             <td align="right">
-                <strong>{{ $header ?? $vendor }}</strong>
+                <strong>{{ $header ?? $vendor ?? $invoice->account_name }}</strong>
             </td>
         </tr>
         <tr valign="top">
-            <td style="font-size: 28px; color: #ccc;">
-                Receipt
-            </td>
-
-            <!-- Organization Name / Date -->
-            <td>
-                <br><br>
-                <strong>To:</strong> {{ $owner->stripeEmail() ?: $owner->name }}
-                <br>
-                <strong>Date:</strong> {{ $invoice->date()->toFormattedDateString() }}
-            </td>
-        </tr>
-        <tr valign="top">
-            <!-- Organization Details -->
+            <!-- Account Details -->
             <td style="font-size:9px;">
-                {{ $vendor }}<br>
+                <span style="font-size: 28px; color: #ccc;">
+                    Receipt
+                </span><br><br>
+
+                <strong>{{ $vendor ?? $invoice->account_name }}</strong><br>
 
                 @if (isset($street))
                     {{ $street }}<br>
@@ -90,17 +81,62 @@
                     <strong>T</strong> {{ $phone }}<br>
                 @endif
 
-                @if (isset($vendorVat))
-                    {{ $vendorVat }}<br>
+                @if (isset($url))
+                    <a href="{{ $url }}">{{ $url }}</a><br>
                 @endif
 
-                @if (isset($url))
-                    <a href="{{ $url }}">{{ $url }}</a>
+                @if (isset($vendorTaxId))
+                    {{ $vendorTaxId }}<br>
+                @else
+                    @foreach ($invoice->accountTaxIds() as $taxId)
+                        {{ $taxId->value }}<br>
+                    @endforeach
                 @endif
+
+                <br><br>
+
+                Billed to:<br><br>
+
+                <strong>{{ $invoice->customer_name ?? $invoice->customer_email }}</strong><br>
+
+                @if ($address = $invoice->customer_address)
+                    @if ($address->line1)
+                        {{ $address->line1 }}<br>
+                    @endif
+
+                    @if ($address->line2)
+                        {{ $address->line2 }}<br>
+                    @endif
+
+                    @if ($address->state)
+                        {{ $address->state }}<br>
+                    @endif
+
+                    @if ($address->postal_code || $address->city)
+                        {{ implode('', [$address->postal_code, $address->city]) }}<br>
+                    @endif
+
+                    @if ($address->country)
+                        {{ $address->country }}<br>
+                    @endif
+                @endif
+
+                @if ($invoice->customer_name)
+                    <strong>E</strong> {{ $invoice->customer_email }}<br>
+                @endif
+
+                @if ($invoice->customer_phone)
+                    <strong>T</strong> {{ $invoice->customer_phone }}<br>
+                @endif
+
+                @foreach ($invoice->customerTaxIds() as $taxId)
+                    {{ $taxId->value }}<br>
+                @endforeach
             </td>
             <td>
                 <!-- Invoice Info -->
                 <p>
+                    <strong>Date:</strong> {{ $invoice->date()->toFormattedDateString() }}<br>
                     <strong>Product:</strong> {{ $product }}<br>
                     <strong>Invoice Number:</strong> {{ $id ?? $invoice->number }}<br>
                 </p>

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -107,7 +107,9 @@ trait ManagesInvoices
         }
 
         try {
-            $stripeInvoice = StripeInvoice::upcoming(['customer' => $this->stripe_id], $this->stripeOptions());
+            $stripeInvoice = StripeInvoice::upcoming(
+                ['customer' => $this->stripe_id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
+            );
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -127,7 +127,7 @@ trait ManagesInvoices
 
         try {
             $stripeInvoice = StripeInvoice::retrieve(
-                $id, $this->stripeOptions()
+                ['id' => $id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
             );
         } catch (Exception $exception) {
             //

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -66,16 +66,31 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get a Carbon date for the invoice.
+     * Get a Carbon instance for the invoicing date.
      *
      * @param  \DateTimeZone|string  $timezone
      * @return \Carbon\Carbon
      */
     public function date($timezone = null)
     {
-        $carbon = Carbon::createFromTimestampUTC($this->invoice->created ?? $this->invoice->date);
+        $carbon = Carbon::createFromTimestampUTC($this->invoice->created);
 
         return $timezone ? $carbon->setTimezone($timezone) : $carbon;
+    }
+
+    /**
+     * Get a Carbon instance for the invoice's due date.
+     *
+     * @param  \DateTimeZone|string  $timezone
+     * @return \Carbon\Carbon|null
+     */
+    public function dueDate($timezone = null)
+    {
+        if ($this->invoice->due_date) {
+            $carbon = Carbon::createFromTimestampUTC($this->invoice->due_date);
+
+            return $timezone ? $carbon->setTimezone($timezone) : $carbon;
+        }
     }
 
     /**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -375,6 +375,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             $this->invoice = StripeInvoice::retrieve([
                 'id' => $this->invoice->id,
                 'expand' => [
+                    'account_tax_ids',
                     'lines.data.tax_amounts.tax_rate',
                     'total_tax_amounts.tax_rate',
                 ],
@@ -400,6 +401,26 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     protected function formatAmount($amount)
     {
         return Cashier::formatAmount($amount, $this->invoice->currency);
+    }
+
+    /**
+     * Return the Tax Ids of the account.
+     *
+     * @return \Stripe\TaxId[]
+     */
+    public function accountTaxIds()
+    {
+        return $this->invoice->account_tax_ids ?? [];
+    }
+
+    /**
+     * Return the Tax Ids of the customer.
+     *
+     * @return \Stripe\TaxId[]
+     */
+    public function customerTaxIds()
+    {
+        return $this->invoice->customer_tax_ids ?? [];
     }
 
     /**


### PR DESCRIPTION
This PR will refactor receipts so it'll pull more data from Stripe directly. There's now more info on the receipts like customer address, tax ids, etc. Also the `description`/memo field is added automatically. The vendor details still need to be provided explicitly because Stripe doesn't adds that historical data to the invoice object.

There's almost no breaking changes. Things that I can think of are the fact that the customer name (previously the `to:` info) is now derived directly from the Stripe customer. `vendor` and `product` parameters are now optional instead of required.

Here's a before / after of the receipts:

![Screenshot 2021-04-23 at 18 39 48](https://user-images.githubusercontent.com/594614/115918278-a3235f80-a477-11eb-8b89-a182f6a935f9.jpg)

Closes https://github.com/laravel/cashier-stripe/issues/952