### PR TITLE
[13.x] Add invoices methods to subscription

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -270,7 +270,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Get an array of the customer's invoices.
+     * Get an array of the customer's invoices including pending ones.
      *
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -270,7 +270,7 @@ trait ManagesInvoices
     }
 
     /**
-     * Get an array of the customer's invoices including pending ones.
+     * Get an array of the customer's invoices, including pending invoices.
      *
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1190,7 +1190,7 @@ class Subscription extends Model
     }
 
     /**
-     * Get an array of the subscription's invoices including pending ones.
+     * Get an array of the subscription's invoices, including pending invoices.
      *
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1176,6 +1176,31 @@ class Subscription extends Model
     }
 
     /**
+     * Get a collection of the subscription's invoices.
+     *
+     * @param  bool  $includePending
+     * @param  array  $parameters
+     * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]
+     */
+    public function invoices($includePending = false, $parameters = [])
+    {
+        return $this->owner->invoices(
+            $includePending, array_merge($parameters, ['subscription' => $this->stripe_id])
+        );
+    }
+
+    /**
+     * Get an array of the subscription's invoices including pending ones.
+     *
+     * @param  array  $parameters
+     * @return \Illuminate\Support\Collection|\Laravel\Cashier\Invoice[]
+     */
+    public function invoicesIncludingPending(array $parameters = [])
+    {
+        return $this->invoices(true, $parameters);
+    }
+
+    /**
      * Sync the tax rates of the user to the subscription.
      *
      * @return void


### PR DESCRIPTION
This PR adds some new invoices methods to the Subscription model to retrieve invoices specific to that subscription. It uses the same API as the methods on the billable model.

```php
$invoices = $user->subscription()->invoices();
```