### PR TITLE
[13.x] Switch to Illuminate\Http\Response

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
@@ -14,7 +15,6 @@ use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
 use Stripe\Subscription as StripeSubscription;
-use Symfony\Component\HttpFoundation\Response;
 
 class WebhookController extends Controller
 {
@@ -34,7 +34,7 @@ class WebhookController extends Controller
      * Handle a Stripe webhook call.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     public function handleWebhook(Request $request)
     {
@@ -58,7 +58,7 @@ class WebhookController extends Controller
      * Handle customer subscription created.
      *
      * @param  array $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleCustomerSubscriptionCreated(array $payload)
     {
@@ -116,7 +116,7 @@ class WebhookController extends Controller
      * Handle customer subscription updated.
      *
      * @param  array  $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
@@ -203,7 +203,7 @@ class WebhookController extends Controller
      * Handle a cancelled customer from a Stripe subscription.
      *
      * @param  array  $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleCustomerSubscriptionDeleted(array $payload)
     {
@@ -222,7 +222,7 @@ class WebhookController extends Controller
      * Handle customer updated.
      *
      * @param  array  $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleCustomerUpdated(array $payload)
     {
@@ -237,7 +237,7 @@ class WebhookController extends Controller
      * Handle deleted customer.
      *
      * @param  array  $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleCustomerDeleted(array $payload)
     {
@@ -261,7 +261,7 @@ class WebhookController extends Controller
      * Handle payment action required for invoice.
      *
      * @param  array  $payload
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function handleInvoicePaymentActionRequired(array $payload)
     {
@@ -297,7 +297,7 @@ class WebhookController extends Controller
      * Handle successful calls on the controller.
      *
      * @param  array  $parameters
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function successMethod($parameters = [])
     {
@@ -308,7 +308,7 @@ class WebhookController extends Controller
      * Handle calls to missing methods on the controller.
      *
      * @param  array  $parameters
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     protected function missingMethod($parameters = [])
     {


### PR DESCRIPTION
Switching the WebhookController to use Laravel's standard http response. This came up for me after adding a new middleware based on [recent changes](https://github.com/laravel/framework/pull/37847) in Laravel 8.49:

```php
    public function handle($request, Closure $next)
    {
        $requestId = (string) Str::uuid();

        Log::withContext([
            'request-id' => $requestId
        ]);

        return $next($request)->header('Request-Id', $requestId);
    }
```

I noticed in my QA environment that all of my webhooks were failing because of the following error: 
```
Call to undefined method Symfony\\Component\\HttpFoundation\\Response::header() at /home/forge/default/app/Http/Middleware/AssignRequestId.php:26
```

I'm not sure if there is a historical or current reason to opt for Symfony response over Illuminate response which extends Symfony response.  