### PR TITLE
[13.x] Fix quantity filling on subscriptions

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -502,7 +502,7 @@ class Subscription extends Model
 
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
-            'quantity' => $quantity,
+            'quantity' => $stripeSubscription->quantity,
         ])->save();
 
         if ($this->hasIncompletePayment()) {
@@ -850,7 +850,7 @@ class Subscription extends Model
             'stripe_id' => $stripeSubscriptionItem->id,
             'stripe_product' => $stripeSubscriptionItem->price->product,
             'stripe_price' => $stripeSubscriptionItem->price->id,
-            'quantity' => $quantity,
+            'quantity' => $stripeSubscriptionItem->quantity,
         ]);
 
         $this->unsetRelation('items');

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -118,7 +118,7 @@ class SubscriptionItem extends Model
         if ($this->subscription->hasSinglePrice()) {
             $this->subscription->fill([
                 'stripe_status' => $stripeSubscriptionItem->subscription->status,
-                'quantity' => $quantity,
+                'quantity' => $stripeSubscriptionItem->quantity,
             ])->save();
         }
 


### PR DESCRIPTION
Even though zero shouldn't be passed as a value for quantity it atm leads to an issue where Stripe will use one as a default and the database will be populated by zero. By using the value returned from the Stripe API call we make sure we always use the correct quantity that's set within Stripe.

Fixes #1237
