### PR TITLE
[13.x] Stripe SDK refactor

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -7,6 +7,7 @@ use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
 use NumberFormatter;
+use Stripe\StripeClient;
 
 class Cashier
 {
@@ -89,17 +90,17 @@ class Cashier
     }
 
     /**
-     * Get the default Stripe API options.
+     * Get the Stripe SDK client.
      *
      * @param  array  $options
-     * @return array
+     * @return \Stripe\StripeClient
      */
-    public static function stripeOptions(array $options = [])
+    public static function stripe(array $options = [])
     {
-        return array_merge([
+        return new StripeClient(array_merge([
             'api_key' => config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
-        ], $options);
+        ], $options));
     }
 
     /**

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -98,7 +98,7 @@ class Cashier
     public static function stripe(array $options = [])
     {
         return new StripeClient(array_merge([
-            'api_key' => config('cashier.secret'),
+            'api_key' => $options['api_key'] ?? config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
         ], $options));
     }

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -49,7 +49,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable
     {
         $customer = $owner->createOrGetStripeCustomer($customerOptions);
 
-        $session = Cashier::stripe()->checkout->sessions->create(array_merge([
+        $session = $owner->stripe()->checkout->sessions->create(array_merge([
             'customer' => $customer->id,
             'mode' => 'payment',
             'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -49,13 +49,13 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable
     {
         $customer = $owner->createOrGetStripeCustomer($customerOptions);
 
-        $session = Session::create(array_merge([
+        $session = Cashier::stripe()->checkout->sessions->create(array_merge([
             'customer' => $customer->id,
             'mode' => 'payment',
             'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
             'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
             'payment_method_types' => ['card'],
-        ], $sessionOptions), Cashier::stripeOptions());
+        ], $sessionOptions));
 
         return new static($owner, $session);
     }

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -9,8 +9,6 @@ use Laravel\Cashier\Payment;
 use Stripe\Exception\CardException as StripeCardException;
 use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 use Stripe\Invoice as StripeInvoice;
-use Stripe\InvoiceItem as StripeInvoiceItem;
-use Stripe\PaymentIntent as StripePaymentIntent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -40,7 +38,7 @@ trait ManagesInvoices
             $options['amount'] = $amount;
         }
 
-        return StripeInvoiceItem::create($options, $this->stripeOptions());
+        return $this->stripe()->invoiceItems->create($options);
     }
 
     /**
@@ -77,7 +75,7 @@ trait ManagesInvoices
 
         try {
             /** @var \Stripe\Invoice $invoice */
-            $stripeInvoice = StripeInvoice::create($parameters, $this->stripeOptions());
+            $stripeInvoice = $this->stripe()->invoices->create($parameters);
 
             if ($stripeInvoice->collection_method === StripeInvoice::COLLECTION_METHOD_CHARGE_AUTOMATICALLY) {
                 $stripeInvoice = $stripeInvoice->pay();
@@ -90,9 +88,9 @@ trait ManagesInvoices
             return false;
         } catch (StripeCardException $exception) {
             $payment = new Payment(
-                StripePaymentIntent::retrieve(
-                    ['id' => $stripeInvoice->refresh()->payment_intent, 'expand' => ['invoice.subscription']],
-                    $this->stripeOptions()
+                $this->stripe()->paymentIntents->retrieve(
+                    $stripeInvoice->refresh()->payment_intent,
+                    ['expand' => ['invoice.subscription']]
                 )
             );
 
@@ -113,9 +111,9 @@ trait ManagesInvoices
         }
 
         try {
-            $stripeInvoice = StripeInvoice::upcoming(array_merge([
+            $stripeInvoice = $this->stripe()->invoices->upcoming(array_merge([
                 'customer' => $this->stripe_id,
-            ], $options), $this->stripeOptions());
+            ], $options));
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {
@@ -134,7 +132,7 @@ trait ManagesInvoices
         $stripeInvoice = null;
 
         try {
-            $stripeInvoice = StripeInvoice::retrieve($id, $this->stripeOptions());
+            $stripeInvoice = $this->stripe()->invoices->retrieve($id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -198,9 +196,8 @@ trait ManagesInvoices
 
         $parameters = array_merge(['limit' => 24], $parameters);
 
-        $stripeInvoices = StripeInvoice::all(
-            ['customer' => $this->stripe_id] + $parameters,
-            $this->stripeOptions()
+        $stripeInvoices = $this->stripe()->invoices->all(
+            ['customer' => $this->stripe_id] + $parameters
         );
 
         // Here we will loop through the Stripe invoices and create our own custom Invoice

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -5,8 +5,6 @@ namespace Laravel\Cashier\Concerns;
 use Illuminate\Support\Collection;
 use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
-use Stripe\PaymentIntent as StripePaymentIntent;
-use Stripe\Refund as StripeRefund;
 
 trait PerformsCharges
 {
@@ -43,7 +41,7 @@ trait PerformsCharges
         }
 
         $payment = new Payment(
-            StripePaymentIntent::create($options, $this->stripeOptions())
+            $this->stripe()->paymentIntents->create($options)
         );
 
         $payment->validate();
@@ -60,9 +58,8 @@ trait PerformsCharges
      */
     public function refund($paymentIntent, array $options = [])
     {
-        return StripeRefund::create(
-            ['payment_intent' => $paymentIntent] + $options,
-            $this->stripeOptions()
+        return $this->stripe()->refunds->create(
+            ['payment_intent' => $paymentIntent] + $options
         );
     }
 

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -86,7 +86,7 @@ trait PerformsCharges
                 $item['quantity'] = $item['quantity'] ?? 1;
 
                 return $item;
-            })->values()->all()
+            })->values()->all(),
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -74,7 +74,7 @@ trait PerformsCharges
      */
     public function checkout($items, array $sessionOptions = [], array $customerOptions = [])
     {
-        $items = Collection::make((array) $items)->map(function ($item, $key) {
+        $payload = ['line_items' => Collection::make((array) $items)->map(function ($item, $key) {
             if (is_string($key)) {
                 return ['price' => $key, 'quantity' => $item];
             }
@@ -84,12 +84,13 @@ trait PerformsCharges
             $item['quantity'] = $item['quantity'] ?? 1;
 
             return $item;
-        })->values()->all();
+        })->values()->all()];
 
-        return Checkout::create($this, array_merge([
-            'allow_promotion_codes' => $this->allowPromotionCodes,
-            'line_items' => $items,
-        ], $sessionOptions), $customerOptions);
+        if ($this->allowPromotionCodes) {
+            $payload['allow_promotion_codes'] = $this->allowPromotionCodes;
+        }
+
+        return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);
     }
 
     /**

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -6,7 +6,6 @@ use Illuminate\Routing\Controller;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Http\Middleware\VerifyRedirectUrl;
 use Laravel\Cashier\Payment;
-use Stripe\PaymentIntent as StripePaymentIntent;
 
 class PaymentController extends Controller
 {
@@ -30,9 +29,7 @@ class PaymentController extends Controller
     {
         return view('cashier::payment', [
             'stripeKey' => config('cashier.key'),
-            'payment' => new Payment(
-                StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
-            ),
+            'payment' => new Payment(Cashier::stripe()->paymentIntents->retrieve($id)),
             'redirect' => url(request('redirect', '/')),
         ]);
     }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -13,7 +13,6 @@ use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
-use Stripe\PaymentIntent as StripePaymentIntent;
 use Stripe\Subscription as StripeSubscription;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -270,9 +269,8 @@ class WebhookController extends Controller
 
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             if (in_array(Notifiable::class, class_uses_recursive($user))) {
-                $payment = new Payment(StripePaymentIntent::retrieve(
-                    $payload['data']['object']['payment_intent'],
-                    $user->stripeOptions()
+                $payment = new Payment(Cashier::stripe()->paymentIntents->retrieve(
+                    $payload['data']['object']['payment_intent']
                 ));
 
                 $user->notify(new $notification($payment));

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -386,8 +386,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
         }
 
         if ($this->invoice->id) {
-            $this->invoice = StripeInvoice::retrieve([
-                'id' => $this->invoice->id,
+            $this->invoice = Cashier::stripe()->invoices->retrieve($this->invoice->id, [
                 'expand' => [
                     'account_tax_ids',
                     'discounts',
@@ -395,10 +394,10 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
                     'total_discount_amounts.discount',
                     'total_tax_amounts.tax_rate',
                 ],
-            ], $this->owner->stripeOptions());
+            ]);
         } else {
             // If no invoice ID is present then assume this is the customer's upcoming invoice...
-            $this->invoice = StripeInvoice::upcoming([
+            $this->invoice = Cashier::stripe()->invoices->upcoming([
                 'customer' => $this->owner->stripe_id,
                 'expand' => [
                     'account_tax_ids',
@@ -407,7 +406,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
                     'total_discount_amounts.discount',
                     'total_tax_amounts.tax_rate',
                 ],
-            ], $this->owner->stripeOptions());
+            ]);
         }
 
         $this->refreshed = true;
@@ -454,7 +453,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function finalize(array $options = [])
     {
-        $this->invoice = $this->invoice->finalizeInvoice($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->finalizeInvoice($options);
 
         return $this;
     }
@@ -467,7 +466,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function pay(array $options = [])
     {
-        $this->invoice = $this->invoice->pay($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->pay($options);
 
         return $this;
     }
@@ -480,7 +479,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function send(array $options = [])
     {
-        $this->invoice = $this->invoice->sendInvoice($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->sendInvoice($options);
 
         return $this;
     }
@@ -493,7 +492,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function void(array $options = [])
     {
-        $this->invoice = $this->invoice->voidInvoice($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->voidInvoice($options);
 
         return $this;
     }
@@ -506,7 +505,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function markUncollectible(array $options = [])
     {
-        $this->invoice = $this->invoice->markUncollectible($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->markUncollectible($options);
 
         return $this;
     }
@@ -519,7 +518,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function delete(array $options = [])
     {
-        $this->invoice = $this->invoice->delete($options, $this->owner->stripeOptions());
+        $this->invoice = $this->invoice->delete($options);
 
         return $this;
     }

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -66,7 +66,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
      */
     public function capture(array $options = [])
     {
-        return $this->paymentIntent->capture($options, Cashier::stripeOptions());
+        return $this->paymentIntent->capture($options);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -17,6 +17,9 @@ use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
 use Stripe\Subscription as StripeSubscription;
 
+/**
+ * @property \Laravel\Cashier\Billable|\Illuminate\Database\Eloquent\Model $owner
+ */
 class Subscription extends Model
 {
     use HasFactory;
@@ -653,8 +656,8 @@ class Subscription extends Model
             $this->parseSwapPrices($prices)
         );
 
-        $stripeSubscription = StripeSubscription::update(
-            $this->stripe_id, $this->getSwapOptions($items, $options), $this->owner->stripeOptions()
+        $stripeSubscription = $this->owner->stripe()->subscriptions->update(
+            $this->stripe_id, $this->getSwapOptions($items, $options)
         );
 
         /** @var \Stripe\SubscriptionItem $firstItem */
@@ -808,9 +811,8 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::duplicatePrice($this, $price);
         }
 
-        $subscription = $this->asStripeSubscription();
-
-        $item = $subscription->items->create(array_merge([
+        $item = $this->owner->stripe()->subscriptionsItems->create(array_merge([
+            'subscription' => $this->stripe_id,
             'price' => $price,
             'quantity' => $quantity,
             'tax_rates' => $this->getPriceTaxRatesForPayload($price),
@@ -868,9 +870,9 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::cannotDeleteLastPrice($this);
         }
 
-        $stripeItem = $this->findItemOrFail($price)->asStripeSubscriptionItem();
+        $stripeItem = $this->findItemOrFail($price);
 
-        $stripeItem->delete(array_filter([
+        $this->owner->stripe()->subscriptionItems->delete($stripeItem->stripe_id, array_filter([
             'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' ? true : null,
             'proration_behavior' => $this->prorateBehavior(),
         ]));
@@ -898,13 +900,11 @@ class Subscription extends Model
      */
     public function cancel()
     {
-        $subscription = $this->asStripeSubscription();
+        $stripeSubscription = $this->updateStripeSubscription([
+            'cancel_at_period_end' => true,
+        ]);
 
-        $subscription->cancel_at_period_end = true;
-
-        $subscription = $subscription->save();
-
-        $this->stripe_status = $subscription->status;
+        $this->stripe_status = $stripeSubscription->status;
 
         // If the user was on trial, we will set the grace period to end when the trial
         // would have ended. Otherwise, we'll retrieve the end of the billing period
@@ -913,7 +913,7 @@ class Subscription extends Model
             $this->ends_at = $this->trial_ends_at;
         } else {
             $this->ends_at = Carbon::createFromTimestamp(
-                $subscription->current_period_end
+                $stripeSubscription->current_period_end
             );
         }
 
@@ -934,17 +934,14 @@ class Subscription extends Model
             $endsAt = $endsAt->getTimestamp();
         }
 
-        $subscription = $this->asStripeSubscription();
+        $stripeSubscription = $this->updateStripeSubscription([
+            'cancel_at' => $endsAt,
+            'proration_behavior' => $this->prorateBehavior(),
+        ]);
 
-        $subscription->proration_behavior = $this->prorateBehavior();
+        $this->stripe_status = $stripeSubscription->status;
 
-        $subscription->cancel_at = $endsAt;
-
-        $subscription = $subscription->save();
-
-        $this->stripe_status = $subscription->status;
-
-        $this->ends_at = Carbon::createFromTimestamp($subscription->cancel_at);
+        $this->ends_at = Carbon::createFromTimestamp($stripeSubscription->cancel_at);
 
         $this->save();
 
@@ -958,7 +955,7 @@ class Subscription extends Model
      */
     public function cancelNow()
     {
-        $this->asStripeSubscription()->cancel([
+        $this->owner->stripe()->subscriptions->cancel($this->stripe_id, [
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
 
@@ -974,7 +971,7 @@ class Subscription extends Model
      */
     public function cancelNowAndInvoice()
     {
-        $this->asStripeSubscription()->cancel([
+        $this->owner->stripe()->subscriptions->cancel($this->stripe_id, [
             'invoice_now' => true,
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
@@ -1011,23 +1008,16 @@ class Subscription extends Model
             throw new LogicException('Unable to resume subscription that is not within grace period.');
         }
 
-        $subscription = $this->asStripeSubscription();
-
-        $subscription->cancel_at_period_end = false;
-
-        if ($this->onTrial()) {
-            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
-        } else {
-            $subscription->trial_end = 'now';
-        }
-
-        $subscription = $subscription->save();
+        $stripeSubscription = $this->updateStripeSubscription([
+            'cancel_at_period_end' => false,
+            'trial_end' => $this->onTrial() ? $this->trial_ends_at->getTimestamp() : 'now',
+        ]);
 
         // Finally, we will remove the ending timestamp from the user's record in the
         // local database to indicate that the subscription is active again and is
         // no longer "cancelled". Then we will save this record in the database.
         $this->fill([
-            'stripe_status' => $subscription->status,
+            'stripe_status' => $stripeSubscription->status,
             'ends_at' => null,
         ])->save();
 
@@ -1136,22 +1126,16 @@ class Subscription extends Model
      */
     public function syncTaxRates()
     {
-        $stripeSubscription = $this->asStripeSubscription();
-
-        $stripeSubscription->default_tax_rates = $this->user->taxRates() ?: null;
-
-        $stripeSubscription->proration_behavior = $this->prorateBehavior();
-
-        $stripeSubscription->save();
+        $this->updateStripeSubscription([
+            'default_tax_rates' => $this->user->taxRates() ?: null,
+            'proration_behavior' => $this->prorateBehavior(),
+        ]);
 
         foreach ($this->items as $item) {
-            $stripeSubscriptionItem = $item->asStripeSubscriptionItem();
-
-            $stripeSubscriptionItem->tax_rates = $this->getPriceTaxRatesForPayload($item->stripe_price) ?: null;
-
-            $stripeSubscriptionItem->proration_behavior = $this->prorateBehavior();
-
-            $stripeSubscriptionItem->save();
+            $item->updateStripeSubscriptionItem([
+                'tax_rates' => $this->getPriceTaxRatesForPayload($item->stripe_price) ?: null,
+                'proration_behavior' => $this->prorateBehavior(),
+            ]);
         }
     }
 
@@ -1232,8 +1216,8 @@ class Subscription extends Model
      */
     public function updateStripeSubscription(array $options = [])
     {
-        return StripeSubscription::update(
-            $this->stripe_id, $options, $this->owner->stripeOptions()
+        return $this->owner->stripe()->subscriptions->update(
+            $this->stripe_id, $options
         );
     }
 
@@ -1245,8 +1229,8 @@ class Subscription extends Model
      */
     public function asStripeSubscription(array $expand = [])
     {
-        return StripeSubscription::retrieve(
-            ['id' => $this->stripe_id, 'expand' => $expand], $this->owner->stripeOptions()
+        return $this->owner->stripe()->subscriptions->retrieve(
+            $this->stripe_id, ['expand' => $expand]
         );
     }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -816,7 +816,7 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::duplicatePrice($this, $price);
         }
 
-        $item = $this->owner->stripe()->subscriptionsItems->create(array_merge([
+        $item = $this->owner->stripe()->subscriptionItems->create(array_merge([
             'subscription' => $this->stripe_id,
             'price' => $price,
             'quantity' => $quantity,

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -726,11 +726,16 @@ class Subscription extends Model
 
             $options = is_string($options) ? [] : $options;
 
-            return [$price => array_merge([
+            $payload = [
                 'price' => $price,
-                'quantity' => $isSinglePriceSwap ? $this->quantity : null,
                 'tax_rates' => $this->getPriceTaxRatesForPayload($price),
-            ], $options)];
+            ];
+
+            if ($isSinglePriceSwap && ! is_null($this->quantity)) {
+                $payload['quantity'] = $this->quantity;
+            }
+
+            return [$price => array_merge($payload, $options)];
         });
     }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -875,9 +875,9 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::cannotDeleteLastPrice($this);
         }
 
-        $stripeItem = $this->findItemOrFail($price);
+        $stripeItem = $this->findItemOrFail($price)->asStripeSubscriptionItem();
 
-        $this->owner->stripe()->subscriptionItems->delete($stripeItem->stripe_id, array_filter([
+        $stripeItem->delete(array_filter([
             'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' ? true : null,
             'proration_behavior' => $this->prorateBehavior(),
         ]));

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -376,19 +376,25 @@ class SubscriptionBuilder
             $trialEnd = null;
         }
 
-        return Checkout::create($this->owner, array_merge([
+        $payload = [
             'mode' => 'subscription',
             'line_items' => Collection::make($this->items)->values()->all(),
-            'allow_promotion_codes' => $this->allowPromotionCodes,
-            'discounts' => [
-                ['coupon' => $this->coupon],
-            ],
             'subscription_data' => [
                 'default_tax_rates' => $this->getTaxRatesForPayload(),
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ],
-        ], $sessionOptions), $customerOptions);
+        ];
+
+        if ($this->coupon) {
+            $payload['discounts'] = [
+                ['coupon' => $this->coupon],
+            ];
+        } elseif ($this->allowPromotionCodes) {
+            $payload['allow_promotion_codes'] = $this->allowPromotionCodes;
+        }
+
+        return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);
     }
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -20,7 +20,7 @@ class SubscriptionBuilder
     /**
      * The model that is subscribing.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var \Laravel\Cashier\Billable|\Illuminate\Database\Eloquent\Model
      */
     protected $owner;
 
@@ -298,15 +298,8 @@ class SubscriptionBuilder
 
         $customer = $this->getStripeCustomer($paymentMethod, $customerOptions);
 
-        $payload = array_merge(
-            ['customer' => $customer->id],
-            $this->buildPayload(),
-            $subscriptionOptions
-        );
-
-        $stripeSubscription = StripeSubscription::create(
-            $payload,
-            $this->owner->stripeOptions()
+        $stripeSubscription = $customer->subscriptions->create(
+            array_merge($this->buildPayload(), $subscriptionOptions)
         );
 
         $subscription = $this->createSubscription($stripeSubscription);

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -198,11 +198,11 @@ class SubscriptionItem extends Model
     {
         $timestamp = $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp;
 
-        return StripeSubscriptionItem::createUsageRecord($this->stripe_id, [
+        return $this->subscription->owner->stripe()->subscriptionItems->createUsageRecord($this->stripe_id, [
             'quantity' => $quantity,
             'action' => $timestamp ? 'set' : 'increment',
             'timestamp' => $timestamp ?? time(),
-        ], $this->subscription->owner->stripeOptions());
+        ]);
     }
 
     /**
@@ -213,8 +213,8 @@ class SubscriptionItem extends Model
      */
     public function usageRecords($options = [])
     {
-        return new Collection(StripeSubscriptionItem::allUsageRecordSummaries(
-            $this->stripe_id, $options, $this->subscription->owner->stripeOptions()
+        return new Collection($this->subscription->owner->stripe()->subscriptionItems->allUsageRecordSummaries(
+            $this->stripe_id, $options
         )->data);
     }
 
@@ -226,8 +226,8 @@ class SubscriptionItem extends Model
      */
     public function updateStripeSubscriptionItem(array $options = [])
     {
-        return StripeSubscriptionItem::update(
-            $this->stripe_id, $options, $this->subscription->owner->stripeOptions()
+        return $this->subscription->owner->stripe()->subscriptionItems->update(
+            $this->stripe_id, $options
         );
     }
 
@@ -239,9 +239,8 @@ class SubscriptionItem extends Model
      */
     public function asStripeSubscriptionItem(array $expand = [])
     {
-        return StripeSubscriptionItem::retrieve(
-            ['id' => $this->stripe_id, 'expand' => $expand],
-            $this->subscription->owner->stripeOptions()
+        return $this->subscription->owner->stripe()->subscriptionItems->retrieve(
+            $this->stripe_id, ['expand' => $expand]
         );
     }
 

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
-use Stripe\SubscriptionItem as StripeSubscriptionItem;
 
 /**
  * @property \Laravel\Cashier\Subscription|null $subscription

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -80,8 +80,8 @@ class CheckoutTest extends FeatureTestCase
             ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertTrue($session->allow_promotion_codes);
-        $this->assertSame(1815, $session->amount_total);
+        $this->assertTrue($checkout->allow_promotion_codes);
+        $this->assertSame(1815, $checkout->amount_total);
 
         $coupon = self::stripe()->coupons->create([
             'duration' => 'repeating',
@@ -98,7 +98,7 @@ class CheckoutTest extends FeatureTestCase
             ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertNull($session->allow_promotion_codes);
-        $this->assertSame(1210, $session->amount_total);
+        $this->assertNull($checkout->allow_promotion_codes);
+        $this->assertSame(1210, $checkout->amount_total);
     }
 }

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -3,10 +3,6 @@
 namespace Laravel\Cashier\Tests\Feature;
 
 use Laravel\Cashier\Checkout;
-use Stripe\Checkout\Session as StripeCheckoutSession;
-use Stripe\Coupon;
-use Stripe\Price as StripePrice;
-use Stripe\TaxRate;
 
 class CheckoutTest extends FeatureTestCase
 {
@@ -14,7 +10,7 @@ class CheckoutTest extends FeatureTestCase
     {
         $user = $this->createCustomer('customers_can_start_a_product_checkout_session');
 
-        $shirtPrice = StripePrice::create([
+        $shirtPrice = self::stripe()->prices->create([
             'currency' => 'USD',
             'product_data' => [
                 'name' => 'T-shirt',
@@ -22,7 +18,7 @@ class CheckoutTest extends FeatureTestCase
             'unit_amount' => 1500,
         ]);
 
-        $carPrice = StripePrice::create([
+        $carPrice = self::stripe()->prices->create([
             'currency' => 'USD',
             'product_data' => [
                 'name' => 'Car',
@@ -38,7 +34,6 @@ class CheckoutTest extends FeatureTestCase
         ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
     }
 
     public function test_customers_can_start_a_one_off_charge_checkout_session()
@@ -51,14 +46,13 @@ class CheckoutTest extends FeatureTestCase
         ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $checkout->asStripeCheckoutSession());
     }
 
     public function test_customers_can_start_a_subscription_checkout_session()
     {
         $user = $this->createCustomer('customers_can_start_a_subscription_checkout_session');
 
-        $price = StripePrice::create([
+        $price = self::stripe()->prices->create([
             'currency' => 'USD',
             'product_data' => [
                 'name' => 'Forge',
@@ -68,7 +62,7 @@ class CheckoutTest extends FeatureTestCase
             'unit_amount' => 1500,
         ]);
 
-        $taxRate = TaxRate::create([
+        $taxRate = self::stripe()->taxRates->create([
             'display_name' => 'VAT',
             'description' => 'VAT Belgium',
             'jurisdiction' => 'BE',
@@ -86,11 +80,10 @@ class CheckoutTest extends FeatureTestCase
             ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $session = $checkout->asStripeCheckoutSession());
         $this->assertTrue($session->allow_promotion_codes);
         $this->assertSame(1815, $session->amount_total);
 
-        $coupon = Coupon::create([
+        $coupon = self::stripe()->coupons->create([
             'duration' => 'repeating',
             'amount_off' => 500,
             'duration_in_months' => 3,
@@ -105,7 +98,6 @@ class CheckoutTest extends FeatureTestCase
             ]);
 
         $this->assertInstanceOf(Checkout::class, $checkout);
-        $this->assertInstanceOf(StripeCheckoutSession::class, $session = $checkout->asStripeCheckoutSession());
         $this->assertNull($session->allow_promotion_codes);
         $this->assertSame(1210, $session->amount_total);
     }

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -2,27 +2,13 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
-use Illuminate\Database\Eloquent\Model as Eloquent;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Tests\TestCase;
-use Stripe\ApiResource;
-use Stripe\Exception\InvalidRequestException;
-use Stripe\Stripe;
+use Stripe\StripeClient;
 
 abstract class FeatureTestCase extends TestCase
 {
-    /**
-     * @var string
-     */
-    protected static $stripePrefix = 'cashier-test-';
-
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        Stripe::setApiKey(getenv('STRIPE_SECRET'));
-    }
-
     protected function setUp(): void
     {
         // Delay consecutive tests to prevent Stripe rate limiting issues.
@@ -30,20 +16,14 @@ abstract class FeatureTestCase extends TestCase
 
         parent::setUp();
 
-        Eloquent::unguard();
-
         $this->loadLaravelMigrations();
 
         $this->artisan('migrate')->run();
     }
 
-    protected static function deleteStripeResource(ApiResource $resource)
+    protected static function stripe(array $options = []): StripeClient
     {
-        try {
-            $resource->delete();
-        } catch (InvalidRequestException $e) {
-            //
-        }
+        return Cashier::stripe(array_merge(['api_key' => getenv('STRIPE_SECRET')], $options));
     }
 
     protected function createCustomer($description = 'taylor', array $options = []): User

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Tests\TestCase;
@@ -9,16 +10,19 @@ use Stripe\StripeClient;
 
 abstract class FeatureTestCase extends TestCase
 {
+    use RefreshDatabase;
+
     protected function setUp(): void
     {
         // Delay consecutive tests to prevent Stripe rate limiting issues.
         sleep(2);
 
         parent::setUp();
+    }
 
+    protected function defineDatabaseMigrations()
+    {
         $this->loadLaravelMigrations();
-
-        $this->artisan('migrate')->run();
     }
 
     protected static function stripe(array $options = []): StripeClient

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -12,14 +12,6 @@ abstract class FeatureTestCase extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp(): void
-    {
-        // Delay consecutive tests to prevent Stripe rate limiting issues.
-        sleep(2);
-
-        parent::setUp();
-    }
-
     protected function defineDatabaseMigrations()
     {
         $this->loadLaravelMigrations();

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -4,9 +4,7 @@ namespace Laravel\Cashier\Tests\Feature;
 
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\PaymentMethod;
-use Stripe\PaymentMethod as StripePaymentMethod;
 use Stripe\SetupIntent as StripeSetupIntent;
-use Stripe\StripeClient;
 
 class PaymentMethodsTest extends FeatureTestCase
 {
@@ -38,9 +36,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_add_default_sepa_payment_method');
         $user->createAsStripeCustomer();
 
-        $stripe = new StripeClient(Cashier::stripeOptions());
-
-        $paymentMethod = $stripe->paymentMethods->create([
+        $paymentMethod = Cashier::stripe()->paymentMethods->create([
             'type' => 'sepa_debit',
             'billing_details' => [
                 'name' => 'John Doe',
@@ -125,10 +121,10 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_retrieve_all_payment_methods');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = StripePaymentMethod::retrieve('pm_card_visa', $user->stripeOptions());
+        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
-        $paymentMethod = StripePaymentMethod::retrieve('pm_card_mastercard', $user->stripeOptions());
+        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_mastercard');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $paymentMethods = $user->paymentMethods();
@@ -143,7 +139,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_sync_the_payment_method_from_stripe');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = StripePaymentMethod::retrieve('pm_card_visa', $user->stripeOptions());
+        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $customer->invoice_settings = ['default_payment_method' => $paymentMethod->id];
@@ -166,10 +162,10 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_delete_all_payment_methods');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = StripePaymentMethod::retrieve('pm_card_visa', $user->stripeOptions());
+        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
-        $paymentMethod = StripePaymentMethod::retrieve('pm_card_mastercard', $user->stripeOptions());
+        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_mastercard');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $paymentMethods = $user->paymentMethods();

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
-use Laravel\Cashier\Cashier;
 use Laravel\Cashier\PaymentMethod;
 use Stripe\SetupIntent as StripeSetupIntent;
 
@@ -36,7 +35,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_add_default_sepa_payment_method');
         $user->createAsStripeCustomer();
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->create([
+        $paymentMethod = self::stripe()->paymentMethods->create([
             'type' => 'sepa_debit',
             'billing_details' => [
                 'name' => 'John Doe',
@@ -121,10 +120,10 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_retrieve_all_payment_methods');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
+        $paymentMethod = self::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_mastercard');
+        $paymentMethod = self::stripe()->paymentMethods->retrieve('pm_card_mastercard');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $paymentMethods = $user->paymentMethods();
@@ -139,7 +138,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_can_sync_the_payment_method_from_stripe');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
+        $paymentMethod = self::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $customer->invoice_settings = ['default_payment_method' => $paymentMethod->id];
@@ -162,10 +161,10 @@ class PaymentMethodsTest extends FeatureTestCase
         $user = $this->createCustomer('we_delete_all_payment_methods');
         $customer = $user->createAsStripeCustomer();
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_visa');
+        $paymentMethod = self::stripe()->paymentMethods->retrieve('pm_card_visa');
         $paymentMethod->attach(['customer' => $customer->id]);
 
-        $paymentMethod = Cashier::stripe()->paymentMethods->retrieve('pm_card_mastercard');
+        $paymentMethod = self::stripe()->paymentMethods->retrieve('pm_card_mastercard');
         $paymentMethod->attach(['customer' => $customer->id]);
 
         $paymentMethods = $user->paymentMethods();

--- a/tests/Feature/PendingUpdatesTest.php
+++ b/tests/Feature/PendingUpdatesTest.php
@@ -47,6 +47,7 @@ class PendingUpdatesTest extends FeatureTestCase
         ])->id;
 
         static::$otherPriceId = self::stripe()->prices->create([
+            'product' => static::$productId,
             'nickname' => 'Monthly $10 Other',
             'currency' => 'USD',
             'recurring' => [

--- a/tests/Feature/PendingUpdatesTest.php
+++ b/tests/Feature/PendingUpdatesTest.php
@@ -2,10 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
-use Laravel\Cashier\Exceptions\IncompletePayment;
 use Stripe\Exception\CardException as StripeCardException;
-use Stripe\Price;
-use Stripe\Product;
 
 class PendingUpdatesTest extends FeatureTestCase
 {
@@ -33,14 +30,13 @@ class PendingUpdatesTest extends FeatureTestCase
     {
         parent::setUpBeforeClass();
 
-        static::$productId = Product::create([
-            'id' => static::$productId,
+        static::$productId = self::stripe()->products->create([
             'name' => 'Laravel Cashier Test Product',
             'type' => 'service',
         ])->id;
 
-        static::$priceId = Price::create([
-            'id' => static::$priceId,
+        static::$priceId = self::stripe()->prices->create([
+            'product' => static::$productId,
             'nickname' => 'Monthly $10',
             'currency' => 'USD',
             'recurring' => [
@@ -48,11 +44,9 @@ class PendingUpdatesTest extends FeatureTestCase
             ],
             'billing_scheme' => 'per_unit',
             'unit_amount' => 1000,
-            'product' => static::$productId,
         ])->id;
 
-        static::$otherPriceId = Price::create([
-            'id' => static::$otherPriceId,
+        static::$otherPriceId = self::stripe()->prices->create([
             'nickname' => 'Monthly $10 Other',
             'currency' => 'USD',
             'recurring' => [
@@ -60,11 +54,10 @@ class PendingUpdatesTest extends FeatureTestCase
             ],
             'billing_scheme' => 'per_unit',
             'unit_amount' => 1000,
-            'product' => static::$productId,
         ])->id;
 
-        static::$premiumPriceId = Price::create([
-            'id' => static::$premiumPriceId,
+        static::$premiumPriceId = self::stripe()->prices->create([
+            'product' => static::$productId,
             'nickname' => 'Monthly $20 Premium',
             'currency' => 'USD',
             'recurring' => [
@@ -72,15 +65,7 @@ class PendingUpdatesTest extends FeatureTestCase
             ],
             'billing_scheme' => 'per_unit',
             'unit_amount' => 2000,
-            'product' => static::$productId,
         ])->id;
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        parent::tearDownAfterClass();
-
-        static::deleteStripeResource(new Product(static::$productId));
     }
 
     public function test_subscription_can_error_if_incomplete()

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -14,6 +14,8 @@ class User extends Model
 
     public $priceTaxRates = [];
 
+    protected $guarded = [];
+
     /**
      * Get the tax rates to apply to the subscription.
      *


### PR DESCRIPTION
This PR refactors the way API requests to Stripe are made by implementing their new recommended way of using the `StripeClient` object. There are a couple of advantages to this:

- `StripeClient` more explicitly throws exceptions when you send malformed payloads instead of failing silently like before
- Simplifies things. No more passing extra options to each API request.
- We stay up to date with Stripe's recommended way of using the SDK

The upgrade path for existing users should be easy. No public API was changed. Only if you were overwriting the `stripeOptions` method you'll need to overwrite the `stripe` method now instead (which I suspect almost no-one is doing). 

Closes https://github.com/laravel/cashier-stripe/issues/939