### PR TITLE
[13.x] Fixed false positive test

### DIFF
--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -522,10 +522,10 @@ class SubscriptionsTest extends FeatureTestCase
         $user = $this->createCustomer('user_with_subscription_can_return_generic_trial_end_date');
         $user->trial_ends_at = $tomorrow = Carbon::tomorrow();
 
-        $user->newSubscription('main', static::$priceId)
+        $user->newSubscription('default', static::$priceId)
             ->create('pm_card_visa');
 
-        $subscription = $user->subscription('main');
+        $subscription = $user->subscription('default');
 
         $this->assertTrue($user->onGenericTrial());
         $this->assertTrue($user->onTrial());


### PR DESCRIPTION
While implementing #1129 in laravel/cashier-paddle I noticed the test was giving a false positive.

When removing the added code in `ManagesSubscriptions` the test still worked fine.

This is because the `name` parameter of `trialEndsAt` defaults to `default`.
The test however was using `main` as the subscription name.

This is fixed by changing the subscription name to `default` as well.