### PR TITLE
[13.x] Implement `stripe_product` column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Multiple discounts on receipts ([#1147](https://github.com/laravel/cashier-stripe/pull/1147))
 - Preview upcoming invoice ([#1146](https://github.com/laravel/cashier-stripe/pull/1146))
 - Add new metered price methods ([#1177](https://github.com/laravel/cashier-stripe/pull/1177))
+- Allow customers to be synced with Stripe ([#1178](https://github.com/laravel/cashier-stripe/pull/1178), [#1183](https://github.com/laravel/cashier-stripe/pull/1183))
 
 ### Changed
 - Rename plans to prices ([#1166](https://github.com/laravel/cashier-stripe/pull/1166))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Preview upcoming invoice ([#1146](https://github.com/laravel/cashier-stripe/pull/1146))
 - Add new metered price methods ([#1177](https://github.com/laravel/cashier-stripe/pull/1177))
 - Allow customers to be synced with Stripe ([#1178](https://github.com/laravel/cashier-stripe/pull/1178), [#1183](https://github.com/laravel/cashier-stripe/pull/1183))
+- Add `stripe_product` column to `subscriptions_items` table ([#1185](https://github.com/laravel/cashier-stripe/pull/1185))
 
 ### Changed
 - Rename plans to prices ([#1166](https://github.com/laravel/cashier-stripe/pull/1166))

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -198,6 +198,17 @@ PR: https://github.com/laravel/cashier-stripe/pull/1120
 
 The hosted payment page for handling payment method failures has been improved to provide support for additional payment methods. No changes to your application are required if you have not published the `payment.blade.php` template. However, all translation support has been removed. If you were relying on this functionality you should publish the view and re-add the appropriate calls to Laravel's translation services.
 
+### Stripe Product Support
+
+Cashier Stripe v13 comes with support for checking Stripe Product identifiers. To provide support for this feature, a new `stripe_product` column should be added to the `stripe_subscriptions` table:
+
+```php
+Schema::table('subscription_items', function (Blueprint $table) {
+    $table->string('stripe_product')->nullable()->after('stripe_id');
+});
+```
+
+
 ## Upgrading To 12.8 From 12.7
 
 ### Metered Billing

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -210,8 +210,7 @@ Schema::table('subscription_items', function (Blueprint $table) {
 });
 ```
 
-If you'd like to make use of the new `onProduct` & `subscribedToProduct` methods on the billable you should make sure the records in the `subscription_items` have their `stripe_product` column filled in with the correct Product ID from Stripe.
-
+If you'd like to make use of the new `onProduct` & `subscribedToProduct` methods on your billable model, you should ensure the records in the `subscription_items` have their `stripe_product` column filled with the correct Product ID from Stripe.
 
 ## Upgrading To 12.8 From 12.7
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -200,6 +200,8 @@ The hosted payment page for handling payment method failures has been improved t
 
 ### Stripe Product Support
 
+PR: https://github.com/laravel/cashier-stripe/pull/1185
+
 Cashier Stripe v13 comes with support for checking Stripe Product identifiers. To provide support for this feature, a new `stripe_product` column should be added to the `stripe_subscriptions` table:
 
 ```php
@@ -207,6 +209,8 @@ Schema::table('subscription_items', function (Blueprint $table) {
     $table->string('stripe_product')->nullable()->after('stripe_id');
 });
 ```
+
+If you'd like to make use of the new `onProduct` & `subscribedToProduct` methods on the billable you should make sure the records in the `subscription_items` have their `stripe_product` column filled in with the correct Product ID from Stripe.
 
 
 ## Upgrading To 12.8 From 12.7

--- a/database/factories/SubscriptionItemFactory.php
+++ b/database/factories/SubscriptionItemFactory.php
@@ -26,6 +26,7 @@ class SubscriptionItemFactory extends Factory
         return [
             'subscription_id' => Subscription::factory(),
             'stripe_id' => 'si_'.Str::random(40),
+            'stripe_product' => 'prod_'.Str::random(40),
             'stripe_price' => 'price_'.Str::random(40),
             'quantity' => null,
         ];

--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -17,6 +17,7 @@ class CreateSubscriptionItemsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('subscription_id');
             $table->string('stripe_id')->index();
+            $table->string('stripe_product');
             $table->string('stripe_price');
             $table->integer('quantity')->nullable();
             $table->timestamps();

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -126,6 +126,30 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Determine if the Stripe model is actively subscribed to one of the given products.
+     *
+     * @param  string|string[]  $products
+     * @param  string  $name
+     * @return bool
+     */
+    public function subscribedToProduct($products, $name = 'default')
+    {
+        $subscription = $this->subscription($name);
+
+        if (! $subscription || ! $subscription->valid()) {
+            return false;
+        }
+
+        foreach ((array) $products as $product) {
+            if ($subscription->hasProduct($product)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the Stripe model is actively subscribed to one of the given prices.
      *
      * @param  string|string[]  $prices
@@ -147,6 +171,19 @@ trait ManagesSubscriptions
         }
 
         return false;
+    }
+
+    /**
+     * Determine if the customer has a valid subscription on the given product.
+     *
+     * @param  string  $price
+     * @return bool
+     */
+    public function onProduct($price)
+    {
+        return ! is_null($this->subscriptions->first(function (Subscription $subscription) use ($price) {
+            return $subscription->valid() && $subscription->hasProduct($price);
+        }));
     }
 
     /**

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -90,6 +90,7 @@ class WebhookController extends Controller
                 foreach ($data['items']['data'] as $item) {
                     $subscription->items()->create([
                         'stripe_id' => $item['id'],
+                        'stripe_product' => $item['price']['product'],
                         'stripe_price' => $item['price']['id'],
                         'quantity' => $item['quantity'] ?? null,
                     ]);
@@ -183,6 +184,7 @@ class WebhookController extends Controller
                         $subscription->items()->updateOrCreate([
                             'stripe_id' => $item['id'],
                         ], [
+                            'stripe_product' => $item['price']['product'],
                             'stripe_price' => $item['price']['id'],
                             'quantity' => $item['quantity'] ?? null,
                         ]);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -121,6 +121,19 @@ class Subscription extends Model
     }
 
     /**
+     * Determine if the subscription has a specific product.
+     *
+     * @param  string  $product
+     * @return bool
+     */
+    public function hasProduct($product)
+    {
+        return $this->items->contains(function (SubscriptionItem $item) use ($product) {
+            return $item->stripe_product === $product;
+        });
+    }
+
+    /**
      * Determine if the subscription has a specific price.
      *
      * @param  string  $price

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -675,6 +675,7 @@ class Subscription extends Model
             $this->items()->updateOrCreate([
                 'stripe_id' => $item->id,
             ], [
+                'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity,
             ]);
@@ -816,7 +817,7 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::duplicatePrice($this, $price);
         }
 
-        $item = $this->owner->stripe()->subscriptionItems->create(array_merge([
+        $stripeSubscriptionItem = $this->owner->stripe()->subscriptionItems->create(array_merge([
             'subscription' => $this->stripe_id,
             'price' => $price,
             'quantity' => $quantity,
@@ -826,8 +827,9 @@ class Subscription extends Model
         ], $options));
 
         $this->items()->create([
-            'stripe_id' => $item->id,
-            'stripe_price' => $price,
+            'stripe_id' => $stripeSubscriptionItem->id,
+            'stripe_product' => $stripeSubscriptionItem->price->product,
+            'stripe_price' => $stripeSubscriptionItem->price->id,
             'quantity' => $quantity,
         ]);
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -286,6 +286,7 @@ class SubscriptionBuilder
         foreach ($stripeSubscription->items as $item) {
             $subscription->items()->create([
                 'stripe_id' => $item->id,
+                'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity,
             ]);

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -151,7 +151,8 @@ class SubscriptionItem extends Model
         ], $options));
 
         $this->fill([
-            'stripe_price' => $price,
+            'stripe_product' => $stripeSubscriptionItem->price->product,
+            'stripe_price' => $stripeSubscriptionItem->price->id,
             'quantity' => $stripeSubscriptionItem->quantity,
         ])->save();
 

--- a/tests/Feature/MultipriceSubscriptionsTest.php
+++ b/tests/Feature/MultipriceSubscriptionsTest.php
@@ -98,6 +98,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
             ->create('pm_card_visa');
 
         $this->assertTrue($user->subscribed('main', self::$priceId));
+        $this->assertTrue($user->onProduct(self::$productId));
         $this->assertTrue($user->onPrice(self::$priceId));
 
         $item = $subscription->findItemOrFail(self::$priceId);
@@ -122,6 +123,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
 
         $subscription->addPrice(self::$otherPriceId, 5);
 
+        $this->assertTrue($user->onProduct(self::$productId));
         $this->assertTrue($user->onPrice(self::$priceId));
         $this->assertFalse($user->onPrice(self::$premiumPriceId));
 

--- a/tests/Feature/MultipriceSubscriptionsTest.php
+++ b/tests/Feature/MultipriceSubscriptionsTest.php
@@ -331,6 +331,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
 
         $subscription->items()->create([
             'stripe_id' => 'it_foo',
+            'stripe_product' => self::$productId,
             'stripe_price' => self::$priceId,
             'quantity' => 1,
         ]);
@@ -354,6 +355,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
 
         $subscription->items()->create([
             'stripe_id' => 'it_foo',
+            'stripe_product' => self::$productId,
             'stripe_price' => self::$otherPriceId,
             'quantity' => 1,
         ]);

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -116,6 +116,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame($metadata, $subscription->asStripeSubscription()->metadata->toArray());
 
         $this->assertTrue($user->subscribed('main'));
+        $this->assertTrue($user->subscribedToProduct(static::$productId, 'main'));
         $this->assertTrue($user->subscribedToPrice(static::$priceId, 'main'));
         $this->assertFalse($user->subscribedToPrice(static::$priceId, 'something'));
         $this->assertFalse($user->subscribedToPrice(static::$otherPriceId, 'main'));

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -57,7 +57,7 @@ class WebhooksTest extends FeatureTestCase
                     'items' => [
                         'data' => [[
                             'id' => 'bar',
-                            'price' => ['id' => 'price_foo'],
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
                             'quantity' => 10,
                         ]],
                     ],
@@ -76,6 +76,7 @@ class WebhooksTest extends FeatureTestCase
 
         $this->assertDatabaseHas('subscription_items', [
             'stripe_id' => 'bar',
+            'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_foo',
             'quantity' => 10,
         ]);
@@ -94,6 +95,7 @@ class WebhooksTest extends FeatureTestCase
 
         $item = $subscription->items()->create([
             'stripe_id' => 'it_foo',
+            'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_bar',
             'quantity' => 1,
         ]);
@@ -109,7 +111,7 @@ class WebhooksTest extends FeatureTestCase
                     'items' => [
                         'data' => [[
                             'id' => 'bar',
-                            'price' => ['id' => 'price_foo'],
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
                             'quantity' => 5,
                         ]],
                     ],
@@ -127,6 +129,7 @@ class WebhooksTest extends FeatureTestCase
         $this->assertDatabaseHas('subscription_items', [
             'subscription_id' => $subscription->id,
             'stripe_id' => 'bar',
+            'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_foo',
             'quantity' => 5,
         ]);
@@ -150,6 +153,7 @@ class WebhooksTest extends FeatureTestCase
 
         $item = $subscription->items()->create([
             'stripe_id' => 'it_foo',
+            'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_bar',
             'quantity' => 1,
         ]);
@@ -166,7 +170,7 @@ class WebhooksTest extends FeatureTestCase
                     'items' => [
                         'data' => [[
                             'id' => 'bar',
-                            'price' => ['id' => 'price_foo'],
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
                             'quantity' => 5,
                         ]],
                     ],
@@ -185,6 +189,7 @@ class WebhooksTest extends FeatureTestCase
         $this->assertDatabaseHas('subscription_items', [
             'subscription_id' => $subscription->id,
             'stripe_id' => 'bar',
+            'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_foo',
             'quantity' => 5,
         ]);
@@ -212,7 +217,7 @@ class WebhooksTest extends FeatureTestCase
                     'items' => [
                         'data' => [[
                             'id' => $subscription->items()->first()->stripe_id,
-                            'price' => ['id' => static::$priceId],
+                            'price' => ['id' => static::$priceId, 'product' => static::$productId],
                             'quantity' => 1,
                         ]],
                     ],


### PR DESCRIPTION
Implements https://github.com/laravel/cashier-stripe/issues/1179

This adds a new `stripe_product`  column to the `subscription_items` table. This will open the door for new API's in Cashier Stripe like the `onProduct` and `subscribedToProduct` methods on a billable. There's potentially more extra methods to be added later on but these should provide support for the most common use cases already.