### PR TITLE
[13.x] Multiple discounts on receipts

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -246,6 +246,7 @@
                         </tr>
                     @endif
 
+
                     <!-- Display The Discount -->
                     @if ($invoice->hasDiscount())
                         <tr>

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -30,7 +30,7 @@
             vertical-align: bottom;
             font-weight: bold;
             padding: 8px;
-            line-height: 20px;
+            line-height: 14px;
             text-align: left;
             border-bottom: 1px solid #ddd;
         }
@@ -41,7 +41,7 @@
 
         .table td {
             padding: 8px;
-            line-height: 20px;
+            line-height: 14px;
             text-align: left;
             vertical-align: top;
         }
@@ -246,20 +246,23 @@
                         </tr>
                     @endif
 
-
                     <!-- Display The Discount -->
                     @if ($invoice->hasDiscount())
-                        <tr>
-                            <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
-                                @if ($invoice->discountIsPercentage())
-                                    {{ $invoice->couponName() }} ({{ $invoice->percentOff() }}% Off)
-                                @else
-                                    {{ $invoice->couponName() }} ({{ $invoice->amountOff() }} Off)
-                                @endif
-                            </td>
+                        @foreach ($invoice->discounts() as $discount)
+                            @php($coupon = $discount->coupon())
 
-                            <td>-{{ $invoice->discount() }}</td>
-                        </tr>
+                            <tr>
+                                <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
+                                    @if ($coupon->isPercentage())
+                                        {{ $coupon->name() }} ({{ $coupon->percentOff() }}% Off)
+                                    @else
+                                        {{ $coupon->name() }} ({{ $coupon->amountOff() }} Off)
+                                    @endif
+                                </td>
+
+                                <td>-{{ $invoice->discountFor($discount) }}</td>
+                            </tr>
+                        @endforeach
                     @endif
 
                     <!-- Display The Taxes -->

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -81,7 +81,7 @@ class Cashier
      */
     public static function findBillable($stripeId)
     {
-        if ($stripeId === null) {
+        if (is_null($stripeId)) {
             return;
         }
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -118,7 +118,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Dynamically get values from the Stripe Checkout Session.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -80,7 +80,7 @@ trait ManagesInvoices
                 $stripeInvoice = $stripeInvoice->sendInvoice();
             }
 
-            return $this->findInvoice($stripeInvoice->id);
+            return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {
             return false;
         } catch (StripeCardException $exception) {

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -107,13 +107,7 @@ trait ManagesInvoices
         }
 
         try {
-            $stripeInvoice = StripeInvoice::upcoming(
-<<<<<<< Updated upstream
-                ['customer' => $this->stripe_id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
-=======
-                ['customer' => $this->stripe_id, 'expand' => ['discounts']], $this->stripeOptions()
->>>>>>> Stashed changes
-            );
+            $stripeInvoice = StripeInvoice::upcoming(['customer' => $this->stripe_id], $this->stripeOptions());
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {
@@ -132,13 +126,7 @@ trait ManagesInvoices
         $stripeInvoice = null;
 
         try {
-            $stripeInvoice = StripeInvoice::retrieve(
-<<<<<<< Updated upstream
-                ['id' => $id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
-=======
-                ['id' => $id, 'expand' => ['discounts']], $this->stripeOptions()
->>>>>>> Stashed changes
-            );
+            $stripeInvoice = StripeInvoice::retrieve($id, $this->stripeOptions());
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -195,7 +183,7 @@ trait ManagesInvoices
     public function invoices($includePending = false, $parameters = [])
     {
         if (! $this->hasStripeId()) {
-            return collect();
+            return new Collection();
         }
 
         $invoices = [];
@@ -203,7 +191,7 @@ trait ManagesInvoices
         $parameters = array_merge(['limit' => 24], $parameters);
 
         $stripeInvoices = StripeInvoice::all(
-            ['customer' => $this->stripe_id, 'expand' => ['data.discounts']] + $parameters,
+            ['customer' => $this->stripe_id] + $parameters,
             $this->stripeOptions()
         );
 

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -80,7 +80,7 @@ trait ManagesInvoices
                 $stripeInvoice = $stripeInvoice->sendInvoice();
             }
 
-            return new Invoice($this, $stripeInvoice);
+            return $this->findInvoice($stripeInvoice->id);
         } catch (StripeInvalidRequestException $exception) {
             return false;
         } catch (StripeCardException $exception) {
@@ -108,7 +108,11 @@ trait ManagesInvoices
 
         try {
             $stripeInvoice = StripeInvoice::upcoming(
+<<<<<<< Updated upstream
                 ['customer' => $this->stripe_id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
+=======
+                ['customer' => $this->stripe_id, 'expand' => ['discounts']], $this->stripeOptions()
+>>>>>>> Stashed changes
             );
 
             return new Invoice($this, $stripeInvoice);
@@ -129,7 +133,11 @@ trait ManagesInvoices
 
         try {
             $stripeInvoice = StripeInvoice::retrieve(
+<<<<<<< Updated upstream
                 ['id' => $id, 'expand' => ['account_tax_ids']], $this->stripeOptions()
+=======
+                ['id' => $id, 'expand' => ['discounts']], $this->stripeOptions()
+>>>>>>> Stashed changes
             );
         } catch (StripeInvalidRequestException $exception) {
             //
@@ -195,7 +203,7 @@ trait ManagesInvoices
         $parameters = array_merge(['limit' => 24], $parameters);
 
         $stripeInvoices = StripeInvoice::all(
-            ['customer' => $this->stripe_id] + $parameters,
+            ['customer' => $this->stripe_id, 'expand' => ['data.discounts']] + $parameters,
             $this->stripeOptions()
         );
 

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Concerns;
 
 use Exception;
+use Illuminate\Support\Collection;
 use Laravel\Cashier\PaymentMethod;
 use Stripe\Customer as StripeCustomer;
 use Stripe\PaymentMethod as StripePaymentMethod;
@@ -54,7 +55,7 @@ trait ManagesPaymentMethods
     public function paymentMethods($type = 'card', $parameters = [])
     {
         if (! $this->hasStripeId()) {
-            return collect();
+            return new Collection();
         }
 
         $parameters = array_merge(['limit' => 24], $parameters);
@@ -65,7 +66,7 @@ trait ManagesPaymentMethods
             $this->stripeOptions()
         );
 
-        return collect($paymentMethods->data)->map(function ($paymentMethod) {
+        return Collection::make($paymentMethods->data)->map(function ($paymentMethod) {
             return new PaymentMethod($this, $paymentMethod);
         });
     }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Illuminate\Support\Collection;
 use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
 use Stripe\PaymentIntent as StripePaymentIntent;
@@ -76,7 +77,7 @@ trait PerformsCharges
      */
     public function checkout($items, array $sessionOptions = [], array $customerOptions = [])
     {
-        $items = collect((array) $items)->map(function ($item, $key) {
+        $items = Collection::make((array) $items)->map(function ($item, $key) {
             if (is_string($key)) {
                 return ['price' => $key, 'quantity' => $item];
             }

--- a/src/Coupon.php
+++ b/src/Coupon.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use Stripe\Coupon as StripeCoupon;
+
+class Coupon implements Arrayable, Jsonable, JsonSerializable
+{
+    /**
+     * The Stripe Coupon instance.
+     *
+     * @var \Stripe\Coupon
+     */
+    protected $coupon;
+
+    /**
+     * Create a new Coupon instance.
+     *
+     * @param  \Stripe\Coupon  $coupon
+     * @return void
+     */
+    public function __construct(StripeCoupon $coupon)
+    {
+        $this->coupon = $coupon;
+    }
+
+    /**
+     * Get the readable name for the Coupon.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->coupon->name ?: $this->coupon->id;
+    }
+
+    /**
+     * Determine if the coupon is a percentage.
+     *
+     * @return bool
+     */
+    public function isPercentage()
+    {
+        return ! is_null($this->coupon->percent_off);
+    }
+
+    /**
+     * Get the discount percentage for the invoice.
+     *
+     * @return float|null
+     */
+    public function percentOff()
+    {
+        return $this->coupon->percent_off;
+    }
+
+    /**
+     * Get the amount off for the coupon.
+     *
+     * @return string|null
+     */
+    public function amountOff()
+    {
+        if (! is_null($this->coupon->amount_off)) {
+            return $this->formatAmount($this->rawAmountOff());
+        }
+    }
+
+    /**
+     * Get the raw amount off for the coupon.
+     *
+     * @return int|null
+     */
+    public function rawAmountOff()
+    {
+        return $this->coupon->amount_off;
+    }
+
+    /**
+     * Format the given amount into a displayable currency.
+     *
+     * @param  int  $amount
+     * @return string
+     */
+    protected function formatAmount($amount)
+    {
+        return Cashier::formatAmount($amount, $this->coupon->currency);
+    }
+
+    /**
+     * Get the Stripe Coupon instance.
+     *
+     * @return \Stripe\Coupon
+     */
+    public function asStripeCoupon()
+    {
+        return $this->coupon;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->asStripeCoupon()->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Dynamically get values from the Stripe object.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->coupon->{$key};
+    }
+}

--- a/src/Discount.php
+++ b/src/Discount.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use Stripe\Discount as StripeDiscount;
+
+class Discount implements Arrayable, Jsonable, JsonSerializable
+{
+    /**
+     * The Stripe PaymentIntent instance.
+     *
+     * @var \Stripe\Discount
+     */
+    protected $discount;
+
+    /**
+     * Create a new Discount instance.
+     *
+     * @param  \Stripe\Discount  $discount
+     * @return void
+     */
+    public function __construct(StripeDiscount $discount)
+    {
+        $this->discount = $discount;
+    }
+
+    /**
+     * Get the coupon code applied to the discount.
+     *
+     * @return string
+     */
+    public function coupon()
+    {
+        return $this->discount->coupon->id;
+    }
+
+    /**
+     * Get the coupon name applied to the discount.
+     *
+     * @return string
+     */
+    public function couponName()
+    {
+        return $this->discount->coupon->name ?: $this->discount->coupon->id;
+    }
+
+    /**
+     * Determine if the discount is a percentage.
+     *
+     * @return bool
+     */
+    public function discountIsPercentage()
+    {
+        return ! is_null($this->discount->coupon->percent_off);
+    }
+
+    /**
+     * Get the discount percentage for the invoice.
+     *
+     * @return float|null
+     */
+    public function percentOff()
+    {
+        return $this->discount->coupon->percent_off;
+    }
+
+    /**
+     * Get the amount off for the discount.
+     *
+     * @return string|null
+     */
+    public function amountOff()
+    {
+        if (! is_null($this->discount->coupon->amount_off)) {
+            return $this->formatAmount($this->rawAmountOff());
+        }
+    }
+
+    /**
+     * Get the raw amount off for the discount.
+     *
+     * @return int|null
+     */
+    public function rawAmountOff()
+    {
+        return $this->discount->coupon->amount_off;
+    }
+
+    /**
+     * Format the given amount into a displayable currency.
+     *
+     * @param  int  $amount
+     * @return string
+     */
+    protected function formatAmount($amount)
+    {
+        return Cashier::formatAmount($amount, $this->discount->coupon->currency);
+    }
+
+    /**
+     * Get the Stripe Discount instance.
+     *
+     * @return \Stripe\Discount
+     */
+    public function asStripeDiscount()
+    {
+        return $this->discount;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->asStripeDiscount()->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Dynamically get values from the Stripe Discount.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->discount->{$key};
+    }
+}

--- a/src/Discount.php
+++ b/src/Discount.php
@@ -10,7 +10,7 @@ use Stripe\Discount as StripeDiscount;
 class Discount implements Arrayable, Jsonable, JsonSerializable
 {
     /**
-     * The Stripe PaymentIntent instance.
+     * The Stripe Discount instance.
      *
      * @var \Stripe\Discount
      */
@@ -28,76 +28,13 @@ class Discount implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the coupon code applied to the discount.
+     * Get the coupon applied to the discount.
      *
-     * @return string
+     * @return \Laravel\Cashier\Coupon
      */
     public function coupon()
     {
-        return $this->discount->coupon->id;
-    }
-
-    /**
-     * Get the coupon name applied to the discount.
-     *
-     * @return string
-     */
-    public function couponName()
-    {
-        return $this->discount->coupon->name ?: $this->discount->coupon->id;
-    }
-
-    /**
-     * Determine if the discount is a percentage.
-     *
-     * @return bool
-     */
-    public function discountIsPercentage()
-    {
-        return ! is_null($this->discount->coupon->percent_off);
-    }
-
-    /**
-     * Get the discount percentage for the invoice.
-     *
-     * @return float|null
-     */
-    public function percentOff()
-    {
-        return $this->discount->coupon->percent_off;
-    }
-
-    /**
-     * Get the amount off for the discount.
-     *
-     * @return string|null
-     */
-    public function amountOff()
-    {
-        if (! is_null($this->discount->coupon->amount_off)) {
-            return $this->formatAmount($this->rawAmountOff());
-        }
-    }
-
-    /**
-     * Get the raw amount off for the discount.
-     *
-     * @return int|null
-     */
-    public function rawAmountOff()
-    {
-        return $this->discount->coupon->amount_off;
-    }
-
-    /**
-     * Format the given amount into a displayable currency.
-     *
-     * @param  int  $amount
-     * @return string
-     */
-    protected function formatAmount($amount)
-    {
-        return Cashier::formatAmount($amount, $this->discount->coupon->currency);
+        return new Coupon($this->discount->coupon);
     }
 
     /**
@@ -142,7 +79,7 @@ class Discount implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Dynamically get values from the Stripe Discount.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -35,7 +35,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     /**
      * The Stripe invoice line items.
      *
-     * @var \Stripe\Collection|\Stripe\InvoiceLineItem[]
+     * @var \Laravel\Cashier\InvoiceLineItem[]
      */
     protected $items;
 
@@ -45,6 +45,13 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      * @var \Laravel\Cashier\Tax[]
      */
     protected $taxes;
+
+    /**
+     * The taxes applied to the invoice.
+     *
+     * @var \Laravel\Cashier\Discount[]
+     */
+    protected $discounts;
 
     /**
      * Create a new invoice instance.
@@ -160,17 +167,60 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function hasDiscount()
     {
+        if (is_null($this->invoice->discounts)) {
+            return false;
+        }
+
         return count($this->invoice->discounts) > 0;
     }
 
     /**
      * Get all of the discount objects from the Stripe invoice.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Laravel\Cashier\Discount[]
      */
     public function discounts()
     {
-        return Collection::make($this->invoice->discounts)->mapInto(Discount::class);
+        if (! is_null($this->discounts)) {
+            return $this->discounts;
+        }
+
+        $this->refreshWithExpandedData();
+
+        return Collection::make($this->invoice->discounts)
+            ->mapInto(Discount::class)
+            ->all();
+    }
+
+    /**
+     * Calculate the amount for a given discount.
+     *
+     * @param  \Laravel\Cashier\Discount  $discount
+     * @return string|null
+     */
+    public function discountFor(Discount $discount)
+    {
+        if (! is_null($discountAmount = $this->rawDiscountFor($discount))) {
+            return $this->formatAmount($discountAmount->amount);
+        }
+    }
+
+    /**
+     * Calculate the raw amount for a given discount.
+     *
+     * @param  \Laravel\Cashier\Discount  $discount
+     * @return int|null
+     */
+    public function rawDiscountFor(Discount $discount)
+    {
+        return Collection::make($this->invoice->total_discount_amounts)
+            ->first(function ($discountAmount) use ($discount) {
+                if (is_string($discountAmount->discount)) {
+                    return $discountAmount->discount === $discount->id;
+                } else {
+                    return $discountAmount->discount->id === $discount->id;
+                }
+            });
     }
 
     /**
@@ -190,13 +240,9 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function rawDiscount()
     {
-        if (! isset($this->invoice->discount)) {
-            return 0;
-        }
-
         $total = 0;
 
-        foreach ($this->invoice->total_discount_amounts as $discount) {
+        foreach ((array) $this->invoice->total_discount_amounts as $discount) {
             $total += $discount->amount;
         }
 
@@ -222,7 +268,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     {
         $lineItems = $this->invoiceItems() + $this->subscriptions();
 
-        return collect($lineItems)->contains(function (InvoiceLineItem $item) {
+        return Collection::make($lineItems)->contains(function (InvoiceLineItem $item) {
             return $item->hasTaxRates();
         });
     }
@@ -238,9 +284,9 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             return $this->taxes;
         }
 
-        $this->refreshWithExpandedTaxRates();
+        $this->refreshWithExpandedData();
 
-        return $this->taxes = collect($this->invoice->total_tax_amounts)
+        return $this->taxes = Collection::make($this->invoice->total_tax_amounts)
             ->sortByDesc('inclusive')
             ->map(function (object $taxAmount) {
                 return new Tax($taxAmount->amount, $this->invoice->currency, $taxAmount->tax_rate);
@@ -285,7 +331,9 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function invoiceItems()
     {
-        return $this->invoiceLineItemsByType('invoiceitem');
+        return Collection::make($this->invoiceLineItems())->filter(function (InvoiceLineItem $item) {
+            return $item->type === 'invoiceitem';
+        })->all();
     }
 
     /**
@@ -295,43 +343,51 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function subscriptions()
     {
-        return $this->invoiceLineItemsByType('subscription');
-    }
-
-    /**
-     * Get all of the invoice items by a given type.
-     *
-     * @param  string  $type
-     * @return \Laravel\Cashier\InvoiceLineItem[]
-     */
-    public function invoiceLineItemsByType($type)
-    {
-        if (is_null($this->items)) {
-            $this->refreshWithExpandedTaxRates();
-
-            $this->items = new Collection($this->invoice->lines->autoPagingIterator());
-        }
-
-        return $this->items->filter(function (StripeInvoiceLineItem $item) use ($type) {
-            return $item->type === $type;
-        })->map(function (StripeInvoiceLineItem $item) {
-            return new InvoiceLineItem($this, $item);
+        return Collection::make($this->invoiceLineItems())->filter(function (InvoiceLineItem $item) {
+            return $item->type === 'subscription';
         })->all();
     }
 
     /**
-     * Refresh the invoice with expanded TaxRate objects.
+     * Get all of the invoice items.
+     *
+     * @return \Laravel\Cashier\InvoiceLineItem[]
+     */
+    public function invoiceLineItems()
+    {
+        if (! is_null($this->items)) {
+            return $this->items;
+        }
+
+        $this->refreshWithExpandedData();
+
+        return $this->items = Collection::make($this->invoice->lines->autoPagingIterator())
+            ->map(function (StripeInvoiceLineItem $item) {
+                return new InvoiceLineItem($this, $item);
+            })->all();
+    }
+
+    /**
+     * Refresh the invoice with expanded objects.
      *
      * @return void
      */
-    protected function refreshWithExpandedTaxRates()
+    protected function refreshWithExpandedData()
     {
+        static $refreshed = false;
+
+        if ($refreshed) {
+            return;
+        }
+
         if ($this->invoice->id) {
             $this->invoice = StripeInvoice::retrieve([
                 'id' => $this->invoice->id,
                 'expand' => [
                     'account_tax_ids',
+                    'discounts',
                     'lines.data.tax_amounts.tax_rate',
+                    'total_discount_amounts.discount',
                     'total_tax_amounts.tax_rate',
                 ],
             ], $this->owner->stripeOptions());
@@ -340,11 +396,16 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             $this->invoice = StripeInvoice::upcoming([
                 'customer' => $this->owner->stripe_id,
                 'expand' => [
+                    'account_tax_ids',
+                    'discounts',
                     'lines.data.tax_amounts.tax_rate',
+                    'total_discount_amounts.discount',
                     'total_tax_amounts.tax_rate',
                 ],
             ], $this->owner->stripeOptions());
         }
+
+        $refreshed = true;
     }
 
     /**
@@ -365,13 +426,15 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function accountTaxIds()
     {
+        $this->refreshWithExpandedData();
+
         return $this->invoice->account_tax_ids ?? [];
     }
 
     /**
      * Return the Tax Ids of the customer.
      *
-     * @return \Stripe\TaxId[]
+     * @return array
      */
     public function customerTaxIds()
     {
@@ -512,7 +575,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Dynamically get values from the Stripe invoice.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -154,17 +154,27 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Determine if the invoice has a discount.
+     * Determine if the invoice has one or more discounts applied.
      *
      * @return bool
      */
     public function hasDiscount()
     {
-        return $this->rawDiscount() > 0;
+        return count($this->invoice->discounts) > 0;
     }
 
     /**
-     * Get the discount amount.
+     * Get all of the discount objects from the Stripe invoice.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function discounts()
+    {
+        return Collection::make($this->invoice->discounts)->mapInto(Discount::class);
+    }
+
+    /**
+     * Get the total discount amount.
      *
      * @return string
      */
@@ -174,7 +184,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the raw discount amount.
+     * Get the raw total discount amount.
      *
      * @return int
      */
@@ -191,78 +201,6 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
         }
 
         return (int) $total;
-    }
-
-    /**
-     * Get the coupon code applied to the invoice.
-     *
-     * @return string|null
-     */
-    public function coupon()
-    {
-        if (isset($this->invoice->discount)) {
-            return $this->invoice->discount->coupon->id;
-        }
-    }
-
-    /**
-     * Get the coupon name applied to the invoice.
-     *
-     * @return string|null
-     */
-    public function couponName()
-    {
-        if (isset($this->invoice->discount)) {
-            return $this->invoice->discount->coupon->name ?: $this->invoice->discount->coupon->id;
-        }
-    }
-
-    /**
-     * Determine if the discount is a percentage.
-     *
-     * @return bool
-     */
-    public function discountIsPercentage()
-    {
-        return isset($this->invoice->discount) && isset($this->invoice->discount->coupon->percent_off);
-    }
-
-    /**
-     * Get the discount percentage for the invoice.
-     *
-     * @return int
-     */
-    public function percentOff()
-    {
-        if ($this->coupon()) {
-            return $this->invoice->discount->coupon->percent_off;
-        }
-
-        return 0;
-    }
-
-    /**
-     * Get the discount amount for the invoice.
-     *
-     * @return string
-     */
-    public function amountOff()
-    {
-        return $this->formatAmount($this->rawAmountOff());
-    }
-
-    /**
-     * Get the raw discount amount for the invoice.
-     *
-     * @return int
-     */
-    public function rawAmountOff()
-    {
-        if (isset($this->invoice->discount->coupon->amount_off)) {
-            return $this->invoice->discount->coupon->amount_off;
-        }
-
-        return 0;
     }
 
     /**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -54,6 +54,13 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     protected $discounts;
 
     /**
+     * Indicate if the Stripe Object was refreshed with extra data.
+     *
+     * @var bool
+     */
+    protected $refreshed = false;
+
+    /**
      * Create a new invoice instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $owner
@@ -374,9 +381,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     protected function refreshWithExpandedData()
     {
-        static $refreshed = false;
-
-        if ($refreshed) {
+        if ($this->refreshed) {
             return;
         }
 
@@ -405,7 +410,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             ], $this->owner->stripeOptions());
         }
 
-        $refreshed = true;
+        $this->refreshed = true;
     }
 
     /**

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Collection;
 use JsonSerializable;
 use Stripe\InvoiceLineItem as StripeInvoiceLineItem;
 use Stripe\TaxRate as StripeTaxRate;
@@ -98,7 +99,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
             return 0;
         }
 
-        return (int) collect($this->item->tax_rates)
+        return (int) Collection::make($this->item->tax_rates)
             ->filter(function (StripeTaxRate $taxRate) use ($inclusive) {
                 return $taxRate->inclusive === (bool) $inclusive;
             })
@@ -119,7 +120,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
             return 0;
         }
 
-        return (int) collect($this->item->tax_amounts)
+        return (int) Collection::make($this->item->tax_amounts)
             ->filter(function (object $taxAmount) use ($inclusive) {
                 return $taxAmount->inclusive === (bool) $inclusive;
             })

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -199,7 +199,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Dynamically get values from the Stripe PaymentIntent.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -105,7 +105,7 @@ class PaymentMethod implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Dynamically get values from the Stripe PaymentMethod.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1037,7 +1037,7 @@ class Subscription extends Model
      */
     public function pending()
     {
-        return $this->asStripeSubscription()->pending_update !== null;
+        return ! is_null($this->asStripeSubscription()->pending_update);
     }
 
     /**
@@ -1069,7 +1069,7 @@ class Subscription extends Model
      */
     public function latestInvoice()
     {
-        $stripeSubscription = $this->asStripeSubscription(['latest_invoice']);
+        $stripeSubscription = $this->asStripeSubscription(['latest_invoice.discounts']);
 
         if ($stripeSubscription->latest_invoice) {
             return new Invoice($this->owner, $stripeSubscription->latest_invoice);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -714,7 +714,7 @@ class Subscription extends Model
     {
         $isSinglePlanSwap = $this->hasSinglePlan() && count($plans) === 1;
 
-        return collect($plans)->mapWithKeys(function ($options, $plan) use ($isSinglePlanSwap) {
+        return Collection::make($plans)->mapWithKeys(function ($options, $plan) use ($isSinglePlanSwap) {
             $plan = is_string($options) ? $options : $plan;
 
             $options = is_string($options) ? [] : $options;

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1069,7 +1069,7 @@ class Subscription extends Model
      */
     public function latestInvoice()
     {
-        $stripeSubscription = $this->asStripeSubscription(['latest_invoice.discounts']);
+        $stripeSubscription = $this->asStripeSubscription(['latest_invoice']);
 
         if ($stripeSubscription->latest_invoice) {
             return new Invoice($this->owner, $stripeSubscription->latest_invoice);

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
@@ -380,7 +381,7 @@ class SubscriptionBuilder
 
         return Checkout::create($this->owner, array_merge([
             'mode' => 'subscription',
-            'line_items' => collect($this->items)->values()->all(),
+            'line_items' => Collection::make($this->items)->values()->all(),
             'allow_promotion_codes' => $this->allowPromotionCodes,
             'discounts' => [
                 'coupon' => $this->coupon,
@@ -423,7 +424,7 @@ class SubscriptionBuilder
             'coupon' => $this->coupon,
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => $this->metadata,
-            'items' => collect($this->items)->values()->all(),
+            'items' => Collection::make($this->items)->values()->all(),
             'payment_behavior' => $this->paymentBehavior(),
             'promotion_code' => $this->promotionCode,
             'proration_behavior' => $this->prorateBehavior(),

--- a/src/Tax.php
+++ b/src/Tax.php
@@ -102,7 +102,7 @@ class Tax
     }
 
     /**
-     * Dynamically get values from the Stripe TaxRate.
+     * Dynamically get values from the Stripe object.
      *
      * @param  string  $key
      * @return mixed

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -199,7 +199,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals('$10.00', $invoice->total());
         $this->assertFalse($invoice->hasDiscount());
         $this->assertFalse($invoice->hasStartingBalance());
-        $this->assertNull($invoice->coupon());
+        $this->assertEmpty($invoice->discounts());
         $this->assertInstanceOf(Carbon::class, $invoice->date());
     }
 
@@ -395,10 +395,12 @@ class SubscriptionsTest extends FeatureTestCase
         // Invoice Tests
         $invoice = $user->invoices()[0];
 
+        $coupon = $invoice->discounts()[0]->coupon();
+
         $this->assertTrue($invoice->hasDiscount());
         $this->assertEquals('$5.00', $invoice->total());
-        $this->assertEquals('$5.00', $invoice->amountOff());
-        $this->assertFalse($invoice->discountIsPercentage());
+        $this->assertEquals('$5.00', $coupon->amountOff());
+        $this->assertFalse($coupon->isPercentage());
     }
 
     public function test_creating_subscription_with_an_anchored_billing_cycle()

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -201,7 +201,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->total_discount_amounts = [$discountAmount];
         $stripeInvoice->customer = 'foo';
-        $stripeInvoice->discount = $discount;
+        $stripeInvoice->discounts = [$discount];
 
         $user = new User();
         $user->stripe_id = 'foo';


### PR DESCRIPTION
This PR implements multiple discount support for receipts. With these changes, all discounts on a receipt are properly displayed with their name set up through Stripe as well as their percentage or amount off.

Here's an example of multiple discounts:

![Screenshot 2021-05-14 at 18 49 09](https://user-images.githubusercontent.com/594614/118302903-15bab480-b4e5-11eb-8720-0eb7f15237d6.jpg)

The general amount of is calculated first. Afterwards, individual discounts are applied per specific product they apply for.

Here's the equivalent Stripe receipt:

![Screenshot 2021-05-14 at 18 51 01](https://user-images.githubusercontent.com/594614/118303126-5fa39a80-b4e5-11eb-8527-a19eaac498c8.jpg)

Some other changes in this PR:

- I've refactored the way extra parameters on the Stripe Invoice object are expanded. They are now only expanded when called upon and the data is cached internally on the object.
- A new `Discount` and `Coupon` object were introduced to wrap the related Stripe objects.
- Cleaned up some inconsistencies with collection class instantiation and `is_null` calls.

Closes https://github.com/laravel/cashier-stripe/issues/1145