### PR TITLE
[13.x] Implement new calculateTaxes call

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -74,19 +74,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Taxes
-    |--------------------------------------------------------------------------
-    |
-    | This setting allows you to define if you automatically want to calculate
-    | taxes for all your new invoices like when starting new subscriptions,
-    | swapping plans, new checkout sessions and also for one-off charges.
-    |
-    */
-
-    'taxes' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Payment Confirmation Notification
     |--------------------------------------------------------------------------
     |

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -74,6 +74,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Taxes
+    |--------------------------------------------------------------------------
+    |
+    | This setting allows you to define if you automatically want to calculate
+    | taxes for all your new invoices like when starting new subscriptions,
+    | swapping plans, new checkout sessions and also for one-off charges.
+    |
+    */
+
+    'taxes' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Payment Confirmation Notification
     |--------------------------------------------------------------------------
     |

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -55,7 +55,7 @@ class Cashier
     public static $deactivatePastDue = true;
 
     /**
-     * Indicates if Cashier will automatically calculate taxes using Strip Tax.
+     * Indicates if Cashier will automatically calculate taxes using Stripe Tax.
      *
      * @var bool
      */

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -55,6 +55,13 @@ class Cashier
     public static $deactivatePastDue = true;
 
     /**
+     * Indicates if Cashier will automatically calculate taxes using Strip Tax.
+     *
+     * @var bool
+     */
+    public static $calculatesTaxes = false;
+
+    /**
      * The default customer model class name.
      *
      * @var string
@@ -169,6 +176,18 @@ class Cashier
     public static function keepPastDueSubscriptionsActive()
     {
         static::$deactivatePastDue = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Cashier to automatically calculate taxes using Stripe Tax.
+     *
+     * @return static
+     */
+    public static function calculateTaxes()
+    {
+        static::$calculatesTaxes = true;
 
         return new static;
     }

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -2,13 +2,15 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Laravel\Cashier\Cashier;
+
 trait HandlesTaxes
 {
     /**
      * Indicates if Cashier should automatically calculate tax for the new subscription.
      *
      * @var bool
-     * @deprecated Use the new cashier.taxes config setting instead.
+     * @deprecated Use the new Cashier::calculateTaxes() method instead.
      */
     protected $automaticTax = false;
 
@@ -37,7 +39,7 @@ trait HandlesTaxes
      * Allow taxes to be automatically calculated by Stripe.
      *
      * @return $this
-     * @deprecated Use the new cashier.taxes config setting instead.
+     * @deprecated Use the new Cashier::calculateTaxes() method instead.
      */
     public function withTax()
     {
@@ -86,7 +88,7 @@ trait HandlesTaxes
     {
         return array_filter([
             'customer_ip_address' => $this->customerIpAddress,
-            'enabled' => $this->automaticTax ?: config('cashier.taxes'),
+            'enabled' => $this->automaticTax ?: Cashier::$calculatesTaxes,
             'estimation_billing_address' => $this->estimationBillingAddress,
         ]);
     }

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -8,11 +8,12 @@ trait HandlesTaxes
      * Indicates if Cashier should automatically calculate tax for the new subscription.
      *
      * @var bool
+     * @deprecated Use the new cashier.taxes config setting instead.
      */
     protected $automaticTax = false;
 
     /**
-     * The IP address of the customer used to determine tax location.
+     * The IP address of the customer used to determine the tax location.
      *
      * @var string|null
      */
@@ -36,6 +37,7 @@ trait HandlesTaxes
      * Allow taxes to be automatically calculated by Stripe.
      *
      * @return $this
+     * @deprecated Use the new cashier.taxes config setting instead.
      */
     public function withTax()
     {
@@ -45,7 +47,7 @@ trait HandlesTaxes
     }
 
     /**
-     * Set the The IP address of the customer used to determine tax location.
+     * Set the The IP address of the customer used to determine the tax location.
      *
      * @return $this
      */
@@ -84,7 +86,7 @@ trait HandlesTaxes
     {
         return array_filter([
             'customer_ip_address' => $this->customerIpAddress,
-            'enabled' => $this->automaticTax,
+            'enabled' => $this->automaticTax ?: config('cashier.taxes'),
             'estimation_billing_address' => $this->estimationBillingAddress,
         ]);
     }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -85,7 +85,7 @@ trait PerformsCharges
 
                 return $item;
             })->values()->all(),
-            'tax_id_collection' => $this->collectsTaxIds,
+            'tax_id_collection' => config('stripe.taxes') ?: $this->collectTaxIds,
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Concerns;
 
 use Illuminate\Support\Collection;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
 
@@ -83,7 +84,7 @@ trait PerformsCharges
 
                 return $item;
             })->values()->all(),
-            'tax_id_collection' => config('stripe.taxes') ?: $this->collectTaxIds,
+            'tax_id_collection' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
         ]);
 
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -23,7 +23,6 @@ trait PerformsCharges
     public function charge($amount, $paymentMethod, array $options = [])
     {
         $options = array_merge([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'confirmation_method' => 'automatic',
             'confirm' => true,
             'currency' => $this->preferredCurrency(),
@@ -63,7 +62,6 @@ trait PerformsCharges
      * Begin a new checkout session for existing prices.
      *
      * @param  array|string  $items
-     * @param  int  $quantity
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
      * @return \Laravel\Cashier\Checkout

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -494,6 +494,7 @@ class Subscription extends Model
         $this->guardAgainstMultiplePrices();
 
         $stripeSubscription = $this->updateStripeSubscription([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
             'quantity' => $quantity,
@@ -615,6 +616,7 @@ class Subscription extends Model
         }
 
         $this->updateStripeSubscription([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'trial_end' => 'now',
             'proration_behavior' => $this->prorateBehavior(),
         ]);
@@ -639,6 +641,7 @@ class Subscription extends Model
         }
 
         $this->updateStripeSubscription([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'trial_end' => $date->getTimestamp(),
             'proration_behavior' => $this->prorateBehavior(),
         ]);
@@ -954,6 +957,7 @@ class Subscription extends Model
     public function cancel()
     {
         $stripeSubscription = $this->updateStripeSubscription([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'cancel_at_period_end' => true,
         ]);
 
@@ -988,6 +992,7 @@ class Subscription extends Model
         }
 
         $stripeSubscription = $this->updateStripeSubscription([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'cancel_at' => $endsAt,
             'proration_behavior' => $this->prorateBehavior(),
         ]);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
-use Laravel\Cashier\Concerns\HandlesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
@@ -23,7 +22,6 @@ use Stripe\Subscription as StripeSubscription;
  */
 class Subscription extends Model
 {
-    use HandlesTaxes;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
@@ -494,7 +492,6 @@ class Subscription extends Model
         $this->guardAgainstMultiplePrices();
 
         $stripeSubscription = $this->updateStripeSubscription([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
             'quantity' => $quantity,
@@ -616,7 +613,6 @@ class Subscription extends Model
         }
 
         $this->updateStripeSubscription([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'trial_end' => 'now',
             'proration_behavior' => $this->prorateBehavior(),
         ]);
@@ -641,7 +637,6 @@ class Subscription extends Model
         }
 
         $this->updateStripeSubscription([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'trial_end' => $date->getTimestamp(),
             'proration_behavior' => $this->prorateBehavior(),
         ]);
@@ -794,7 +789,6 @@ class Subscription extends Model
     protected function getSwapOptions(Collection $items, array $options = [])
     {
         $payload = [
-            'automatic_tax' => $this->automaticTaxPayload(),
             'items' => $items->values()->all(),
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
@@ -957,7 +951,6 @@ class Subscription extends Model
     public function cancel()
     {
         $stripeSubscription = $this->updateStripeSubscription([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'cancel_at_period_end' => true,
         ]);
 
@@ -992,7 +985,6 @@ class Subscription extends Model
         }
 
         $stripeSubscription = $this->updateStripeSubscription([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'cancel_at' => $endsAt,
             'proration_behavior' => $this->prorateBehavior(),
         ]);
@@ -1137,7 +1129,6 @@ class Subscription extends Model
     public function upcomingInvoice(array $options = [])
     {
         return $this->owner->upcomingInvoice(array_merge([
-            'automatic_tax' => $this->automaticTaxPayload(),
             'subscription' => $this->stripe_id,
         ], $options));
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -333,7 +333,7 @@ class SubscriptionBuilder
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ]),
-            'tax_id_collection' => config('stripe.taxes') ?: $this->collectTaxIds,
+            'tax_id_collection' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
         ]);
 
         return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -323,6 +323,7 @@ class SubscriptionBuilder
         }
 
         $payload = array_filter([
+            'automatic_tax' => $this->automaticTaxPayload(),
             'mode' => 'subscription',
             'line_items' => Collection::make($this->items)->values()->all(),
             'allow_promotion_codes' => $this->allowPromotionCodes,
@@ -332,7 +333,7 @@ class SubscriptionBuilder
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ]),
-            'tax_id_collection' => $this->collectTaxIds,
+            'tax_id_collection' => config('stripe.taxes') ?: $this->collectTaxIds,
         ]);
 
         return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);


### PR DESCRIPTION
This implements a new `Cashier::calculateTaxes()` static method that'll allow you enable automatic tax calculation on all relevant Stripe calls. By default it follows Stripe's behavior and is set to `false`. Additionally, the previous `withTax` method is now deprecated as it is not needed anymore. You can now use your code as regularly without the need of using extra methods. This method call goes into the boot method of your `ApServiceProvider`.

Also, the `tax_id_collection` is now enabled by default when the calculation of taxes is enabled. This PR also fixes a typo for an forgotten rename of `collectsTaxIds`.

I'll send in a PR to the docs when this one is accepted.