### PR TITLE
[13.x] Fix a stripe notice with SubscriptionBuilder and metered prices

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -294,7 +294,7 @@ class SubscriptionBuilder
                 'stripe_id' => $item->id,
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
-                'quantity' => $item->quantity,
+                'quantity' => $item->quantity ?? null,
             ]);
         }
 


### PR DESCRIPTION
This fixes a Stripe Notice (Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity) when using the SubscriptionBuilder with metered prices.
See my comments on #1254.