### PR TITLE
Add support for inline price data

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -25,8 +25,8 @@ trait ManagesInvoices
      */
     public function tab($description, $amount, array $options = [])
     {
-        if ($this->isAutomaticTaxEnabled()) {
-            throw new LogicException('For now, you cannot add invoice items in combination automatic tax calculation.');
+        if ($this->isAutomaticTaxEnabled() && !array_key_exists('price_data', $options)) {
+            throw new LogicException('When using automatic tax calculation, you need to set "price_data" in options.');
         }
 
         $this->assertCustomerExists();
@@ -37,7 +37,12 @@ trait ManagesInvoices
             'description' => $description,
         ], $options);
 
-        if (array_key_exists('quantity', $options)) {
+        if (array_key_exists('price_data', $options)) {
+            $options['price_data'] = array_merge([
+                'unit_amount' => $amount,
+                'currency' => $this->preferredCurrency(),
+            ],  $options['price_data']);
+        } elseif (array_key_exists('quantity', $options)) {
             $options['unit_amount'] = $options['unit_amount'] ?? $amount;
         } else {
             $options['amount'] = $amount;

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -26,7 +26,7 @@ trait ManagesInvoices
     public function tab($description, $amount, array $options = [])
     {
         if ($this->isAutomaticTaxEnabled() && ! array_key_exists('price_data', $options)) {
-            throw new LogicException('When using automatic tax calculation, you need to set "price_data" in options.');
+            throw new LogicException('When using automatic tax calculation, you need to define the "price_data" in the options.');
         }
 
         $this->assertCustomerExists();

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -25,7 +25,7 @@ trait ManagesInvoices
      */
     public function tab($description, $amount, array $options = [])
     {
-        if ($this->isAutomaticTaxEnabled() && !array_key_exists('price_data', $options)) {
+        if ($this->isAutomaticTaxEnabled() && ! array_key_exists('price_data', $options)) {
             throw new LogicException('When using automatic tax calculation, you need to set "price_data" in options.');
         }
 
@@ -41,7 +41,7 @@ trait ManagesInvoices
             $options['price_data'] = array_merge([
                 'unit_amount' => $amount,
                 'currency' => $this->preferredCurrency(),
-            ],  $options['price_data']);
+            ], $options['price_data']);
         } elseif (array_key_exists('quantity', $options)) {
             $options['unit_amount'] = $options['unit_amount'] ?? $amount;
         } else {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -746,7 +746,7 @@ class Subscription extends Model
                 'tax_rates' => $this->getPriceTaxRatesForPayload($price),
             ];
 
-            if(!isset($options['price_data'])) {
+            if (! isset($options['price_data'])) {
                 $payload['price'] = $price;
             }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -743,9 +743,12 @@ class Subscription extends Model
             $options = is_string($options) ? [] : $options;
 
             $payload = [
-                'price' => $price,
                 'tax_rates' => $this->getPriceTaxRatesForPayload($price),
             ];
+
+            if(!isset($options['price_data'])) {
+                $payload['price'] = $price;
+            }
 
             if ($isSinglePriceSwap && ! is_null($this->quantity)) {
                 $payload['quantity'] = $this->quantity;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -97,7 +97,11 @@ class SubscriptionBuilder
      */
     public function price($price, $quantity = 1)
     {
-        $options = ['price' => $price];
+        if(is_array($price)) {
+            $options = $price;
+        } else {
+            $options = ['price' => $price];
+        }
 
         if (! is_null($quantity)) {
             $options['quantity'] = $quantity;
@@ -107,7 +111,11 @@ class SubscriptionBuilder
             $options['tax_rates'] = $taxRates;
         }
 
-        $this->items[$price] = $options;
+        if(is_array($price)) {
+            $this->items[] = $options;
+        } else {
+            $this->items[$price] = $options;
+        }
 
         return $this;
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -97,7 +97,7 @@ class SubscriptionBuilder
      */
     public function price($price, $quantity = 1)
     {
-        if(is_array($price)) {
+        if (is_array($price)) {
             $options = $price;
         } else {
             $options = ['price' => $price];
@@ -111,7 +111,7 @@ class SubscriptionBuilder
             $options['tax_rates'] = $taxRates;
         }
 
-        if(is_array($price)) {
+        if (is_array($price)) {
             $this->items[] = $options;
         } else {
             $this->items[$price] = $options;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -75,7 +75,7 @@ class SubscriptionBuilder
      *
      * @param  mixed  $owner
      * @param  string  $name
-     * @param  string|string[]  $prices
+     * @param  string|string[]|array[]  $prices
      * @return void
      */
     public function __construct($owner, $name, $prices = [])
@@ -91,17 +91,13 @@ class SubscriptionBuilder
     /**
      * Set a price on the subscription builder.
      *
-     * @param  string  $price
+     * @param  string|array  $price
      * @param  int|null  $quantity
      * @return $this
      */
     public function price($price, $quantity = 1)
     {
-        if (is_array($price)) {
-            $options = $price;
-        } else {
-            $options = ['price' => $price];
-        }
+        $options = is_array($price) ? $price : ['price' => $price];
 
         if (! is_null($quantity)) {
             $options['quantity'] = $quantity;

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -75,7 +75,7 @@ class InvoicesTest extends FeatureTestCase
 
         $response = $user->invoiceFor('Laravel T-shirt', 599, [
             'price_data' => [
-                'product'      => $productId,
+                'product' => $productId,
                 'tax_behavior' => 'exclusive',
             ],
         ]);

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -62,6 +62,30 @@ class InvoicesTest extends FeatureTestCase
         $this->assertEquals(998, $response->total);
     }
 
+    public function test_customer_can_be_invoiced_with_inline_price_data()
+    {
+        $user = $this->createCustomer('customer_can_be_invoiced_with_inline_price_data');
+        $user->createAsStripeCustomer();
+        $user->updateDefaultPaymentMethod('pm_card_visa');
+
+        $productId = self::stripe()->products->create([
+            'name' => 'Laravel Cashier Test Product',
+            'type' => 'service',
+        ])->id;
+
+        $response = $user->invoiceFor('Laravel T-shirt', 599, [
+            'price_data' => [
+                'product'      => $productId,
+                'tax_behavior' => 'exclusive'
+            ]
+        ]);
+
+        $this->assertInstanceOf(Invoice::class, $response);
+        $this->assertEquals(599, $response->total);
+        $this->assertEquals('exclusive', $response->invoiceLineItems()[0]->price->tax_behavior);
+    }
+
+
     public function test_find_invoice_by_id()
     {
         $user = $this->createCustomer('find_invoice_by_id');

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -76,15 +76,14 @@ class InvoicesTest extends FeatureTestCase
         $response = $user->invoiceFor('Laravel T-shirt', 599, [
             'price_data' => [
                 'product'      => $productId,
-                'tax_behavior' => 'exclusive'
-            ]
+                'tax_behavior' => 'exclusive',
+            ],
         ]);
 
         $this->assertInstanceOf(Invoice::class, $response);
         $this->assertEquals(599, $response->total);
         $this->assertEquals('exclusive', $response->invoiceLineItems()[0]->price->tax_behavior);
     }
-
 
     public function test_find_invoice_by_id()
     {

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -230,10 +230,10 @@ class SubscriptionsTest extends FeatureTestCase
 
         $subscription->swap([[
             'price_data' => [
-                'product'     => static::$productId,
+                'product' => static::$productId,
                 'tax_behavior' => 'exclusive',
-                'currency'    => 'USD',
-                'recurring'   => [
+                'currency' => 'USD',
+                'recurring' => [
                     'interval' => 'month',
                 ],
                 'unit_amount' => 1100,
@@ -465,19 +465,17 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $user = $this->createCustomer('creating_subscription_with_inline_price_data');
 
-        // Create Subscription
         $user->newSubscription('main')->price([
             'price_data' => [
-                'product'     => static::$productId,
+                'product' => static::$productId,
                 'tax_behavior' => 'exclusive',
-                'currency'    => 'USD',
-                'recurring'   => [
+                'currency' => 'USD',
+                'recurring' => [
                     'interval' => 'month',
                 ],
                 'unit_amount' => 1100,
             ],
-        ])
-            ->create('pm_card_visa');
+        ])->create('pm_card_visa');
 
         $subscription = $user->subscription('main');
 
@@ -489,7 +487,6 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
 
-        // Invoice Tests
         $invoice = $user->invoices()[0];
 
         $this->assertEquals('$11.00', $invoice->total());

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -236,8 +236,8 @@ class SubscriptionsTest extends FeatureTestCase
                 'recurring'   => [
                     'interval' => 'month',
                 ],
-                'unit_amount' => 1100
-            ]
+                'unit_amount' => 1100,
+            ],
         ]]);
 
         $this->assertEquals(1100, $subscription->asStripeSubscription()->items->data[0]->price->unit_amount);
@@ -461,7 +461,6 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($coupon->isPercentage());
     }
 
-
     public function test_creating_subscription_with_inline_price_data()
     {
         $user = $this->createCustomer('creating_subscription_with_inline_price_data');
@@ -475,8 +474,8 @@ class SubscriptionsTest extends FeatureTestCase
                 'recurring'   => [
                     'interval' => 'month',
                 ],
-                'unit_amount' => 1100
-            ]
+                'unit_amount' => 1100,
+            ],
         ])
             ->create('pm_card_visa');
 
@@ -495,9 +494,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertEquals('$11.00', $invoice->total());
         $this->assertEquals('exclusive', $invoice->invoiceLineItems()[0]->price->tax_behavior);
-
     }
-
 
     public function test_creating_subscription_with_an_anchored_billing_cycle()
     {

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -222,6 +222,28 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame(3, $subscription->asStripeSubscription()->quantity);
     }
 
+    public function test_swapping_subscription_with_inline_price_data()
+    {
+        $user = $this->createCustomer('swapping_subscription_with_inline_price_data');
+        $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+        $subscription = $user->subscription('main');
+
+        $subscription->swap([[
+            'price_data' => [
+                'product'     => static::$productId,
+                'tax_behavior' => 'exclusive',
+                'currency'    => 'USD',
+                'recurring'   => [
+                    'interval' => 'month',
+                ],
+                'unit_amount' => 1100
+            ]
+        ]]);
+
+        $this->assertEquals(1100, $subscription->asStripeSubscription()->items->data[0]->price->unit_amount);
+        $this->assertEquals('exclusive', $subscription->asStripeSubscription()->items->data[0]->price->tax_behavior);
+    }
+
     public function test_declined_card_during_new_quantity()
     {
         $user = $this->createCustomer('declined_card_during_new_quantity');
@@ -438,6 +460,44 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals('$5.00', $coupon->amountOff());
         $this->assertFalse($coupon->isPercentage());
     }
+
+
+    public function test_creating_subscription_with_inline_price_data()
+    {
+        $user = $this->createCustomer('creating_subscription_with_inline_price_data');
+
+        // Create Subscription
+        $user->newSubscription('main')->price([
+            'price_data' => [
+                'product'     => static::$productId,
+                'tax_behavior' => 'exclusive',
+                'currency'    => 'USD',
+                'recurring'   => [
+                    'interval' => 'month',
+                ],
+                'unit_amount' => 1100
+            ]
+        ])
+            ->create('pm_card_visa');
+
+        $subscription = $user->subscription('main');
+
+        $this->assertTrue($user->subscribed('main'));
+        $this->assertNotNull($user->subscribed('main', static::$otherPriceId));
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Invoice Tests
+        $invoice = $user->invoices()[0];
+
+        $this->assertEquals('$11.00', $invoice->total());
+        $this->assertEquals('exclusive', $invoice->invoiceLineItems()[0]->price->tax_behavior);
+
+    }
+
 
     public function test_creating_subscription_with_an_anchored_billing_cycle()
     {


### PR DESCRIPTION
Stripe allows to create subscriptions and invoices without creating a `price` object via the dashboard beforehand. This is useful in cases where you want to create very individual subscriptions or invoices.

This PR adds the possibility to subscribe, swap and invoice with custom `price_data`:

```php
// Create Subscription

$user->newSubscription('main')->price([
    'price_data' => [
        'product'      => $productId,
        'tax_behavior' => 'exclusive',
        'currency'     => 'USD',
        'recurring'    => [
            'interval' => 'month',
        ],
        'unit_amount'  => 1100
    ]
])
    ->create('pm_card_visa');
```

```php
// Create Invoice

$user->invoiceFor('Laravel T-shirt', 599, [
    'price_data' => [
        'product'      => $productId,
        'tax_behavior' => 'exclusive'
    ]
]);
```

```php
// Swap Subscription

$subscription->swap([
    [
        'price_data' => [
            'product'      => $productId,
            'tax_behavior' => 'exclusive',
            'currency'     => 'USD',
            'recurring'    => [
                'interval' => 'month',
            ],
            'unit_amount'  => 1100
        ]
    ]
]);
```


This also fixes  one-off charges when automatic tax is enabled (#1204)