### PR TITLE
[13.x] Implement customer balances

### DIFF
--- a/src/CustomerBalanceTransaction.php
+++ b/src/CustomerBalanceTransaction.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Laravel\Cashier\Exceptions\InvalidCustomerBalanceTransaction;
+use Stripe\CustomerBalanceTransaction as StripeCustomerBalanceTransaction;
+
+class CustomerBalanceTransaction
+{
+    /**
+     * The Stripe model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $owner;
+
+    /**
+     * The Stripe CustomerBalanceTransaction instance.
+     *
+     * @var \Stripe\CustomerBalanceTransaction
+     */
+    protected $transaction;
+
+    /**
+     * Create a new CustomerBalanceTransaction instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  \Stripe\CustomerBalanceTransaction  $transaction
+     * @return void
+     *
+     * @throws \Laravel\Cashier\Exceptions\InvalidCustomerBalanceTransaction
+     */
+    public function __construct($owner, StripeCustomerBalanceTransaction $transaction)
+    {
+        if ($owner->stripe_id !== $transaction->customer) {
+            throw InvalidCustomerBalanceTransaction::invalidOwner($transaction, $owner);
+        }
+
+        $this->owner = $owner;
+        $this->transaction = $transaction;
+    }
+
+    /**
+     * Get the total transaction amount.
+     *
+     * @return string
+     */
+    public function amount()
+    {
+        return $this->formatAmount($this->rawAmount());
+    }
+
+    /**
+     * Get the raw total transaction amount.
+     *
+     * @return int
+     */
+    public function rawAmount()
+    {
+        return $this->transaction->amount;
+    }
+
+    /**
+     * Get the ending balance.
+     *
+     * @return string
+     */
+    public function endingBalance()
+    {
+        return $this->formatAmount($this->rawEndingBalance());
+    }
+
+    /**
+     * Get the raw ending balance.
+     *
+     * @return int
+     */
+    public function rawEndingBalance()
+    {
+        return $this->transaction->ending_balance;
+    }
+
+    /**
+     * Format the given amount into a displayable currency.
+     *
+     * @param  int  $amount
+     * @return string
+     */
+    protected function formatAmount($amount)
+    {
+        return Cashier::formatAmount($amount, $this->transaction->currency);
+    }
+
+    /**
+     * Return the related invoice for this transaction.
+     *
+     * @return \Laravel\Cashier\Invoice
+     */
+    public function invoice()
+    {
+        return $this->transaction->invoice
+            ? $this->owner->findInvoice($this->transaction->invoice)
+            : null;
+    }
+
+    /**
+     * Get the Stripe CustomerBalanceTransaction instance.
+     *
+     * @return \Stripe\CustomerBalanceTransaction
+     */
+    public function asStripeCustomerBalanceTransaction()
+    {
+        return $this->invoice;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->asStripeCustomerBalanceTransaction()->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Dynamically get values from the Stripe object.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->transaction->{$key};
+    }
+}

--- a/src/Exceptions/InvalidCustomerBalanceTransaction.php
+++ b/src/Exceptions/InvalidCustomerBalanceTransaction.php
@@ -16,6 +16,6 @@ class InvalidCustomerBalanceTransaction extends Exception
      */
     public static function invalidOwner(StripeCustomerBalanceTransaction $transaction, $owner)
     {
-        return new static("The transaction `{$transaction->id}` does not belong to this customer `$owner->stripe_id`.");
+        return new static("The transaction `{$transaction->id}` does not belong to customer `$owner->stripe_id`.");
     }
 }

--- a/src/Exceptions/InvalidCustomerBalanceTransaction.php
+++ b/src/Exceptions/InvalidCustomerBalanceTransaction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Stripe\CustomerBalanceTransaction as StripeCustomerBalanceTransaction;
+
+class InvalidCustomerBalanceTransaction extends Exception
+{
+    /**
+     * Create a new CustomerBalanceTransaction instance.
+     *
+     * @param  \Stripe\CustomerBalanceTransaction  $transaction
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return static
+     */
+    public static function invalidOwner(StripeCustomerBalanceTransaction $transaction, $owner)
+    {
+        return new static("The transaction `{$transaction->id}` does not belong to this customer `$owner->stripe_id`.");
+    }
+}


### PR DESCRIPTION
This PR implements some API's around customer balances. This will make it easier for apps to retrieve a customer's balance, apply new balance transactions and display a history of balance adjustments.

```php
// Retrieve current balance...
$balance = $user->balance(); // $5.00

// Credit new balance...
$user->applyBalance(500, 'Premium customer top-up.');

// Debit balance...
$user->applyBalance(-300, 'Bad usage penalty.');

// Retrieve all transactions...
$transactions = $user->balanceTransactions();

// Display all transactions...
foreach ($transactions as $transaction) {
    // Specific amount of the transaction...
    $transaction->amount();

    // Retrieve the related invoice when available...
    $transaction->invoice();
}
```

Closes https://github.com/laravel/cashier-stripe/issues/762