### PR TITLE
[13.x] Prevent tax calculation for one-off charges

### DIFF
--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -94,7 +94,7 @@ trait HandlesTaxes
     }
 
     /**
-     * Determine if automatic tax is enabled or not.
+     * Determine if automatic tax is enabled.
      *
      * @return bool
      */

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -88,9 +88,19 @@ trait HandlesTaxes
     {
         return array_filter([
             'customer_ip_address' => $this->customerIpAddress,
-            'enabled' => $this->automaticTax ?: Cashier::$calculatesTaxes,
+            'enabled' => $this->isAutomaticTaxEnabled(),
             'estimation_billing_address' => $this->estimationBillingAddress,
         ]);
+    }
+
+    /**
+     * Determine if automatic tax is enabled or not.
+     *
+     * @return bool
+     */
+    protected function isAutomaticTaxEnabled()
+    {
+        return $this->automaticTax ?: Cashier::$calculatesTaxes;
     }
 
     /**

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Laravel\Cashier\Invoice;
 use Laravel\Cashier\Payment;
+use LogicException;
 use Stripe\Exception\CardException as StripeCardException;
 use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 use Stripe\Invoice as StripeInvoice;
@@ -24,6 +25,10 @@ trait ManagesInvoices
      */
     public function tab($description, $amount, array $options = [])
     {
+        if ($this->isAutomaticTaxEnabled()) {
+            throw new LogicException('For now, you cannot add invoice items in combination automatic tax calculation.');
+        }
+
         $this->assertCustomerExists();
 
         $options = array_merge([

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
+use LogicException;
 
 trait PerformsCharges
 {
@@ -102,6 +103,10 @@ trait PerformsCharges
      */
     public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
     {
+        if ($this->isAutomaticTaxEnabled()) {
+            throw new LogicException('For now, you cannot use checkout charges in combination automatic tax calculation.');
+        }
+
         return $this->checkout([[
             'price_data' => [
                 'currency' => $this->preferredCurrency(),


### PR DESCRIPTION
This is a temporary implementation that prevents single charge methods from being used while automatic tax calculation is enabled. Until a better way to handle this is found this is the best solution to warn people about not using these two features together.