### PR TITLE
[13.x] Server side Checkout redirect

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -4,11 +4,13 @@ namespace Laravel\Cashier;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\View;
 use JsonSerializable;
 use Stripe\Checkout\Session;
 
-class Checkout implements Arrayable, Jsonable, JsonSerializable
+class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
 {
     /**
      * The Stripe model instance.
@@ -66,6 +68,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable
      * @param  string  $label
      * @param  array  $options
      * @return \Illuminate\Contracts\View\View
+     * @deprecated Use the redirect method instead.
      */
     public function button($label = 'Check out', array $options = [])
     {
@@ -74,6 +77,27 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable
             'sessionId' => $this->session->id,
             'stripeKey' => config('cashier.key'),
         ], $options));
+    }
+
+    /**
+     * Redirect to the checkout session.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function redirect()
+    {
+        return Redirect::to($this->session->url, 303);
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $this->redirect();
     }
 
     /**

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -68,6 +68,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      * @param  string  $label
      * @param  array  $options
      * @return \Illuminate\Contracts\View\View
+     *
      * @deprecated Use the redirect method instead.
      */
     public function button($label = 'Check out', array $options = [])


### PR DESCRIPTION
This PR implements some nice API's to Stripe's recent addition of exposing the Checkout url on its session object. This will greatly simplify the workflow for a library like Cashier to use redirects instead of doing it through Stripe.js

Before:

```php
$checkoutBtn = Auth::user()->checkout('price_tshirt')->button();

return view('checkout', compact('checkoutBtn'));
```

And have the customer click a button. Now:

```php
return Auth::user()->checkout('price_tshirt');
```

I've deprecated the `button` method because I think that from now on that's going to be a very rare use case.