### PR TITLE
[12.x] Add methods for managing TaxIDs

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -9,7 +9,7 @@ use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Stripe\BillingPortal\Session as StripeBillingPortalSession;
 use Stripe\Customer as StripeCustomer;
-use Stripe\Exception\InvalidRequestException;
+use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 
 trait ManagesCustomer
 {
@@ -212,7 +212,7 @@ trait ManagesCustomer
             return StripeCustomer::retrieveTaxId(
                 $this->stripe_id, $id, [], $this->stripeOptions()
             );
-        } catch (InvalidRequestException $exception) {
+        } catch (StripeInvalidRequestException $exception) {
             //
         }
     }
@@ -246,7 +246,7 @@ trait ManagesCustomer
 
         try {
             StripeCustomer::deleteTaxId($this->stripe_id, $id, [], $this->stripeOptions());
-        } catch (InvalidRequestException $exception) {
+        } catch (StripeInvalidRequestException $exception) {
             //
         }
     }

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -3,11 +3,13 @@
 namespace Laravel\Cashier\Concerns;
 
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Stripe\BillingPortal\Session as StripeBillingPortalSession;
 use Stripe\Customer as StripeCustomer;
+use Stripe\Exception\InvalidRequestException;
 
 trait ManagesCustomer
 {
@@ -181,6 +183,72 @@ trait ManagesCustomer
         return new RedirectResponse(
             $this->billingPortalUrl($returnUrl)
         );
+    }
+
+    /**
+     * Get a collection of the customer's TaxID's.
+     *
+     * @return \Illuminate\Support\Collection|\Stripe\TaxId[]
+     */
+    public function taxIds(array $options = [])
+    {
+        $this->assertCustomerExists();
+
+        return new Collection(
+            StripeCustomer::allTaxIds($this->stripe_id, $options, $this->stripeOptions())->data
+        );
+    }
+
+    /**
+     * Find a TaxID by ID.
+     *
+     * @return \Stripe\TaxId|null
+     */
+    public function findTaxId($id)
+    {
+        $this->assertCustomerExists();
+
+        try {
+            return StripeCustomer::retrieveTaxId(
+                $this->stripe_id, $id, [], $this->stripeOptions()
+            );
+        } catch (InvalidRequestException $exception) {
+            //
+        }
+    }
+
+    /**
+     * Create a TaxID for the customer.
+     *
+     * @param  string  $type
+     * @param  string  $value
+     * @return \Stripe\TaxId
+     */
+    public function createTaxId($type, $value)
+    {
+        $this->assertCustomerExists();
+
+        return StripeCustomer::createTaxId($this->stripe_id, [
+            'type' => $type,
+            'value' => $value,
+        ], $this->stripeOptions());
+    }
+
+    /**
+     * Delete a TaxID for the customer.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    public function deleteTaxId($id)
+    {
+        $this->assertCustomerExists();
+
+        try {
+            StripeCustomer::deleteTaxId($this->stripe_id, $id, [], $this->stripeOptions());
+        } catch (InvalidRequestException $exception) {
+            //
+        }
     }
 
     /**

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -131,7 +131,7 @@ trait ManagesInvoices
             $stripeInvoice = StripeInvoice::retrieve(
                 $id, $this->stripeOptions()
             );
-        } catch (Exception $exception) {
+        } catch (StripeInvalidRequestException $exception) {
             //
         }
 


### PR DESCRIPTION
This PR adds some methods to easily manage TaxID's on a customer. This is useful for keeping this data in Stripe so it also appears on its invoices an later in our own receipts like in https://github.com/laravel/cashier-stripe/pull/1136

Usage:

```php
// Return all of the customer's TaxIDs in an collection instance...
$user->taxIds(); 

// Retrieve a specific TaxID from the customer...
$user->findTaxId('txi_IzcmyhZukd4oKD');

// Create a new TaxID for the customer...
$user->createTaxId($type, $value);

// Delete a TaxID from the customer...
$user->deleteTaxId('txi_IzcmyhZukd4oKD');
```

Closes https://github.com/laravel/cashier-stripe/issues/1071