### PR TITLE
[13.x] Skip tests without Stripe Secret

### DIFF
--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -12,6 +12,15 @@ abstract class FeatureTestCase extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        if (! getenv('STRIPE_SECRET')) {
+            $this->markTestSkipped('Stripe secret key not set.');
+        }
+
+        parent::setUp();
+    }
+
     protected function defineDatabaseMigrations()
     {
         $this->loadLaravelMigrations();

--- a/tests/Feature/MeteredBillingTest.php
+++ b/tests/Feature/MeteredBillingTest.php
@@ -30,6 +30,10 @@ class MeteredBillingTest extends FeatureTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
         parent::setUpBeforeClass();
 
         static::$productId = self::stripe()->products->create([

--- a/tests/Feature/MultipriceSubscriptionsTest.php
+++ b/tests/Feature/MultipriceSubscriptionsTest.php
@@ -38,6 +38,10 @@ class MultipriceSubscriptionsTest extends FeatureTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
         parent::setUpBeforeClass();
 
         static::$productId = self::stripe()->products->create([

--- a/tests/Feature/PendingUpdatesTest.php
+++ b/tests/Feature/PendingUpdatesTest.php
@@ -28,6 +28,10 @@ class PendingUpdatesTest extends FeatureTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
         parent::setUpBeforeClass();
 
         static::$productId = self::stripe()->products->create([

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -47,6 +47,10 @@ class SubscriptionsTest extends FeatureTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
         parent::setUpBeforeClass();
 
         static::$productId = self::stripe()->products->create([

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -23,6 +23,10 @@ class WebhooksTest extends FeatureTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
         parent::setUpBeforeClass();
 
         static::$productId = self::stripe()->products->create([


### PR DESCRIPTION
This will allow PR's to pass their test suite when submitted. Of course, we'll still only notice breakages after merging. Ideally, Stripe will provide tooling for us in the future to mock their API.