### PR TITLE
[14.x] Rename cancelled to canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,7 +586,7 @@
 - Add ability to ignore cashier routes ([#763](https://github.com/laravel/cashier-stripe/pull/763))
 
 ### Fixed
-- Only mount card element if payment has not succeeded or been cancelled ([#765](https://github.com/laravel/cashier-stripe/pull/765))
+- Only mount card element if payment has not succeeded or been canceled ([#765](https://github.com/laravel/cashier-stripe/pull/765))
 - Set off_session parameter to true when creating a new subscription ([#764](https://github.com/laravel/cashier-stripe/pull/764))
 
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -443,7 +443,7 @@ Exceptions may be thrown for the following methods: `charge`, `invoiceFor`, and 
 
 > If you would like to let Stripe host your payment verification pages, [you may configure this in your Stripe settings](https://dashboard.stripe.com/account/billing/automatic). However, you should still handle payment exceptions in your application and inform the user they will receive an email with further payment confirmation instructions.
 
-In addition, the subscription `create` method on the subscription builder previously immediately cancelled any subscription with an `incomplete` or `incomplete_expired` status and threw a `SubscriptionCreationFailed` exception when a subscription could not be created. This has been replaced with the behavior described above and the `SubscriptionCreationFailed` exception has been removed.
+In addition, the subscription `create` method on the subscription builder previously immediately canceled any subscription with an `incomplete` or `incomplete_expired` status and threw a `SubscriptionCreationFailed` exception when a subscription could not be created. This has been replaced with the behavior described above and the `SubscriptionCreationFailed` exception has been removed.
 
 #### The Subscription `stripe_status` Column
 
@@ -598,7 +598,7 @@ Previously, when a user attempted to change subscription plans and their payment
 
 However, Cashier will now catch the payment failure exception while allowing the plan swap to continue. The payment failure will be handled by Stripe and Stripe may attempt to retry the payment at a later time. If the payment fails during the final retry attempt, Stripe will execute the action you have configured in your billing settings: https://stripe.com/docs/billing/lifecycle#settings
 
-Therefore, you should ensure you have configured Cashier to handle Stripe's webhooks. When configured properly, this will allow Cashier to mark the subscription as cancelled when the final payment retry attempt fails and Stripe notifies your application via a webhook request. Please refer to our [instructions for setting up Stripe webhooks with Cashier.](https://laravel.com/docs/master/billing#handling-stripe-webhooks).
+Therefore, you should ensure you have configured Cashier to handle Stripe's webhooks. When configured properly, this will allow Cashier to mark the subscription as canceled when the final payment retry attempt fails and Stripe notifies your application via a webhook request. Please refer to our [instructions for setting up Stripe webhooks with Cashier.](https://laravel.com/docs/master/billing#handling-stripe-webhooks).
 
 
 ## Upgrading To 9.0 From 8.x

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -51,11 +51,11 @@
 
                 <div v-else-if="paymentIntent.status === 'canceled'">
                     <h2 class="text-xl mb-4 text-gray-600">
-                        Payment Cancelled
+                        Payment Canceled
                     </h2>
 
                     <p class="mb-6">
-                        This payment was cancelled.
+                        This payment was canceled.
                     </p>
                 </div>
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -60,7 +60,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             'customer' => $customer->id,
             'mode' => 'payment',
             'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
-            'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
+            'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=canceled',
             'payment_method_types' => ['card'],
         ], $sessionOptions));
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -203,7 +203,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle a cancelled customer from a Stripe subscription.
+     * Handle a canceled customer from a Stripe subscription.
      *
      * @param  array  $payload
      * @return \Symfony\Component\HttpFoundation\Response
@@ -214,7 +214,7 @@ class WebhookController extends Controller
             $user->subscriptions->filter(function ($subscription) use ($payload) {
                 return $subscription->stripe_id === $payload['data']['object']['id'];
             })->each(function ($subscription) {
-                $subscription->markAsCancelled();
+                $subscription->markAsCanceled();
             });
         }
 
@@ -246,7 +246,7 @@ class WebhookController extends Controller
     {
         if ($user = $this->getUserByStripeId($payload['data']['object']['id'])) {
             $user->subscriptions->each(function (Subscription $subscription) {
-                $subscription->skipTrial()->markAsCancelled();
+                $subscription->skipTrial()->markAsCanceled();
             });
 
             $user->forceFill([

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -117,11 +117,11 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Determine if the payment was cancelled.
+     * Determine if the payment was canceled.
      *
      * @return bool
      */
-    public function isCancelled()
+    public function isCanceled()
     {
         return $this->paymentIntent->status === StripePaymentIntent::STATUS_CANCELED;
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -274,7 +274,7 @@ class Subscription extends Model
      */
     public function recurring()
     {
-        return ! $this->onTrial() && ! $this->cancelled();
+        return ! $this->onTrial() && ! $this->canceled();
     }
 
     /**
@@ -285,7 +285,7 @@ class Subscription extends Model
      */
     public function scopeRecurring($query)
     {
-        $query->notOnTrial()->notCancelled();
+        $query->notOnTrial()->notCanceled();
     }
 
     /**
@@ -293,29 +293,29 @@ class Subscription extends Model
      *
      * @return bool
      */
-    public function cancelled()
+    public function canceled()
     {
         return ! is_null($this->ends_at);
     }
 
     /**
-     * Filter query by cancelled.
+     * Filter query by canceled.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeCancelled($query)
+    public function scopeCanceled($query)
     {
         $query->whereNotNull('ends_at');
     }
 
     /**
-     * Filter query by not cancelled.
+     * Filter query by not canceled.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeNotCancelled($query)
+    public function scopeNotCanceled($query)
     {
         $query->whereNull('ends_at');
     }
@@ -327,7 +327,7 @@ class Subscription extends Model
      */
     public function ended()
     {
-        return $this->cancelled() && ! $this->onGracePeriod();
+        return $this->canceled() && ! $this->onGracePeriod();
     }
 
     /**
@@ -338,7 +338,7 @@ class Subscription extends Model
      */
     public function scopeEnded($query)
     {
-        $query->cancelled()->notOnGracePeriod();
+        $query->canceled()->notOnGracePeriod();
     }
 
     /**
@@ -1015,7 +1015,7 @@ class Subscription extends Model
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
 
-        $this->markAsCancelled();
+        $this->markAsCanceled();
 
         return $this;
     }
@@ -1032,19 +1032,19 @@ class Subscription extends Model
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
 
-        $this->markAsCancelled();
+        $this->markAsCanceled();
 
         return $this;
     }
 
     /**
-     * Mark the subscription as cancelled.
+     * Mark the subscription as canceled.
      *
      * @return void
      *
      * @internal
      */
-    public function markAsCancelled()
+    public function markAsCanceled()
     {
         $this->fill([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
@@ -1053,7 +1053,7 @@ class Subscription extends Model
     }
 
     /**
-     * Resume the cancelled subscription.
+     * Resume the canceled subscription.
      *
      * @return $this
      *
@@ -1072,7 +1072,7 @@ class Subscription extends Model
 
         // Finally, we will remove the ending timestamp from the user's record in the
         // local database to indicate that the subscription is active again and is
-        // no longer "cancelled". Then we will save this record in the database.
+        // no longer "canceled". Then we shall save this record in the database.
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
             'ends_at' => null,

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -128,7 +128,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($user->subscription('main')->active());
-        $this->assertFalse($user->subscription('main')->cancelled());
+        $this->assertFalse($user->subscription('main')->canceled());
         $this->assertFalse($user->subscription('main')->onGracePeriod());
         $this->assertTrue($user->subscription('main')->recurring());
         $this->assertFalse($user->subscription('main')->ended());
@@ -138,7 +138,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->cancel();
 
         $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
         $this->assertTrue($subscription->onGracePeriod());
         $this->assertFalse($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -148,7 +148,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->fill(['ends_at' => Carbon::now()->subDays(5)])->save();
 
         $this->assertFalse($subscription->active());
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertFalse($subscription->recurring());
         $this->assertTrue($subscription->ended());
@@ -159,7 +159,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->resume();
 
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -450,7 +450,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -487,7 +487,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main'));
         $this->assertNotNull($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -513,7 +513,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -791,8 +791,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($user->subscriptions()->onTrial()->exists());
         $this->assertTrue($user->subscriptions()->notOnTrial()->exists());
         $this->assertTrue($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -805,8 +805,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($user->subscriptions()->onTrial()->exists());
         $this->assertTrue($user->subscriptions()->notOnTrial()->exists());
         $this->assertTrue($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -819,8 +819,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -833,8 +833,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertTrue($user->subscriptions()->cancelled()->exists());
-        $this->assertFalse($user->subscriptions()->notCancelled()->exists());
+        $this->assertTrue($user->subscriptions()->canceled()->exists());
+        $this->assertFalse($user->subscriptions()->notCanceled()->exists());
         $this->assertTrue($user->subscriptions()->onGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -847,8 +847,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertTrue($user->subscriptions()->cancelled()->exists());
-        $this->assertFalse($user->subscriptions()->notCancelled()->exists());
+        $this->assertTrue($user->subscriptions()->canceled()->exists());
+        $this->assertFalse($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->ended()->exists());
@@ -925,11 +925,11 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertTrue($user->refresh()->subscribed());
 
-        $subscription->markAsCancelled();
+        $subscription->markAsCanceled();
 
         $this->assertFalse($user->refresh()->subscribed());
 
-        $subscription->markAsCancelled();
+        $subscription->markAsCanceled();
 
         $user->subscriptions()->create([
             'name' => 'default',
@@ -944,9 +944,9 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->refresh()->subscribed());
     }
 
-    public function test_subscriptions_can_be_cancelled_at_a_specific_time()
+    public function test_subscriptions_can_be_canceled_at_a_specific_time()
     {
-        $user = $this->createCustomer('subscriptions_can_be_cancelled_at_a_specific_time');
+        $user = $this->createCustomer('subscriptions_can_be_canceled_at_a_specific_time');
 
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
 

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -204,12 +204,12 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
-    public function test_cancelled_subscription_is_properly_reactivated()
+    public function test_canceled_subscription_is_properly_reactivated()
     {
-        $user = $this->createCustomer('cancelled_subscription_is_properly_reactivated');
+        $user = $this->createCustomer('canceled_subscription_is_properly_reactivated');
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa')->cancel();
 
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -230,15 +230,15 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertFalse($subscription->fresh()->cancelled(), 'Subscription is still cancelled.');
+        $this->assertFalse($subscription->fresh()->canceled(), 'Subscription is still canceled.');
     }
 
-    public function test_subscription_is_marked_as_cancelled_when_deleted_in_stripe()
+    public function test_subscription_is_marked_as_canceled_when_deleted_in_stripe()
     {
-        $user = $this->createCustomer('subscription_is_marked_as_cancelled_when_deleted_in_stripe');
+        $user = $this->createCustomer('subscription_is_marked_as_canceled_when_deleted_in_stripe');
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
 
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -252,7 +252,7 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertTrue($subscription->fresh()->cancelled(), 'Subscription is still active.');
+        $this->assertTrue($subscription->fresh()->canceled(), 'Subscription is still active.');
     }
 
     public function test_subscription_is_deleted_when_status_is_incomplete_expired()

--- a/tests/Unit/PaymentTest.php
+++ b/tests/Unit/PaymentTest.php
@@ -27,13 +27,13 @@ class PaymentTest extends TestCase
         $this->assertTrue($payment->requiresAction());
     }
 
-    public function test_it_can_return_its_cancelled_status()
+    public function test_it_can_return_its_canceled_status()
     {
         $paymentIntent = new PaymentIntent();
         $paymentIntent->status = Subscription::STATUS_CANCELED;
         $payment = new Payment($paymentIntent);
 
-        $this->assertTrue($payment->isCancelled());
+        $this->assertTrue($payment->isCanceled());
     }
 
     public function test_it_can_return_its_succeeded_status()


### PR DESCRIPTION
This PR contains breaking changes but I believe it's a sensible to make. Stripe maintains the American "canceled" while we in Cashier use the British "cancelled". I believe bringing this on-par with Stripe will be easier to make the translation between Cashier/Stripe.

Breaking changes are not always wanted and there's the question if this actually benefits end users. I believe it does as it prevents confustion like in #1278 and other situations I've seen over the past years. Besides, the adjustments are very easy to make.
