### PR TITLE
[12.x] Fix adding invoice item with quantities

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -30,10 +30,15 @@ trait ManagesInvoices
 
         $options = array_merge([
             'customer' => $this->stripe_id,
-            'amount' => $amount,
             'currency' => $this->preferredCurrency(),
             'description' => $description,
         ], $options);
+
+        if (array_key_exists('quantity', $options)) {
+            $options['unit_amount'] = $amount;
+        } else {
+            $options['amount'] = $amount;
+        }
 
         return StripeInvoiceItem::create($options, $this->stripeOptions());
     }

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -84,4 +84,17 @@ class InvoicesTest extends FeatureTestCase
 
         $otherUser->findInvoiceOrFail($invoice->id);
     }
+
+    /** @group FOO */
+    public function test_customer_can_be_invoiced_with_quantity()
+    {
+        $user = $this->createCustomer('customer_can_be_invoiced');
+        $user->createAsStripeCustomer();
+        $user->updateDefaultPaymentMethod('pm_card_visa');
+
+        $response = $user->invoiceFor('Laracon', 1000, ['quantity' => 5]);
+
+        $this->assertInstanceOf(Invoice::class, $response);
+        $this->assertEquals(5000, $response->total);
+    }
 }


### PR DESCRIPTION
Apparently if you use a quantity here you're required to use `unit_amount` instead of `amount`. No idea why no-one ever stumbled on this before.

Fixes https://github.com/laravel/cashier-stripe/issues/1153