### PR TITLE
[13.x] Allow latest moneyphp version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, bcmath
           tools: composer:v2
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
+        "ext-bcmath": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/console": "^8.0",
         "illuminate/contracts": "^8.0",
@@ -26,7 +27,7 @@
         "illuminate/routing": "^8.0",
         "illuminate/support": "^8.0",
         "illuminate/view": "^8.0",
-        "moneyphp/money": "^3.2",
+        "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^7.39",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
This is a breaking change for some users, as moneyphp version 4 requires the bcmath extension