### PR TITLE
[13.x] Fix webhook order issue

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -17,7 +17,7 @@ class CreateSubscriptionsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id');
             $table->string('name');
-            $table->string('stripe_id');
+            $table->string('stripe_id')->unique();
             $table->string('stripe_status');
             $table->string('stripe_price')->nullable();
             $table->integer('quantity')->nullable();

--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -16,7 +16,7 @@ class CreateSubscriptionItemsTable extends Migration
         Schema::create('subscription_items', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('subscription_id');
-            $table->string('stripe_id')->index();
+            $table->string('stripe_id')->unique();
             $table->string('stripe_product');
             $table->string('stripe_price');
             $table->integer('quantity')->nullable();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -120,83 +120,78 @@ class WebhookController extends Controller
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
-        // Prevent issue with subscription created webhook arriving too late...
-        sleep(1);
-
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             $data = $payload['data']['object'];
 
-            $user->subscriptions->filter(function (Subscription $subscription) use ($data) {
-                return $subscription->stripe_id === $data['id'];
-            })->each(function (Subscription $subscription) use ($data) {
-                if (
-                    isset($data['status']) &&
-                    $data['status'] === StripeSubscription::STATUS_INCOMPLETE_EXPIRED
-                ) {
-                    $subscription->items()->delete();
-                    $subscription->delete();
+            $subscription = $user->subscriptions()->firstOrNew(['stripe_id' => $data['id']]);
 
-                    return;
+            if (
+                isset($data['status']) &&
+                $data['status'] === StripeSubscription::STATUS_INCOMPLETE_EXPIRED
+            ) {
+                $subscription->items()->delete();
+                $subscription->delete();
+
+                return;
+            }
+
+            $firstItem = $data['items']['data'][0];
+            $isSinglePrice = count($data['items']['data']) === 1;
+
+            // Price...
+            $subscription->stripe_price = $isSinglePrice ? $firstItem['price']['id'] : null;
+
+            // Quantity...
+            $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
+
+            // Trial ending date...
+            if (isset($data['trial_end'])) {
+                $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
+
+                if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
+                    $subscription->trial_ends_at = $trialEnd;
+                }
+            }
+
+            // Cancellation date...
+            if (isset($data['cancel_at_period_end'])) {
+                if ($data['cancel_at_period_end']) {
+                    $subscription->ends_at = $subscription->onTrial()
+                        ? $subscription->trial_ends_at
+                        : Carbon::createFromTimestamp($data['current_period_end']);
+                } elseif (isset($data['cancel_at'])) {
+                    $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at']);
+                } else {
+                    $subscription->ends_at = null;
+                }
+            }
+
+            // Status...
+            if (isset($data['status'])) {
+                $subscription->stripe_status = $data['status'];
+            }
+
+            $subscription->save();
+
+            // Update subscription items...
+            if (isset($data['items'])) {
+                $prices = [];
+
+                foreach ($data['items']['data'] as $item) {
+                    $prices[] = $item['price']['id'];
+
+                    $subscription->items()->updateOrCreate([
+                        'stripe_id' => $item['id'],
+                    ], [
+                        'stripe_product' => $item['price']['product'],
+                        'stripe_price' => $item['price']['id'],
+                        'quantity' => $item['quantity'] ?? null,
+                    ]);
                 }
 
-                $firstItem = $data['items']['data'][0];
-                $isSinglePrice = count($data['items']['data']) === 1;
-
-                // Price...
-                $subscription->stripe_price = $isSinglePrice ? $firstItem['price']['id'] : null;
-
-                // Quantity...
-                $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
-
-                // Trial ending date...
-                if (isset($data['trial_end'])) {
-                    $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
-
-                    if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
-                        $subscription->trial_ends_at = $trialEnd;
-                    }
-                }
-
-                // Cancellation date...
-                if (isset($data['cancel_at_period_end'])) {
-                    if ($data['cancel_at_period_end']) {
-                        $subscription->ends_at = $subscription->onTrial()
-                            ? $subscription->trial_ends_at
-                            : Carbon::createFromTimestamp($data['current_period_end']);
-                    } elseif (isset($data['cancel_at'])) {
-                        $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at']);
-                    } else {
-                        $subscription->ends_at = null;
-                    }
-                }
-
-                // Status...
-                if (isset($data['status'])) {
-                    $subscription->stripe_status = $data['status'];
-                }
-
-                $subscription->save();
-
-                // Update subscription items...
-                if (isset($data['items'])) {
-                    $prices = [];
-
-                    foreach ($data['items']['data'] as $item) {
-                        $prices[] = $item['price']['id'];
-
-                        $subscription->items()->updateOrCreate([
-                            'stripe_id' => $item['id'],
-                        ], [
-                            'stripe_product' => $item['price']['product'],
-                            'stripe_price' => $item['price']['id'],
-                            'quantity' => $item['quantity'] ?? null,
-                        ]);
-                    }
-
-                    // Delete items that aren't attached to the subscription anymore...
-                    $subscription->items()->whereNotIn('stripe_price', $prices)->delete();
-                }
-            });
+                // Delete items that aren't attached to the subscription anymore...
+                $subscription->items()->whereNotIn('stripe_price', $prices)->delete();
+            }
         }
 
         return $this->successMethod();

--- a/tests/Feature/MultipriceSubscriptionsTest.php
+++ b/tests/Feature/MultipriceSubscriptionsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Tests\Feature;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use Laravel\Cashier\Tests\Fixtures\User;
@@ -332,7 +333,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
         ]);
 
         $subscription->items()->create([
-            'stripe_id' => 'it_foo',
+            'stripe_id' => 'it_'.Str::random(10),
             'stripe_product' => self::$productId,
             'stripe_price' => self::$priceId,
             'quantity' => 1,
@@ -356,7 +357,7 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
         $subscription->save();
 
         $subscription->items()->create([
-            'stripe_id' => 'it_foo',
+            'stripe_id' => 'it_'.Str::random(10),
             'stripe_product' => self::$productId,
             'stripe_price' => self::$otherPriceId,
             'quantity' => 1,

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Tests\Feature;
 
 use Carbon\Carbon;
 use DateTime;
+use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Payment;
@@ -910,7 +911,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         $subscription = $user->subscriptions()->create([
             'name' => 'default',
-            'stripe_id' => 'sub_xxx',
+            'stripe_id' => 'sub_'.Str::random(10),
             'stripe_status' => 'active',
             'stripe_price' => 'price_xxx',
             'quantity' => 1,
@@ -928,7 +929,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         $user->subscriptions()->create([
             'name' => 'default',
-            'stripe_id' => 'sub_xxx',
+            'stripe_id' => 'sub_'.Str::random(10),
             'stripe_status' => 'active',
             'stripe_price' => 'price_xxx',
             'quantity' => 1,

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Tests\Feature;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Notifications\ConfirmPayment;
 use Stripe\Subscription as StripeSubscription;
@@ -94,7 +95,7 @@ class WebhooksTest extends FeatureTestCase
         ]);
 
         $item = $subscription->items()->create([
-            'stripe_id' => 'it_foo',
+            'stripe_id' => 'it_'.Str::random(10),
             'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_bar',
             'quantity' => 1,
@@ -152,7 +153,7 @@ class WebhooksTest extends FeatureTestCase
         ]);
 
         $item = $subscription->items()->create([
-            'stripe_id' => 'it_foo',
+            'stripe_id' => 'it_'.Str::random(10),
             'stripe_product' => 'prod_bar',
             'stripe_price' => 'price_bar',
             'quantity' => 1,


### PR DESCRIPTION
This PR is an attempt at fixing the issue with the subscripion.updated webhook arriving sooner than the subscription.created webhook. What we'll do is create the subscription when it isn't yet created. This is a more safer way than delaying the handling by one second.
Should the susbcription.created webhook be handled later on, it won't be created twice since there's a check in the subscription.created handler.

I've also added two new unique indexes on stripe_id columns in the subscription tables. Honestly I don't know why these weren't there before.

I've tried this out and manages to confirm it fixes things for me in the situation that the subscription.updated webhook arrives first.

PS.: most of the changes in this PR are indentation changes.