### PR TITLE
[14.x] Cascade Stripe exceptions when invoicing

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -332,6 +332,26 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Determine if the invoice will charge the customer automatically.
+     *
+     * @return bool
+     */
+    public function chargesAutomatically()
+    {
+        return $this->invoice->collection_method === StripeInvoice::COLLECTION_METHOD_CHARGE_AUTOMATICALLY;
+    }
+
+    /**
+     * Determine if the invoice will send an invoice to the customer.
+     *
+     * @return bool
+     */
+    public function sendsInvoice()
+    {
+        return $this->invoice->collection_method === StripeInvoice::COLLECTION_METHOD_SEND_INVOICE;
+    }
+
+    /**
      * Get all of the "invoice item" line items.
      *
      * @return \Laravel\Cashier\InvoiceLineItem[]

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Tests\Feature;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Laravel\Cashier\Invoice;
+use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 use Stripe\InvoiceItem as StripeInvoiceItem;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -25,9 +26,9 @@ class InvoicesTest extends FeatureTestCase
         $user->createAsStripeCustomer();
         $user->updateDefaultPaymentMethod('pm_card_visa');
 
-        $response = $user->invoice();
+        $this->expectException(StripeInvalidRequestException::class);
 
-        $this->assertFalse($response);
+        $user->invoice();
     }
 
     public function test_customer_can_be_invoiced()


### PR DESCRIPTION
This PR changes the behavior of `->invoice()` to cascade Stripe exceptions. Previously they were silently failing by returning false. It's best to better inform the user when something goes amis or when they're attempting to invoice a user when there isn't anything to invoice. Most likely this means there's a mistake in their system so it's good to explicitly warn about that. `CardException`'s are still caught to trigger the `IncompletePayment` exceptions.