### PR TITLE
[13.x] Implement support for Stripe Tax

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Laravel\Cashier\Concerns\CalculatesTaxes;
 use Laravel\Cashier\Concerns\ManagesCustomer;
 use Laravel\Cashier\Concerns\ManagesInvoices;
 use Laravel\Cashier\Concerns\ManagesPaymentMethods;
@@ -10,6 +11,7 @@ use Laravel\Cashier\Concerns\PerformsCharges;
 
 trait Billable
 {
+    use CalculatesTaxes;
     use ManagesCustomer;
     use ManagesInvoices;
     use ManagesPaymentMethods;

--- a/src/Concerns/CalculatesTaxes.php
+++ b/src/Concerns/CalculatesTaxes.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+trait CalculatesTaxes
+{
+    /**
+     * Automatically calculate tax for the new subscription.
+     *
+     * @var bool
+     */
+    protected $automaticTax = false;
+
+    /**
+     * The IP address of the customer used to determine tax location.
+     *
+     * @var string|null
+     */
+    protected $customerIPAddress;
+
+    /**
+     * A pre-collected billing address used to estimate tax rates when performing "one-off" charges.
+     *
+     * @var array
+     */
+    protected $estimationBillingAddress = [];
+
+    /**
+     * Allow taxes to be automatically calculated by Stripe.
+     *
+     * @return $this
+     */
+    public function withTax()
+    {
+        $this->automaticTax = true;
+
+        return $this;
+    }
+
+    /**
+     * Set the The IP address of the customer used to determine tax location.
+     *
+     * @return $this
+     */
+    public function withTaxIPAddress($ipAddress)
+    {
+        $this->customerIPAddress = $ipAddress;
+
+        return $this;
+    }
+
+    /**
+     * Set a pre-collected billing address used to estimate tax rates when performing "one-off" charges.
+     *
+     * @param  string  $country
+     * @param  string|null  $postalCode
+     * @param  string|null  $state
+     * @return $this
+     */
+    public function withTaxAddress($country, $postalCode = null, $state = null)
+    {
+        $this->estimationBillingAddress = array_filter([
+            'country' => $country,
+            'postal_code' => $postalCode,
+            'state' => $state,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Return the payload for the automatic tax calculation.
+     *
+     * @return array|null
+     */
+    protected function automaticTaxPayload()
+    {
+        return array_filter([
+            'customer_ip_address' => $this->customerIPAddress,
+            'enabled' => $this->automaticTax,
+            'estimation_billing_address' => $this->estimationBillingAddress,
+        ]);
+    }
+}

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -71,7 +71,10 @@ trait ManagesInvoices
     {
         $this->assertCustomerExists();
 
-        $parameters = array_merge($options, ['customer' => $this->stripe_id]);
+        $parameters = array_merge([
+            'automatic_tax' => $this->automaticTaxPayload(),
+            'customer' => $this->stripe_id,
+        ], $options);
 
         try {
             /** @var \Stripe\Invoice $invoice */
@@ -110,10 +113,13 @@ trait ManagesInvoices
             return;
         }
 
+        $parameters = array_merge([
+            'automatic_tax' => $this->automaticTaxPayload(),
+            'customer' => $this->stripe_id,
+        ], $options);
+
         try {
-            $stripeInvoice = $this->stripe()->invoices->upcoming(array_merge([
-                'customer' => $this->stripe_id,
-            ], $options));
+            $stripeInvoice = $this->stripe()->invoices->upcoming($parameters);
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -23,6 +23,7 @@ trait PerformsCharges
     public function charge($amount, $paymentMethod, array $options = [])
     {
         $options = array_merge([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'confirmation_method' => 'automatic',
             'confirm' => true,
             'currency' => $this->preferredCurrency(),
@@ -71,6 +72,7 @@ trait PerformsCharges
     {
         $payload = array_filter([
             'allow_promotion_codes' => $this->allowPromotionCodes,
+            'automatic_tax' => $this->automaticTaxPayload(),
             'discounts' => $this->checkoutDiscounts(),
             'line_items' => Collection::make((array) $items)->map(function ($item, $key) {
                 if (is_string($key)) {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Laravel\Cashier\Concerns\CalculatesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
@@ -22,6 +23,7 @@ use Stripe\Subscription as StripeSubscription;
  */
 class Subscription extends Model
 {
+    use CalculatesTaxes;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
@@ -789,6 +791,7 @@ class Subscription extends Model
     protected function getSwapOptions(Collection $items, array $options = [])
     {
         $payload = [
+            'automatic_tax' => $this->automaticTaxPayload(),
             'items' => $items->values()->all(),
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
@@ -1128,6 +1131,7 @@ class Subscription extends Model
     public function upcomingInvoice(array $options = [])
     {
         return $this->owner->upcomingInvoice(array_merge([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'subscription' => $this->stripe_id,
         ], $options));
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
+use Laravel\Cashier\Concerns\CalculatesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Stripe\Subscription as StripeSubscription;
@@ -16,6 +17,7 @@ use Stripe\Subscription as StripeSubscription;
 class SubscriptionBuilder
 {
     use AllowsCoupons;
+    use CalculatesTaxes;
     use InteractsWithPaymentBehavior;
     use Prorates;
 
@@ -361,6 +363,7 @@ class SubscriptionBuilder
     protected function buildPayload()
     {
         $payload = array_filter([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'billing_cycle_anchor' => $this->billingCycleAnchor,
             'coupon' => $this->couponId,
             'expand' => ['latest_invoice.payment_intent'],


### PR DESCRIPTION
This implements support for Stripe Tax into Cashier Stripe. 

```php
$subscription = Auth::user()->newSubscription('default', 'price_monthly')
    ->withTax()
    ->create('pm_card_visa');
```

Checkout:

```php
$checkout = Auth::user()
    ->withTax()
    ->checkout('price_tshirt');
```

Invoice:

```php
$invoice = Auth::user()
    ->withTax()
    ->invoiceFor('price_tshirt', 2000);
```