### PR TITLE
[13.x] Fix issue with requires_action

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -301,6 +301,8 @@
                     if (this.paymentMethod.type === 'card') {
                         if (this.paymentIntent.status === 'requires_payment_method') {
                             data.payment_method.card = this.paymentElement;
+                        } else if (this.paymentIntent.status === 'requires_action') {
+                            data.payment_method = this.paymentIntent.payment_method.id;
                         }
 
                         paymentPromise = stripe.confirmCardPayment(secret, data);

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -32,13 +32,17 @@ class PaymentController extends Controller
             $id, ['expand' => ['payment_method']])
         );
 
+        $paymentIntent = Arr::only($payment->asStripePaymentIntent()->toArray(), [
+            'id', 'status', 'payment_method_types', 'client_secret', 'payment_method',
+        ]);
+
+        $paymentIntent['payment_method'] = Arr::only($paymentIntent['payment_method'] ?? [], 'id');
+
         return view('cashier::payment', [
             'stripeKey' => config('cashier.key'),
             'amount' => $payment->amount(),
             'payment' => $payment,
-            'paymentIntent' => Arr::only($payment->asStripePaymentIntent()->toArray(), [
-                'id', 'status', 'payment_method_types', 'client_secret',
-            ]),
+            'paymentIntent' => array_filter($paymentIntent),
             'paymentMethod' => (string) request('source_type', optional($payment->payment_method)->type),
             'errorMessage' => request('redirect_status') === 'failed'
                 ? 'Something went wrong when trying to confirm the payment. Please try again.'


### PR DESCRIPTION
When requires_action is presented on a card payment, the currently set payment method should be used to handle any extra action required by Stripe.

Fixes https://github.com/laravel/cashier-stripe/issues/1221