### PR TITLE
[13.x] Fix enabling auto collecting in checkout

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -51,6 +51,12 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     {
         $customer = $owner->createOrGetStripeCustomer($customerOptions);
 
+        // Make sure to collect address and name when Tax ID collection is enabled...
+        if ($sessionOptions['tax_id_collection']['enabled'] ?? false) {
+            $sessionOptions['customer_update']['address'] = 'auto';
+            $sessionOptions['customer_update']['name'] = 'auto';
+        }
+
         $session = $owner->stripe()->checkout->sessions->create(array_merge([
             'customer' => $customer->id,
             'mode' => 'payment',

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -90,12 +90,6 @@ trait PerformsCharges
             ],
         ]);
 
-        // Make sure to collect address and name when Tax ID collection is enabled...
-        if ($payload['tax_id_collection']['enabled'] ?? false) {
-            $payload['customer_update']['address'] = 'auto';
-            $payload['customer_update']['name'] = 'auto';
-        }
-
         return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);
     }
 


### PR DESCRIPTION
This PR fixes an issue with Stripe Checkout when creating new subscriptions. When Tax ID collection is enabled, auto collection of the customer's address and name should be enabled. Previously this was only done for one-off charges.

Fixes https://github.com/laravel/cashier-stripe/issues/1269