### PR TITLE
[13.x] Extract coupon functionality to trait

### DIFF
--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+trait AllowsCoupons
+{
+    /**
+     * The coupon ID being applied.
+     *
+     * @var string|null
+     */
+    protected $couponId;
+
+    /**
+     * The promotion code ID being applied.
+     *
+     * @var string|null
+     */
+    protected $promotionCodeId;
+
+    /**
+     * Determines if user redeemable promotion codes are available in Stripe Checkout.
+     *
+     * @var bool
+     */
+    protected $allowPromotionCodes = false;
+
+    /**
+     * The coupon ID to be applied.
+     *
+     * @param  string  $couponId
+     * @return $this
+     */
+    public function withCoupon($couponId)
+    {
+        $this->couponId = $couponId;
+
+        return $this;
+    }
+
+    /**
+     * The promotion code ID to apply.
+     *
+     * @param  string  $promotionCodeId
+     * @return $this
+     */
+    public function withPromotionCode($promotionCodeId)
+    {
+        $this->promotionCodeId = $promotionCodeId;
+
+        return $this;
+    }
+
+    /**
+     * Enables user redeemable promotion codes for a Stripe Checkout session.
+     *
+     * @return $this
+     */
+    public function allowPromotionCodes()
+    {
+        $this->allowPromotionCodes = true;
+
+        return $this;
+    }
+
+    /**
+     * Return the discounts for a Stripe Checkout session.
+     *
+     * @return array[]|null
+     */
+    protected function checkoutDiscounts()
+    {
+        if ($this->couponId) {
+            return [['coupon' => $this->couponId]];
+        }
+
+        if ($this->promotionCodeId) {
+            return [['promotion_code' => $this->promotionCodeId]];
+        }
+    }
+}

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -8,12 +8,7 @@ use Laravel\Cashier\Payment;
 
 trait PerformsCharges
 {
-    /**
-     * Determines if user redeemable promotion codes are available in Stripe Checkout.
-     *
-     * @var bool
-     */
-    protected $allowPromotionCodes;
+    use AllowsCoupons;
 
     /**
      * Make a "one off" charge on the customer for the given amount.
@@ -76,6 +71,7 @@ trait PerformsCharges
     {
         $payload = array_filter([
             'allow_promotion_codes' => $this->allowPromotionCodes,
+            'discounts' => $this->checkoutDiscounts(),
             'line_items' => Collection::make((array) $items)->map(function ($item, $key) {
                 if (is_string($key)) {
                     return ['price' => $key, 'quantity' => $item];
@@ -114,17 +110,5 @@ trait PerformsCharges
             ],
             'quantity' => $quantity,
         ]], $sessionOptions, $customerOptions);
-    }
-
-    /**
-     * Enables user redeemable promotion codes.
-     *
-     * @return $this
-     */
-    public function allowPromotionCodes()
-    {
-        $this->allowPromotionCodes = true;
-
-        return $this;
     }
 }

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -36,6 +36,34 @@ class CheckoutTest extends FeatureTestCase
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
 
+    public function test_customers_can_start_a_product_checkout_session_with_a_coupon_applied()
+    {
+        $user = $this->createCustomer('customers_can_start_a_product_checkout_session_with_a_coupon_applied');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $coupon = self::stripe()->promotionCodes->create([
+            'duration' => 'repeating',
+            'amount_off' => 500,
+            'duration_in_months' => 3,
+            'currency' => 'USD',
+        ]);
+
+        $checkout = $user->withCoupon($coupon->id)
+            ->checkout($shirtPrice->id, [
+                'success_url' => 'http://example.com',
+                'cancel_url' => 'http://example.com',
+            ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
+
     public function test_customers_can_start_a_one_off_charge_checkout_session()
     {
         $user = $this->createCustomer('customers_can_start_a_one_off_charge_checkout_session');


### PR DESCRIPTION
One more PR for v13. This PR extracts coupon functionality to an `AllowsCoupons` trait. It consolidates code over two places where we were using it and keeps classes like the `SubscriptionBuilder` tidy. This PR also additionally allows for `withCoupon` to be used on a customer before creating a Stripe Checkout session:

```php
$checkout = $user->withCoupon($coupon->id)
    ->checkout($shirtPrice->id, [
        'success_url' => 'http://example.com',
        'cancel_url' => 'http://example.com',
    ]);
```

There's a minor breaking change in the sense that the `$coupon` and `$promotionCode` properties have been renamed to `$couponId` & `$promotionCodeId`. There's two reasons for that:

1. I wanted to prevent conflicting with a `coupon` column on the billable model
2. I wanted to more explicitly indicated that these should be ID's that you're passing, not the codes themselves (although with a coupon the code is the ID)

This might be worth mentioning in the upgrade guide but I doubt much people are directly using the properties. I've already checked Spark Stripe and couldn't find any usages.

Closes https://github.com/laravel/cashier-stripe/issues/1107