### PR TITLE
[13.x] Update customer details when tax id is collected

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -90,6 +90,12 @@ trait PerformsCharges
             ],
         ]);
 
+        // Make sure to collect address and name when Tax ID collection is enabled...
+        if ($payload['tax_id_collection']['enabled'] ?? false) {
+            $payload['customer_update']['address'] = 'auto';
+            $payload['customer_update']['name'] = 'auto';
+        }
+
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);
     }
 


### PR DESCRIPTION
When enabling tax id collection, Stripe will throw an exception when you don't explicitly enable customer name and billing address updates. 
