### PR TITLE
[13.x] Also collect Tax IDs when enabling Stripe Tax

### DIFF
--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -41,6 +41,8 @@ trait HandlesTaxes
     {
         $this->automaticTax = true;
 
+        $this->collectTaxIds();
+
         return $this;
     }
 

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -85,7 +85,7 @@ trait PerformsCharges
 
                 return $item;
             })->values()->all(),
-            'tax_id_collection' => $this->collectsTaxIds,
+            'tax_id_collection' => $this->collectTaxIds,
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);


### PR DESCRIPTION
I figured you'd always want to collect Tax ID's when Stripe Tax is enabled so properly calculate the taxes.

Also fixes an incorrect property name.