### PR TITLE
[13.x] Collect Tax IDs in Checkout

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier;
 
-use Laravel\Cashier\Concerns\CalculatesTaxes;
+use Laravel\Cashier\Concerns\HandlesTaxes;
 use Laravel\Cashier\Concerns\ManagesCustomer;
 use Laravel\Cashier\Concerns\ManagesInvoices;
 use Laravel\Cashier\Concerns\ManagesPaymentMethods;
@@ -11,7 +11,7 @@ use Laravel\Cashier\Concerns\PerformsCharges;
 
 trait Billable
 {
-    use CalculatesTaxes;
+    use HandlesTaxes;
     use ManagesCustomer;
     use ManagesInvoices;
     use ManagesPaymentMethods;

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -30,7 +30,7 @@ trait HandlesTaxes
      *
      * @var bool
      */
-    protected $taxIdCollection = false;
+    protected $collectTaxIds = false;
 
     /**
      * Allow taxes to be automatically calculated by Stripe.
@@ -96,7 +96,7 @@ trait HandlesTaxes
      */
     public function collectTaxIds()
     {
-        $this->taxIdCollection = true;
+        $this->collectTaxIds = true;
 
         return $this;
     }

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier\Concerns;
 
-trait CalculatesTaxes
+trait HandlesTaxes
 {
     /**
      * Indicates if Cashier should automatically calculate tax for the new subscription.
@@ -24,6 +24,13 @@ trait CalculatesTaxes
      * @var array
      */
     protected $estimationBillingAddress = [];
+
+    /**
+     * Indicates if Tax IDs should be collected during a Stripe Checkout session.
+     *
+     * @var bool
+     */
+    protected $taxIdCollection = false;
 
     /**
      * Allow taxes to be automatically calculated by Stripe.
@@ -80,5 +87,17 @@ trait CalculatesTaxes
             'enabled' => $this->automaticTax,
             'estimation_billing_address' => $this->estimationBillingAddress,
         ]);
+    }
+
+    /**
+     * Indicate that Tax IDs should be collected during a Stripe Checkout session.
+     *
+     * @return $this
+     */
+    public function collectTaxIds()
+    {
+        $this->taxIdCollection = true;
+
+        return $this;
     }
 }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -85,6 +85,7 @@ trait PerformsCharges
 
                 return $item;
             })->values()->all(),
+            'tax_id_collection' => $this->taxIdCollection,
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -85,7 +85,7 @@ trait PerformsCharges
 
                 return $item;
             })->values()->all(),
-            'tax_id_collection' => $this->taxIdCollection,
+            'tax_id_collection' => $this->collectsTaxIds,
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
-use Laravel\Cashier\Concerns\CalculatesTaxes;
+use Laravel\Cashier\Concerns\HandlesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
@@ -23,7 +23,7 @@ use Stripe\Subscription as StripeSubscription;
  */
 class Subscription extends Model
 {
-    use CalculatesTaxes;
+    use HandlesTaxes;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
-use Laravel\Cashier\Concerns\CalculatesTaxes;
+use Laravel\Cashier\Concerns\HandlesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Stripe\Subscription as StripeSubscription;
@@ -17,7 +17,7 @@ use Stripe\Subscription as StripeSubscription;
 class SubscriptionBuilder
 {
     use AllowsCoupons;
-    use CalculatesTaxes;
+    use HandlesTaxes;
     use InteractsWithPaymentBehavior;
     use Prorates;
 
@@ -332,6 +332,7 @@ class SubscriptionBuilder
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ]),
+            'tax_id_collection' => $this->taxIdCollection,
         ]);
 
         return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -332,7 +332,7 @@ class SubscriptionBuilder
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ]),
-            'tax_id_collection' => $this->taxIdCollection,
+            'tax_id_collection' => $this->collectTaxIds,
         ]);
 
         return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);


### PR DESCRIPTION
This allows a Stripe Checkout session to collect a customer's Tax ID which can be used to calculate taxes, etc.

```php
$checkout = $user->collectTaxIds()->checkout('price_tshirt');
```

More info: https://stripe.com/docs/tax/checkout/tax-ids

Additionally, I've renamed the concerns trait to handle all tax things. It's unreleased yet so not a breaking change.