### PR TITLE
Allow the base url for the Stripe API to be customised

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -7,6 +7,7 @@ use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
 use NumberFormatter;
+use Stripe\BaseStripeClient;
 use Stripe\Customer as StripeCustomer;
 use Stripe\StripeClient;
 
@@ -25,6 +26,13 @@ class Cashier
      * @var string
      */
     const STRIPE_VERSION = '2020-08-27';
+
+    /**
+     * The base url for the Stripe API
+     *
+     * @var string
+     */
+    public static $apiBaseUrl = BaseStripeClient::DEFAULT_API_BASE;
 
     /**
      * The custom currency formatter.
@@ -106,6 +114,7 @@ class Cashier
         return new StripeClient(array_merge([
             'api_key' => $options['api_key'] ?? config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
+            'api_base' => static::$apiBaseUrl,
         ], $options));
     }
 

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -28,7 +28,7 @@ class Cashier
     const STRIPE_VERSION = '2020-08-27';
 
     /**
-     * The base url for the Stripe API
+     * The base URL for the Stripe API
      *
      * @var string
      */


### PR DESCRIPTION
This PR allows the base url of the Stripe API to be changed if needed, such as when using https://github.com/stripe/stripe-mock.

If there's already a way to change the base url without needing this change then please let me know what I'm missing as I couldn't see a way to customise the `$options` parameter of the `stripe()` method.