### PR TITLE
[12.x] Prorations and extending trials

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -587,11 +587,10 @@ class Subscription extends Model
             return $this;
         }
 
-        $subscription = $this->asStripeSubscription();
-
-        $subscription->trial_end = 'now';
-
-        $subscription->save();
+        $this->updateStripeSubscription([
+            'trial_end' => 'now',
+            'proration_behavior' => $this->prorateBehavior(),
+        ]);
 
         $this->trial_ends_at = null;
 
@@ -612,11 +611,10 @@ class Subscription extends Model
             throw new InvalidArgumentException("Extending a subscription's trial requires a date in the future.");
         }
 
-        $subscription = $this->asStripeSubscription();
-
-        $subscription->trial_end = $date->getTimestamp();
-
-        $subscription->save();
+        $this->updateStripeSubscription([
+            'trial_end' => $date->getTimestamp(),
+            'proration_behavior' => $this->prorateBehavior(),
+        ]);
 
         $this->trial_ends_at = $date;
 


### PR DESCRIPTION
This will allow the usage of proration behavior when extending trials:

```php
$subscription = $subscription->noProrate()->extendTrail($date);
```

Closes https://github.com/laravel/cashier-stripe/issues/1149