### PR TITLE
[13.x] Revert breaking change to payment controller

### DIFF
--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -35,6 +35,7 @@ class PaymentController extends Controller
         return view('cashier::payment', [
             'stripeKey' => config('cashier.key'),
             'amount' => $payment->amount(),
+            'payment' => $payment,
             'paymentIntent' => Arr::only($payment->asStripePaymentIntent()->toArray(), [
                 'id', 'status', 'payment_method_types', 'client_secret',
             ]),


### PR DESCRIPTION
Reverts a small change by https://github.com/laravel/cashier-stripe/pull/1120. This will allow people who have already exported the `payment.blade.php` file to have a seamless transition. 