### PR TITLE
[12.x] Add extra 10 seconds of trial time

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -373,7 +373,8 @@ class SubscriptionBuilder
             // Checkout Sessions are active for 24 hours after their creation and within that time frame the customer
             // can complete the payment at any time. Stripe requires the trial end at least 48 hours in the future
             // so that there is still at least a one day trial if your customer pays at the end of the 24 hours.
-            $minimumTrialPeriod = Carbon::now()->addHours(48);
+            // We also add 10 seconds of extra time to account for any delay with the API request onto Stripe.
+            $minimumTrialPeriod = Carbon::now()->addHours(48)->addSeconds(10);
 
             $trialEnd = $this->trialExpires->gt($minimumTrialPeriod) ? $this->trialExpires : $minimumTrialPeriod;
         } else {

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -373,7 +373,7 @@ class SubscriptionBuilder
             // Checkout Sessions are active for 24 hours after their creation and within that time frame the customer
             // can complete the payment at any time. Stripe requires the trial end at least 48 hours in the future
             // so that there is still at least a one day trial if your customer pays at the end of the 24 hours.
-            // We also add 10 seconds of extra time to account for any delay with the API request onto Stripe.
+            // We also add 10 seconds of extra time to account for any delay with an API request onto Stripe.
             $minimumTrialPeriod = Carbon::now()->addHours(48)->addSeconds(10);
 
             $trialEnd = $this->trialExpires->gt($minimumTrialPeriod) ? $this->trialExpires : $minimumTrialPeriod;


### PR DESCRIPTION
When creating a Stripe Session checkout there's a minimum amount of time of 48 hours in which the user needs to be given a trial period. Because there could be a slight delay between the time the code is run and the API endpoint is hit, the timestamp could already be less than 48 hours away. Therefor I've tried to fix this by adding an additional 10 seconds of trial time to account for these execution delays.