### PR TITLE
[14.x] Drop PHP 7.3 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
         laravel: [^8.0]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/laravel/cashier/compare/v13.0.0...13.x)
 
+### Removed
+- Drop PHP 7.3 support ([#1186](https://github.com/laravel/cashier-stripe/pull/1186))
+
 
 ## [v13.0.0 (2021-06-08)](https://github.com/laravel/cashier/compare/v12.14.1...v13.0.0)
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "ext-json": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/contracts": "^8.0",


### PR DESCRIPTION
Dropping this early on in the 14.x development cycle will reduce API calls to Stripe and avoid hitting their rate limiting more.