### PR TITLE
Bugfix: Creating Checkout session with Coupon (#1163)

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -381,19 +381,21 @@ class SubscriptionBuilder
             $trialEnd = null;
         }
 
-        return Checkout::create($this->owner, array_merge([
+        return Checkout::create($this->owner, array_filter(array_merge([
             'mode' => 'subscription',
             'line_items' => collect($this->items)->values()->all(),
             'allow_promotion_codes' => $this->allowPromotionCodes,
             'discounts' => [
-                'coupon' => $this->coupon,
+                [
+                    'coupon' => $this->coupon,
+                ],
             ],
             'subscription_data' => [
                 'default_tax_rates' => $this->getTaxRatesForPayload(),
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ],
-        ], $sessionOptions), $customerOptions);
+        ], $sessionOptions)), $customerOptions);
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue #1163.

### Description:
It's not possible to generate a Stripe Checkout session through Cashier when using Coupons via the `->withCoupon()` method.

#### There are two issues:
(1) The Stripe API does not accept both `allow_promotion_codes` and `discounts` parameters. Stripe throws an exception even when the `allow_promotion_codes` parameter is set to `false`.

(2) The `discount` parameter in the session creation payload needs to be an indexed array.

Both issues seem to be in inconsistent implementation of the Checkout API. It's not very well documented and this different from the way how regular subscriptions are created (without Checkout). See https://stripe.com/docs/billing/subscriptions/discounts for more details.

### Changes:
- Empty values such as `'allow_promotion_codes' = false` are filtered from the payload before sending it to Stripe
- `coupon` nested one level deeper in the `discounts` parameter


