### PR TITLE
[13.x] Use default name for subscription factory

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -29,7 +29,7 @@ class SubscriptionFactory extends Factory
 
         return [
             (new $model)->getForeignKey() => ($model)::factory(),
-            'name' => $this->faker->title,
+            'name' => 'default',
             'stripe_id' => 'sub_'.Str::random(40),
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,


### PR DESCRIPTION
Probably better to use a default name here. When they need other subscriptions in their tests they can use specific names as I suspect everyone is already doing.