### PR TITLE
[13.x] Clarify that default_source is no longer returned

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -144,7 +144,7 @@ PR: https://github.com/laravel/cashier-stripe/pull/1077
 
 All support for the deprecated Stripe Sources API has been removed from Cashier. If you haven't already, we recommend that you upgrade to [the Payment Methods API](https://stripe.com/docs/payments/payment-methods).
 
-This also means that the `defaultPaymentMethod` call will no longer return the `default_source` of a customer as a fallback. 
+This also means that the `defaultPaymentMethod` method no longer returns the `default_source` of a customer. 
 
 ### New Payment Methods Support
 


### PR DESCRIPTION
This clarifies that the default source is no longer returned from `defaultPaymentMethod`. See https://github.com/laravel/cashier-stripe/issues/1264