### PR TITLE
[13.x] Add invoicePrice and tabPrice methods

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -65,6 +65,45 @@ trait ManagesInvoices
     }
 
     /**
+     * Add an invoice item for a specific Price ID to the customer's upcoming invoice.
+     *
+     * @param  string  $price
+     * @param  int  $quantity
+     * @param  array  $options
+     * @return \Stripe\InvoiceItem
+     */
+    public function tabPrice($price, $quantity = 1, array $options = [])
+    {
+        $this->assertCustomerExists();
+
+        $options = array_merge([
+            'customer' => $this->stripe_id,
+            'price' => $price,
+            'quantity' => $quantity,
+        ], $options);
+
+        return $this->stripe()->invoiceItems->create($options);
+    }
+
+    /**
+     * Invoice the customer for the given Price ID and generate an invoice immediately.
+     *
+     * @param  string  $price
+     * @param  int  $quantity
+     * @param  array  $tabOptions
+     * @param  array  $invoiceOptions
+     * @return \Laravel\Cashier\Invoice|bool
+     *
+     * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     */
+    public function invoicePrice($price, $quantity = 1, array $tabOptions = [], array $invoiceOptions = [])
+    {
+        $this->tabPrice($price, $quantity, $tabOptions);
+
+        return $this->invoice($invoiceOptions);
+    }
+
+    /**
      * Invoice the customer outside of the regular billing cycle.
      *
      * @param  array  $options

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -42,6 +42,26 @@ class InvoicesTest extends FeatureTestCase
         $this->assertEquals(49900, $response->total);
     }
 
+    public function test_customer_can_be_invoiced_with_a_price()
+    {
+        $user = $this->createCustomer('customer_can_be_invoiced');
+        $user->createAsStripeCustomer();
+        $user->updateDefaultPaymentMethod('pm_card_visa');
+
+        $price = $user->stripe()->prices->create([
+            'currency' => $user->preferredCurrency(),
+            'product_data' => [
+                'name' => 'Laravel T-shirt',
+            ],
+            'unit_amount' => 499,
+        ]);
+
+        $response = $user->invoicePrice($price, 2);
+
+        $this->assertInstanceOf(Invoice::class, $response);
+        $this->assertEquals(998, $response->total);
+    }
+
     public function test_find_invoice_by_id()
     {
         $user = $this->createCustomer('find_invoice_by_id');


### PR DESCRIPTION
Adds an `invoicePrice` and `tabPrice` method that works with a given Price ID. This is a useful alternative to single charge invoices which cannot be used in combination with automatic tax calculation.

```php
// Invoice for a single price...
$invoice = $user->invoicePrice('price_tshirt', 5);

// Invoice for a couple of prices
$user->tabPrice('price_tshirt', 5);
$user->tabPrice('price_mug', 5);
$invoice = $user->invoice();
```

Closes https://github.com/laravel/cashier-stripe/issues/1211