### PR TITLE
[13.x] Fix async issue with webhooks

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -120,7 +120,7 @@ class WebhookController extends Controller
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
-        // Prevent issue with subscriptio created webhook arriving too late...
+        // Prevent issue with subscription created webhook arriving too late...
         sleep(1);
 
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -120,8 +120,7 @@ class WebhookController extends Controller
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
-        // We delay the update of the subscription update webhook by one second to prevent
-        // an asynchronous issue with the subscription created webhook arriving too late.
+        // Prevent issue with subscriptio created webhook arriving too late...
         sleep(1);
 
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -120,6 +120,10 @@ class WebhookController extends Controller
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
+        // We delay the update of the subscription update webhook by one second to prevent
+        // an asynchronous issue with the subscription created webhook arriving too late.
+        sleep(1);
+
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             $data = $payload['data']['object'];
 


### PR DESCRIPTION
This PR fixes an async issue with webhooks. When using a checkout session, a susbcription created and subscription updated event are sent by Stripe. Because Stripe handles the checkout session so fast, these are sent at almost the exact same time. This can cause the updated event to arrive before the created event. By delaying the updating event by one second, we give ample time for the created webhook to be handled first. This solution was suggested by a community member who tried it out in their production app and hasn't experienced the issue ever since.

Fixes #1201
