### PR TITLE
IncompletePayment exception: Fix typo in message for `requiresConfirm…

### DIFF
--- a/src/Exceptions/IncompletePayment.php
+++ b/src/Exceptions/IncompletePayment.php
@@ -69,7 +69,7 @@ class IncompletePayment extends Exception
     {
         return new static(
             $payment,
-            'The payment attempt failed because additional it needs to be confirmed before it can be completed.'
+            'The payment attempt failed because it needs to be confirmed before it can be completed.'
         );
     }
 }


### PR DESCRIPTION
The message had an unnecessary `additional` word that made the phrase potentially confusing to end users.