### PR TITLE
[13.x] Fallback to null quantity for metered price

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -850,7 +850,7 @@ class Subscription extends Model
             'stripe_id' => $stripeSubscriptionItem->id,
             'stripe_product' => $stripeSubscriptionItem->price->product,
             'stripe_price' => $stripeSubscriptionItem->price->id,
-            'quantity' => $stripeSubscriptionItem->quantity,
+            'quantity' => $stripeSubscriptionItem->quantity ?? null,
         ]);
 
         $this->unsetRelation('items');


### PR DESCRIPTION
Subscription items with a metered price don't have a quantity.

Fixes https://github.com/laravel/cashier-stripe/issues/1254