### PR TITLE
[13.x] Send data when upcoming invoice is refreshed

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -170,7 +170,7 @@ trait ManagesInvoices
         try {
             $stripeInvoice = $this->stripe()->invoices->upcoming($parameters);
 
-            return new Invoice($this, $stripeInvoice);
+            return new Invoice($this, $stripeInvoice, $parameters);
         } catch (StripeInvalidRequestException $exception) {
             //
         }


### PR DESCRIPTION
This fixes a bug where an upcoming invoice is refreshed but its original parameters weren't sent along. For example, a previewed invoice wouldn't look the same in its PDF download.
