### PR TITLE
[13.x] Throw payment exceptions on item swap

### DIFF
--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -110,7 +110,6 @@ class SubscriptionItem extends Model
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
             'quantity' => $quantity,
-            'expand' => ['subscription.latest_invoice.payment_intent'],
         ]);
 
         $this->fill([
@@ -125,9 +124,7 @@ class SubscriptionItem extends Model
         }
 
         if ($this->subscription->hasIncompletePayment()) {
-            (new Payment(
-                $stripeSubscriptionItem->subscription->latest_invoice->payment_intent
-            ))->validate();
+            optional($this->subscription->latestPayment())->validate();
         }
 
         return $this;
@@ -152,7 +149,6 @@ class SubscriptionItem extends Model
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
             'tax_rates' => $this->subscription->getPlanTaxRatesForPayload($plan),
-            'expand' => ['subscription.latest_invoice.payment_intent'],
         ], $options));
 
         $this->fill([
@@ -168,9 +164,7 @@ class SubscriptionItem extends Model
         }
 
         if ($this->subscription->hasIncompletePayment()) {
-            (new Payment(
-                $stripeSubscriptionItem->subscription->latest_invoice->payment_intent
-            ))->validate();
+            optional($this->subscription->latestPayment())->validate();
         }
 
         return $this;


### PR DESCRIPTION
This PR refactors the way payments for subscription items are validated a bit (tests were failing atm) and it also adds exception throwing to plan swapping for subscription items. 

I noticed this wasn't implemented yet for subscription items either.