### PR TITLE
[12.x] Implement webhook command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
+        "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0",

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Cashier\Console\WebhookCommand;
 use Stripe\Stripe;
 use Stripe\Util\LoggerInterface;
 
@@ -21,6 +22,7 @@ class CashierServiceProvider extends ServiceProvider
         $this->registerResources();
         $this->registerMigrations();
         $this->registerPublishing();
+        $this->registerCommands();
 
         Stripe::setAppInfo(
             'Laravel Cashier',
@@ -138,6 +140,20 @@ class CashierServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/cashier'),
             ], 'cashier-views');
+        }
+    }
+
+    /**
+     * Register the package's commands.
+     *
+     * @return void
+     */
+    protected function registerCommands()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                WebhookCommand::class,
+            ]);
         }
     }
 }

--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -16,7 +16,7 @@ class WebhookCommand extends Command
     protected $signature = 'cashier:webhook
             {--disabled : Immediately disable the webhook after creation}
             {--url= : The URL endpoint for the webhook}
-            {--api_version= : The Stripe API version the webhook should use}';
+            {--api-version= : The Stripe API version the webhook should use}';
 
     /**
      * The console command description.
@@ -42,7 +42,7 @@ class WebhookCommand extends Command
                 'invoice.payment_action_required',
             ],
             'url' => $this->option('url') ?? route('cashier.webhook'),
-            'api_version' => $this->option('api_version') ?? Cashier::STRIPE_VERSION,
+            'api_version' => $this->option('api-version') ?? Cashier::STRIPE_VERSION,
         ], Cashier::stripeOptions());
 
         $this->info('The Stripe webhook was created successfully. Retrieve the webhook secret in your Stripe dashboard and define it as an environment variable.');

--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -15,8 +15,8 @@ class WebhookCommand extends Command
      */
     protected $signature = 'cashier:webhook
             {--disabled : Immediately disable the webhook after creation}
-            {--url= : Provide the url endpoint to connect the webhook to}
-            {--api_version= : Provide the Stripe API version the webhook should use}';
+            {--url= : The URL endpoint for the webhook}
+            {--api_version= : The Stripe API version the webhook should use}';
 
     /**
      * The console command description.
@@ -45,12 +45,12 @@ class WebhookCommand extends Command
             'api_version' => $this->option('api_version') ?? Cashier::STRIPE_VERSION,
         ], Cashier::stripeOptions());
 
-        $this->info('The Stripe webhook was created successfully. Make sure you look up the webhook secret in your Stripe dashboard and set it up through your app\'s environment variables.');
+        $this->info('The Stripe webhook was created successfully. Retrieve the webhook secret in your Stripe dashboard and define it as an environment variable.');
 
         if ($this->option('disabled')) {
             WebhookEndpoint::update($endpoint->id, ['disabled' => true], Cashier::stripeOptions());
 
-            $this->info('The Stripe webhook was disabled as requested. Make sure you enable it through the Stripe dashboard when you\'re ready.');
+            $this->info('The Stripe webhook was disabled as requested. You may enable the webhook via the Stripe dashboard when needed.');
         }
     }
 }

--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Cashier\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Cashier\Cashier;
+use Stripe\WebhookEndpoint;
+
+class WebhookCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cashier:webhook
+            {--disabled : Immediately disable the webhook after creation}
+            {--url= : Provide the url endpoint to connect the webhook to}
+            {--api_version= : Provide the Stripe API version the webhook should use}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create the Stripe webhook to interact with Cashier.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $endpoint = WebhookEndpoint::create([
+            'enabled_events' => [
+                'customer.subscription.created',
+                'customer.subscription.updated',
+                'customer.subscription.deleted',
+                'customer.updated',
+                'customer.deleted',
+                'invoice.payment_action_required',
+            ],
+            'url' => $this->option('url') ?? route('cashier.webhook'),
+            'api_version' => $this->option('api_version') ?? Cashier::STRIPE_VERSION,
+        ], Cashier::stripeOptions());
+
+        $this->info('The Stripe webhook was created successfully. Make sure you look up the webhook secret in your Stripe dashboard and set it up through your app\'s environment variables.');
+
+        if ($this->option('disabled')) {
+            WebhookEndpoint::update($endpoint->id, ['disabled' => true], Cashier::stripeOptions());
+
+            $this->info('The Stripe webhook was disabled as requested. Make sure you enable it through the Stripe dashboard when you\'re ready.');
+        }
+    }
+}


### PR DESCRIPTION
This implements a webhook command to easily set up the webhook needed to send the events that Cashier needs from Stripe. By default it'll use the `APP_URL` with the default webhook route and the default Cashier version. Both of these can be customized. You can also pass a `--disabled` flag if you don't want it to start sending events straight away.

```bash
# Create the webhook with the events needed for Cashier
php artisan cashier:webhook

# Set an explicit url
php artisan cashier:webhook --url="http://example.com/stripe/webhook"

# Set an explicit Stripe API version
php artisan cashier:webhook --api_version="2019-12-03"

# Disable the webhook upon creation
php artisan cashier:webhook --disabled
```

This will make the setup process that much easier for new Cashier users and users that are upgrading to newer versions. We can add this command to the upgrade guide.