### PR TITLE
Retrieve all type of payment methods

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -61,7 +61,7 @@ trait ManagesPaymentMethods
 
         // "type" is temporarily required by Stripe...
         $paymentMethods = StripePaymentMethod::all(
-            ['customer' => $this->stripe_id, 'type' => 'card'] + $parameters,
+            array_merge(['customer' => $this->stripe_id, 'type' => 'card'], $parameters),
             $this->stripeOptions()
         );
 


### PR DESCRIPTION
Hi,
The default parameters can now be overridden with this fix.
In my purpose, I would like to retrieve any kind of payment type (in my case, 'sepa_debit') by defining it in the paramaters.
Thanks for your time

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
