### PR TITLE
[13.x] Preview upcoming invoice

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -108,7 +108,9 @@ trait ManagesInvoices
         }
 
         try {
-            $stripeInvoice = StripeInvoice::upcoming(['customer' => $this->stripe_id], $this->stripeOptions());
+            $stripeInvoice = StripeInvoice::upcoming(array_merge([
+                'customer' => $this->stripe_id,
+            ], $options), $this->stripeOptions());
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -101,7 +101,7 @@ trait ManagesInvoices
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function upcomingInvoice($options = [])
+    public function upcomingInvoice(array $options = [])
     {
         if (! $this->hasStripeId()) {
             return;

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -100,7 +100,7 @@ trait ManagesInvoices
      *
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function upcomingInvoice()
+    public function upcomingInvoice($options = [])
     {
         if (! $this->hasStripeId()) {
             return;

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -98,6 +98,7 @@ trait ManagesInvoices
     /**
      * Get the customer's upcoming invoice.
      *
+     * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
      */
     public function upcomingInvoice($options = [])

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -632,7 +632,7 @@ class Subscription extends Model
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function upcomingInvoice($options = [])
+    public function upcomingInvoice(array $options = [])
     {
         return $this->owner->upcomingInvoice(array_merge([
             'subscription' => $this->stripe_id,
@@ -646,7 +646,7 @@ class Subscription extends Model
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function previewUpcomingInvoice($plans, $options = [])
+    public function previewUpcomingInvoice($plans, array $options = [])
     {
         if (empty($plans = (array) $plans)) {
             throw new InvalidArgumentException('Please provide at least one plan when swapping.');

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -659,10 +659,10 @@ class Subscription extends Model
             $this->parseSwapPlans($plans)
         );
 
-        return $this->upcomingInvoice([
+        return $this->upcomingInvoice(array_merge([
             'subscription_items' => $items->values()->all(),
             'subscription_trial_end' => $this->onTrial() ? $this->trial_ends_at->getTimestamp() : 'now',
-        ]);
+        ], $options));
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -627,13 +627,24 @@ class Subscription extends Model
         return $this;
     }
 
+    /**
+     * Fetches upcoming invoice for this subscription
+     *
+     * @return \Laravel\Cashier\Invoice|null
+     */
+    public function upcomingInvoice($options = [])
+    {
+        return $this->owner->upcomingInvoice(array_merge([
+            'subscription' => $this->stripe_id,
+        ], $options));
+    }
 
     /**
      * Previews upcoming invoice with new stripe plans
      *
      * @param  string|array  $plans
      * @param  array  $options
-     * @return \Stripe\Invoice
+     * @return \Laravel\Cashier\Invoice|null
      */
     public function previewUpcomingInvoice($plans, $options = [])
     {
@@ -647,11 +658,10 @@ class Subscription extends Model
             $this->parseSwapPlans($plans)
         );
 
-        return StripeInvoice::upcoming(array_merge([
-            'subscription' => $this->stripe_id,
+        return $this->upcomingInvoice([
             'subscription_items' => $items->values()->all(),
-            'subscription_trial_end' => $this->onTrial() ? $this->trial_ends_at->getTimestamp() : 'now'
-        ], $options), $this->owner->stripeOptions());
+            'subscription_trial_end' => $this->onTrial() ? $this->trial_ends_at->getTimestamp() : 'now',
+        ]);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -15,7 +15,6 @@ use Laravel\Cashier\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
-use Stripe\Invoice as StripeInvoice;
 use Stripe\Subscription as StripeSubscription;
 
 class Subscription extends Model
@@ -628,7 +627,7 @@ class Subscription extends Model
     }
 
     /**
-     * Fetches upcoming invoice for this subscription
+     * Fetches upcoming invoice for this subscription.
      *
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
@@ -641,7 +640,7 @@ class Subscription extends Model
     }
 
     /**
-     * Previews upcoming invoice with new stripe plans
+     * Previews upcoming invoice with new stripe plans.
      *
      * @param  string|array  $plans
      * @param  array  $options

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -630,6 +630,7 @@ class Subscription extends Model
     /**
      * Fetches upcoming invoice for this subscription
      *
+     * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
      */
     public function upcomingInvoice($options = [])

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1088,7 +1088,7 @@ class Subscription extends Model
     }
 
     /**
-     * Previews the upcoming invoice with new Stripe plans.
+     * Preview the upcoming invoice with new Stripe plans.
      *
      * @param  string|array  $plans
      * @param  array  $options

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -868,7 +868,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription = $user->newSubscription('main', static::$planId)
             ->create('pm_card_visa');
 
-        $invoice = $subscription->previewUpcomingInvoice(static::$otherPlanId);
+        $invoice = $subscription->previewInvoice(static::$otherPlanId);
 
         $this->assertSame('draft', $invoice->status);
         $this->assertSame(1000, $invoice->total);

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -869,7 +869,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription = $user->newSubscription('main', static::$planId)
             ->create('pm_card_visa');
 
-        $invoice = $subscription->previewInvoice(static::$otherPlanId);
+        $invoice = $subscription->previewUpcomingInvoice(static::$otherPlanId);
 
         $this->assertSame('draft', $invoice->status);
         $this->assertSame(1000, $invoice->total);

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -862,7 +862,6 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame($endsAt->timestamp, $subscription->asStripeSubscription()->cancel_at);
     }
 
-
     public function test_upcoming_invoice()
     {
         $user = $this->createCustomer('subscription_upcoming_invoice');

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -861,4 +861,17 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame($endsAt->timestamp, $subscription->ends_at->timestamp);
         $this->assertSame($endsAt->timestamp, $subscription->asStripeSubscription()->cancel_at);
     }
+
+
+    public function test_upcoming_invoice()
+    {
+        $user = $this->createCustomer('subscription_upcoming_invoice');
+        $subscription = $user->newSubscription('main', static::$planId)
+            ->create('pm_card_visa');
+
+        $invoice = $subscription->previewInvoice(static::$otherPlanId);
+
+        $this->assertSame('draft', $invoice->status);
+        $this->assertSame(1000, $invoice->total);
+    }
 }


### PR DESCRIPTION
Noticed this issue and thought I would suggest a PR since I've done something similar in my current project. Nothing fancy. Just a very basic method that has the same signature as the `swap` method

```php
$upcomingInvoice = $subscription->previewInvoice('price_to_swap')
```

Closes #1142