### PR TITLE
Functionality:  pause_collection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, bcmath
           tools: composer:v2
           coverage: none
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 composer.lock
 /phpunit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,7 +580,7 @@
 - Add ability to ignore cashier routes ([#763](https://github.com/laravel/cashier-stripe/pull/763))
 
 ### Fixed
-- Only mount card element if payment has not succeeded or been cancelled ([#765](https://github.com/laravel/cashier-stripe/pull/765))
+- Only mount card element if payment has not succeeded or been canceled ([#765](https://github.com/laravel/cashier-stripe/pull/765))
 - Set off_session parameter to true when creating a new subscription ([#764](https://github.com/laravel/cashier-stripe/pull/764))
 
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -443,7 +443,7 @@ Exceptions may be thrown for the following methods: `charge`, `invoiceFor`, and 
 
 > If you would like to let Stripe host your payment verification pages, [you may configure this in your Stripe settings](https://dashboard.stripe.com/account/billing/automatic). However, you should still handle payment exceptions in your application and inform the user they will receive an email with further payment confirmation instructions.
 
-In addition, the subscription `create` method on the subscription builder previously immediately cancelled any subscription with an `incomplete` or `incomplete_expired` status and threw a `SubscriptionCreationFailed` exception when a subscription could not be created. This has been replaced with the behavior described above and the `SubscriptionCreationFailed` exception has been removed.
+In addition, the subscription `create` method on the subscription builder previously immediately canceled any subscription with an `incomplete` or `incomplete_expired` status and threw a `SubscriptionCreationFailed` exception when a subscription could not be created. This has been replaced with the behavior described above and the `SubscriptionCreationFailed` exception has been removed.
 
 #### The Subscription `stripe_status` Column
 
@@ -598,7 +598,7 @@ Previously, when a user attempted to change subscription plans and their payment
 
 However, Cashier will now catch the payment failure exception while allowing the plan swap to continue. The payment failure will be handled by Stripe and Stripe may attempt to retry the payment at a later time. If the payment fails during the final retry attempt, Stripe will execute the action you have configured in your billing settings: https://stripe.com/docs/billing/lifecycle#settings
 
-Therefore, you should ensure you have configured Cashier to handle Stripe's webhooks. When configured properly, this will allow Cashier to mark the subscription as cancelled when the final payment retry attempt fails and Stripe notifies your application via a webhook request. Please refer to our [instructions for setting up Stripe webhooks with Cashier.](https://laravel.com/docs/master/billing#handling-stripe-webhooks).
+Therefore, you should ensure you have configured Cashier to handle Stripe's webhooks. When configured properly, this will allow Cashier to mark the subscription as canceled when the final payment retry attempt fails and Stripe notifies your application via a webhook request. Please refer to our [instructions for setting up Stripe webhooks with Cashier.](https://laravel.com/docs/master/billing#handling-stripe-webhooks).
 
 
 ## Upgrading To 9.0 From 8.x

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
+        "ext-bcmath": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/console": "^8.0",
         "illuminate/contracts": "^8.0",
@@ -26,7 +27,7 @@
         "illuminate/routing": "^8.0",
         "illuminate/support": "^8.0",
         "illuminate/view": "^8.0",
-        "moneyphp/money": "^3.2",
+        "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^7.39",
         "symfony/http-kernel": "^5.0",

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Subscription;
+use Stripe\Price as StripePrice;
 use Stripe\Subscription as StripeSubscription;
 
 class SubscriptionFactory extends Factory
@@ -42,13 +43,13 @@ class SubscriptionFactory extends Factory
     /**
      * Add a price identifier to the model.
      *
-     * @param  string  $price
+     * @param  \Stripe\Price|string  $price
      * @return $this
      */
     public function withPrice($price)
     {
         return $this->state([
-            'stripe_price' => $price,
+            'stripe_price' => $price instanceof StripePrice ? $price->id : $price,
         ]);
     }
 
@@ -87,6 +88,7 @@ class SubscriptionFactory extends Factory
     {
         return $this->state([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => now(),
         ]);
     }
 

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -2,10 +2,12 @@
 
 namespace Laravel\Cashier\Database\Factories;
 
+use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\WithPauseCollection;
 use Laravel\Cashier\Subscription;
 use Stripe\Price as StripePrice;
 use Stripe\Subscription as StripeSubscription;
@@ -35,6 +37,7 @@ class SubscriptionFactory extends Factory
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,
             'quantity' => null,
+            'pause_collection' => null,
             'trial_ends_at' => null,
             'ends_at' => null,
         ];
@@ -138,5 +141,34 @@ class SubscriptionFactory extends Factory
         return $this->state([
             'stripe_status' => StripeSubscription::STATUS_UNPAID,
         ]);
+    }
+
+    /**
+     * Mark the subscription as paused.
+     *
+     * @return $this
+     */
+    public function paused( ?string $behavior = null, ?Carbon $resumesAt = null ) {
+        $pauseCollection = [
+            'behavior' => $behavior ?? WithPauseCollection::BEHAVIOR_VOID,
+        ];
+        if ( $resumesAt ) {
+            $pauseCollection['resumes_at'] = $resumesAt->timestamp;
+        }
+
+        return $this->state( [
+            'pause_collection' => $pauseCollection,
+        ] );
+    }
+
+    /**
+     * Mark the subscription as not paused.
+     *
+     * @return $this
+     */
+    public function unpaused() {
+        return $this->state( [
+            'pause_collection' => null,
+        ] );
     }
 }

--- a/database/migrations/2019_05_03_000004_add_pause_collection_to_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000004_add_pause_collection_to_subscriptions_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPauseCollectionToSubscriptionsTable extends Migration
+{
+
+    /**
+     * Get used table name.
+     *
+     * @return mixed
+     */
+    protected function getTableName() {
+        $modelClass = \Laravel\Cashier\Cashier::$subscriptionModel;
+
+        return (new $modelClass)->getTable();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table( $this->getTableName(), function ( Blueprint $table ) {
+            $table->json( 'pause_collection' )->nullable()
+                  ->after( 'quantity' );
+        } );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down() {
+        Schema::table( $this->getTableName(), function ( Blueprint $table ) {
+            $table->dropColumn( 'pause_collection' );
+        } );
+    }
+}

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -51,11 +51,11 @@
 
                 <div v-else-if="paymentIntent.status === 'canceled'">
                     <h2 class="text-xl mb-4 text-gray-600">
-                        Payment Cancelled
+                        Payment Canceled
                     </h2>
 
                     <p class="mb-6">
-                        This payment was cancelled.
+                        This payment was canceled.
                     </p>
                 </div>
 

--- a/src/Concerns/UsesPauseCollection.php
+++ b/src/Concerns/UsesPauseCollection.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Carbon\Carbon;
+use Laravel\Cashier\Contracts\WithPauseCollection;
+use LogicException;
+
+/**
+ * @property array|null $pause_collection
+ *
+ * @extends WithPauseCollection
+ */
+trait UsesPauseCollection {
+
+    /**
+     * @inerhitDoc
+     */
+    public function pause(string $behavior, ?Carbon $resumesAt = null)
+    {
+        if ($this->canceled()) {
+            throw new LogicException('Unable to pause subscription that is cancelled.');
+        }
+
+        $payload = [ 'behavior' => $behavior ];
+        if ($resumesAt) {
+            $payload['resumes_at'] = $resumesAt->timestamp;
+        }
+        $stripeSubscription = $this->updateStripeSubscription([ 'pause_collection' => $payload, ]);
+
+        $this->fill([
+            'pause_collection' => $stripeSubscription->pause_collection,
+        ])->save();
+
+        return $this;
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function pauseBehaviorMarkUncollectible(?Carbon $resumesAt = null)
+    {
+        return $this->pause(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE, $resumesAt);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function pauseBehaviorKeepAsDraft(?Carbon $resumesAt = null)
+    {
+        return $this->pause(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT, $resumesAt);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function pauseBehaviorVoid(?Carbon $resumesAt = null)
+    {
+        return $this->pause(WithPauseCollection::BEHAVIOR_VOID, $resumesAt);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function unpause()
+    {
+        if (!$this->paused()) {
+            throw new LogicException('Unable to unpause subscription that is not paused.');
+        }
+
+        $stripeSubscription = $this->updateStripeSubscription([ 'pause_collection' => '', ]);
+
+        $this->fill([
+            'pause_collection' => $stripeSubscription->pause_collection,
+        ])->save();
+
+        return $this;
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function syncStripePauseCollection()
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $this->pause_collection = $subscription->pause_collection ? $subscription->pause_collection->toArray() : null;
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function paused(?string $behavior = null): bool
+    {
+        $hasBehavior = is_array($this->pause_collection) && !empty($this->pause_collection['behavior']);
+        if ($behavior) {
+            return $hasBehavior && $this->pause_collection['behavior'] === $behavior;
+        }
+
+        return $hasBehavior;
+    }
+
+    /**
+     * Filter query by pause_collection behavior.
+     *
+     * @param Builder $query
+     * @param string|null $behavior
+     *
+     * @return Builder
+     */
+    public function scopePaused($query, ?string $behavior = null): Builder
+    {
+        if (!$behavior) {
+            return $query->whereNotNull('pause_collection')
+                         ->where('pause_collection->behavior', '!=', '')
+                         ->whereNotNull('pause_collection->behavior');
+        }
+
+        return $query->where('pause_collection->behavior', '=', $behavior);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function notPaused(?string $behavior = null): bool
+    {
+        return !$this->paused($behavior);
+    }
+
+    /**
+     * Filter query by not paused payment collection.
+     *
+     * @param Builder $query
+     * @param string|null $behavior
+     *
+     * @return Builder
+     */
+    public function scopeNotPaused($query, ?string $behavior = null): Builder
+    {
+        if (!$behavior) {
+            return $query->where(function ($query) {
+                $query->whereNull('pause_collection')
+                      ->orWhere('pause_collection->behavior', '=', '')
+                      ->orWhereNull('pause_collection->behavior');
+            });
+        }
+
+        return $query->where(function ($query) use ($behavior) {
+            $query->where('pause_collection->behavior', '!=', $behavior)
+                  ->orWhereNull('pause_collection')
+                  ->orWhereNull('pause_collection->behavior');
+        });
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function pauseResumesAtTimestamp(?string $behavior = null): ?string
+    {
+        if (!$this->paused($behavior) || empty($this->pause_collection['resumes_at'])) {
+            return null;
+        }
+
+        return $this->pause_collection['resumes_at'];
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function pauseResumesAt(?string $behavior = null): ?Carbon
+    {
+        if ($timestamp = $this->pauseResumesAtTimestamp($behavior)) {
+            return Carbon::createFromTimestamp($timestamp);
+        }
+
+        return null;
+    }
+}

--- a/src/Contracts/WithPauseCollection.php
+++ b/src/Contracts/WithPauseCollection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Cashier\Contracts;
+
+use Carbon\Carbon;
+
+interface WithPauseCollection {
+
+    const BEHAVIOR_MARK_UNCOLLECTIBLE = 'mark_uncollectible';
+    const BEHAVIOR_KEEP_AS_DRAFT      = 'keep_as_draft';
+    const BEHAVIOR_VOID               = 'void';
+
+    /**
+     * Retrieve and save the Stripe pause_collection of the subscription.
+     *
+     * @return static
+     */
+    public function syncStripePauseCollection();
+
+    /**
+     * Pause subscription.
+     *
+     * @param string $behavior
+     * @param Carbon|null $resumesAt
+     *
+     * @return $this
+     *
+     * @throws \LogicException
+     * @throws \Stripe\Exception\ApiErrorException
+     */
+    public function pause(string $behavior, ?Carbon $resumesAt = null);
+
+    /**
+     * Pause with behavior mark_uncollectible.
+     *
+     * @param Carbon|null $resumesAt
+     *
+     * @return $this
+     */
+    public function pauseBehaviorMarkUncollectible(?Carbon $resumesAt = null);
+
+    /**
+     * Pause with behavior keep_as_draft.
+     *
+     * @param Carbon|null $resumesAt
+     *
+     * @return $this
+     */
+    public function pauseBehaviorKeepAsDraft(?Carbon $resumesAt = null);
+
+    /**
+     * Pause with behavior void.
+     *
+     * @param Carbon|null $resumesAt
+     *
+     * @return $this
+     */
+    public function pauseBehaviorVoid(?Carbon $resumesAt = null);
+
+    /**
+     * Resume the paused subscription.
+     *
+     * @return $this
+     *
+     * @throws \LogicException
+     * @throws \Stripe\Exception\ApiErrorException
+     */
+    public function unpause();
+
+    /**
+     * Check is current subscription paused.
+     *
+     * @param string|null $behavior - Check specific behavior, if null will check any behavior.
+     *
+     * @return bool
+     */
+    public function paused(?string $behavior = null): bool;
+
+    /**
+     * Check is current subscription not paused.
+     *
+     * @param string|null $behavior - Check specific behavior, if null will check any behavior.
+     *
+     * @return bool
+     */
+    public function notPaused(?string $behavior = null): bool;
+
+    /**
+     * Get auto pause resumes timestamp.
+     *
+     * @param string|null $behavior
+     *
+     * @return string|null
+     */
+    public function pauseResumesAtTimestamp(?string $behavior = null): ?string;
+
+    /**
+     * Get auto pause resumes datetime.
+     *
+     * @param string|null $behavior - Check specific behavior, if null will check any behavior.
+     *
+     * @return Carbon|null
+     */
+    public function pauseResumesAt(?string $behavior = null): ?Carbon;
+
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -203,7 +203,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle a cancelled customer from a Stripe subscription.
+     * Handle a canceled customer from a Stripe subscription.
      *
      * @param  array  $payload
      * @return \Symfony\Component\HttpFoundation\Response
@@ -214,7 +214,7 @@ class WebhookController extends Controller
             $user->subscriptions->filter(function ($subscription) use ($payload) {
                 return $subscription->stripe_id === $payload['data']['object']['id'];
             })->each(function ($subscription) {
-                $subscription->markAsCancelled();
+                $subscription->markAsCanceled();
             });
         }
 
@@ -246,7 +246,7 @@ class WebhookController extends Controller
     {
         if ($user = $this->getUserByStripeId($payload['data']['object']['id'])) {
             $user->subscriptions->each(function (Subscription $subscription) {
-                $subscription->skipTrial()->markAsCancelled();
+                $subscription->skipTrial()->markAsCanceled();
             });
 
             $user->forceFill([

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -86,6 +86,7 @@ class WebhookController extends Controller
                     'stripe_status' => $data['status'],
                     'stripe_price' => $isSinglePrice ? $firstItem['price']['id'] : null,
                     'quantity' => $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null,
+                    'pause_collection' => $data['pause_collection'] ?? null,
                     'trial_ends_at' => $trialEndsAt,
                     'ends_at' => null,
                 ]);
@@ -174,6 +175,11 @@ class WebhookController extends Controller
             // Status...
             if (isset($data['status'])) {
                 $subscription->stripe_status = $data['status'];
+            }
+
+            // Pause collection...
+            if ( array_key_exists( 'pause_collection', $data ) ) {
+                $subscription->pause_collection = $data['pause_collection'];
             }
 
             $subscription->save();

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -117,13 +117,25 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Determine if the payment was cancelled.
+     * Determine if the payment was canceled.
      *
      * @return bool
      */
-    public function isCancelled()
+    public function isCanceled()
     {
         return $this->paymentIntent->status === StripePaymentIntent::STATUS_CANCELED;
+    }
+
+    /**
+     * Determine if the payment was canceled.
+     *
+     * @return bool
+     *
+     * @deprecated Use isCanceled instead.
+     */
+    public function isCancelled()
+    {
+        return $this->isCanceled();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -224,7 +224,7 @@ class Subscription extends Model
      */
     public function active()
     {
-        return (is_null($this->ends_at) || $this->onGracePeriod()) &&
+        return ! $this->ended() &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE_EXPIRED &&
             (! Cashier::$deactivatePastDue || $this->stripe_status !== StripeSubscription::STATUS_PAST_DUE) &&

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -274,7 +274,7 @@ class Subscription extends Model
      */
     public function recurring()
     {
-        return ! $this->onTrial() && ! $this->cancelled();
+        return ! $this->onTrial() && ! $this->canceled();
     }
 
     /**
@@ -285,7 +285,7 @@ class Subscription extends Model
      */
     public function scopeRecurring($query)
     {
-        $query->notOnTrial()->notCancelled();
+        $query->notOnTrial()->notCanceled();
     }
 
     /**
@@ -293,31 +293,69 @@ class Subscription extends Model
      *
      * @return bool
      */
-    public function cancelled()
+    public function canceled()
     {
         return ! is_null($this->ends_at);
     }
 
     /**
-     * Filter query by cancelled.
+     * Determine if the subscription is no longer active.
+     *
+     * @return bool
+     *
+     * @deprecated Use canceled instead.
+     */
+    public function cancelled()
+    {
+        return $this->canceled();
+    }
+
+    /**
+     * Filter query by canceled.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeCancelled($query)
+    public function scopeCanceled($query)
     {
         $query->whereNotNull('ends_at');
     }
 
     /**
-     * Filter query by not cancelled.
+     * Filter query by canceled.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     *
+     * @deprecated Use scopeCanceled instead.
+     */
+    public function scopeCancelled($query)
+    {
+        $this->scopeCanceled($query);
+    }
+
+    /**
+     * Filter query by not canceled.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeNotCancelled($query)
+    public function scopeNotCanceled($query)
     {
         $query->whereNull('ends_at');
+    }
+
+    /**
+     * Filter query by not canceled.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     *
+     * @deprecated Use scopeNotCanceled instead.
+     */
+    public function scopeNotCancelled($query)
+    {
+        $this->scopeNotCanceled($query);
     }
 
     /**
@@ -327,7 +365,7 @@ class Subscription extends Model
      */
     public function ended()
     {
-        return $this->cancelled() && ! $this->onGracePeriod();
+        return $this->canceled() && ! $this->onGracePeriod();
     }
 
     /**
@@ -338,7 +376,7 @@ class Subscription extends Model
      */
     public function scopeEnded($query)
     {
-        $query->cancelled()->notOnGracePeriod();
+        $query->canceled()->notOnGracePeriod();
     }
 
     /**
@@ -1015,7 +1053,7 @@ class Subscription extends Model
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
 
-        $this->markAsCancelled();
+        $this->markAsCanceled();
 
         return $this;
     }
@@ -1032,19 +1070,19 @@ class Subscription extends Model
             'prorate' => $this->prorateBehavior() === 'create_prorations',
         ]);
 
-        $this->markAsCancelled();
+        $this->markAsCanceled();
 
         return $this;
     }
 
     /**
-     * Mark the subscription as cancelled.
+     * Mark the subscription as canceled.
      *
      * @return void
      *
      * @internal
      */
-    public function markAsCancelled()
+    public function markAsCanceled()
     {
         $this->fill([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
@@ -1053,7 +1091,21 @@ class Subscription extends Model
     }
 
     /**
-     * Resume the cancelled subscription.
+     * Mark the subscription as canceled.
+     *
+     * @return void
+     *
+     * @deprecated Use markAsCanceled instead.
+     *
+     * @internal
+     */
+    public function markAsCancelled()
+    {
+        $this->markAsCanceled();
+    }
+
+    /**
+     * Resume the canceled subscription.
      *
      * @return $this
      *
@@ -1072,7 +1124,7 @@ class Subscription extends Model
 
         // Finally, we will remove the ending timestamp from the user's record in the
         // local database to indicate that the subscription is active again and is
-        // no longer "cancelled". Then we will save this record in the database.
+        // no longer "canceled". Then we shall save this record in the database.
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
             'ends_at' => null,

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -12,6 +12,8 @@ use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
+use Laravel\Cashier\Concerns\UsesPauseCollection;
+use Laravel\Cashier\Contracts\WithPauseCollection;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
@@ -21,12 +23,13 @@ use Stripe\Subscription as StripeSubscription;
 /**
  * @property \Laravel\Cashier\Billable|\Illuminate\Database\Eloquent\Model $owner
  */
-class Subscription extends Model
+class Subscription extends Model implements WithPauseCollection
 {
     use AllowsCoupons;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
+    use UsesPauseCollection;
 
     /**
      * The attributes that are not mass assignable.
@@ -49,6 +52,7 @@ class Subscription extends Model
      */
     protected $casts = [
         'quantity' => 'integer',
+        'pause_collection' => 'array',
     ];
 
     /**

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -128,7 +128,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($user->subscription('main')->active());
-        $this->assertFalse($user->subscription('main')->cancelled());
+        $this->assertFalse($user->subscription('main')->canceled());
         $this->assertFalse($user->subscription('main')->onGracePeriod());
         $this->assertTrue($user->subscription('main')->recurring());
         $this->assertFalse($user->subscription('main')->ended());
@@ -138,7 +138,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->cancel();
 
         $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
         $this->assertTrue($subscription->onGracePeriod());
         $this->assertFalse($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -148,7 +148,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->fill(['ends_at' => Carbon::now()->subDays(5)])->save();
 
         $this->assertFalse($subscription->active());
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertFalse($subscription->recurring());
         $this->assertTrue($subscription->ended());
@@ -159,7 +159,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->resume();
 
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -450,7 +450,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -487,7 +487,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main'));
         $this->assertNotNull($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -513,7 +513,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main', static::$priceId));
         $this->assertFalse($user->subscribed('main', static::$otherPriceId));
         $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->recurring());
         $this->assertFalse($subscription->ended());
@@ -791,8 +791,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($user->subscriptions()->onTrial()->exists());
         $this->assertTrue($user->subscriptions()->notOnTrial()->exists());
         $this->assertTrue($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -805,8 +805,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($user->subscriptions()->onTrial()->exists());
         $this->assertTrue($user->subscriptions()->notOnTrial()->exists());
         $this->assertTrue($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -819,8 +819,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertFalse($user->subscriptions()->cancelled()->exists());
-        $this->assertTrue($user->subscriptions()->notCancelled()->exists());
+        $this->assertFalse($user->subscriptions()->canceled()->exists());
+        $this->assertTrue($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -833,8 +833,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertTrue($user->subscriptions()->cancelled()->exists());
-        $this->assertFalse($user->subscriptions()->notCancelled()->exists());
+        $this->assertTrue($user->subscriptions()->canceled()->exists());
+        $this->assertFalse($user->subscriptions()->notCanceled()->exists());
         $this->assertTrue($user->subscriptions()->onGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertFalse($user->subscriptions()->ended()->exists());
@@ -847,8 +847,8 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->onTrial()->exists());
         $this->assertFalse($user->subscriptions()->notOnTrial()->exists());
         $this->assertFalse($user->subscriptions()->recurring()->exists());
-        $this->assertTrue($user->subscriptions()->cancelled()->exists());
-        $this->assertFalse($user->subscriptions()->notCancelled()->exists());
+        $this->assertTrue($user->subscriptions()->canceled()->exists());
+        $this->assertFalse($user->subscriptions()->notCanceled()->exists());
         $this->assertFalse($user->subscriptions()->onGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->notOnGracePeriod()->exists());
         $this->assertTrue($user->subscriptions()->ended()->exists());
@@ -925,11 +925,11 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertTrue($user->refresh()->subscribed());
 
-        $subscription->markAsCancelled();
+        $subscription->markAsCanceled();
 
         $this->assertFalse($user->refresh()->subscribed());
 
-        $subscription->markAsCancelled();
+        $subscription->markAsCanceled();
 
         $user->subscriptions()->create([
             'name' => 'default',
@@ -944,9 +944,9 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->refresh()->subscribed());
     }
 
-    public function test_subscriptions_can_be_cancelled_at_a_specific_time()
+    public function test_subscriptions_can_be_canceled_at_a_specific_time()
     {
-        $user = $this->createCustomer('subscriptions_can_be_cancelled_at_a_specific_time');
+        $user = $this->createCustomer('subscriptions_can_be_canceled_at_a_specific_time');
 
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
 

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -204,12 +204,12 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
-    public function test_cancelled_subscription_is_properly_reactivated()
+    public function test_canceled_subscription_is_properly_reactivated()
     {
-        $user = $this->createCustomer('cancelled_subscription_is_properly_reactivated');
+        $user = $this->createCustomer('canceled_subscription_is_properly_reactivated');
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa')->cancel();
 
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->canceled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -230,15 +230,15 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertFalse($subscription->fresh()->cancelled(), 'Subscription is still cancelled.');
+        $this->assertFalse($subscription->fresh()->canceled(), 'Subscription is still canceled.');
     }
 
-    public function test_subscription_is_marked_as_cancelled_when_deleted_in_stripe()
+    public function test_subscription_is_marked_as_canceled_when_deleted_in_stripe()
     {
-        $user = $this->createCustomer('subscription_is_marked_as_cancelled_when_deleted_in_stripe');
+        $user = $this->createCustomer('subscription_is_marked_as_canceled_when_deleted_in_stripe');
         $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
 
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->canceled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -252,7 +252,7 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertTrue($subscription->fresh()->cancelled(), 'Subscription is still active.');
+        $this->assertTrue($subscription->fresh()->canceled(), 'Subscription is still active.');
     }
 
     public function test_subscription_is_deleted_when_status_is_incomplete_expired()

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -2,12 +2,15 @@
 
 namespace Laravel\Cashier\Tests\Fixtures;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Model;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Cashier\Billable;
+use Orchestra\Testbench\Factories\UserFactory;
 
 class User extends Model
 {
+    use HasFactory;
     use Billable, Notifiable;
 
     public $taxRates = [];
@@ -51,5 +54,14 @@ class User extends Model
     public function priceTaxRates()
     {
         return $this->priceTaxRates;
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    protected static function newFactory() {
+        return UserFactory::new();
     }
 }

--- a/tests/Unit/PaymentTest.php
+++ b/tests/Unit/PaymentTest.php
@@ -27,13 +27,13 @@ class PaymentTest extends TestCase
         $this->assertTrue($payment->requiresAction());
     }
 
-    public function test_it_can_return_its_cancelled_status()
+    public function test_it_can_return_its_canceled_status()
     {
         $paymentIntent = new PaymentIntent();
         $paymentIntent->status = Subscription::STATUS_CANCELED;
         $payment = new Payment($paymentIntent);
 
-        $this->assertTrue($payment->isCancelled());
+        $this->assertTrue($payment->isCanceled());
     }
 
     public function test_it_can_return_its_succeeded_status()

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Cashier\Tests\Unit;
 
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
+use Laravel\Cashier\Contracts\WithPauseCollection;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use Laravel\Cashier\Subscription;
 use PHPUnit\Framework\TestCase;
@@ -140,5 +142,67 @@ class SubscriptionTest extends TestCase
 
         $this->assertTrue($subscription->hasMultiplePrices());
         $this->assertFalse($subscription->hasSinglePrice());
+    }
+
+    public function test_we_can_check_if_a_subscription_is_not_paused() {
+        $subscription = new Subscription( [ 'pause_collection' => null ] );
+
+        // Generally ...
+        $this->assertFalse( $subscription->paused() );
+        $this->assertTrue( $subscription->notPaused() );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp() );
+        $this->assertNull( $subscription->pauseResumesAt() );
+
+        // Behavior "void" ...
+        $this->assertFalse( $subscription->paused( WithPauseCollection::BEHAVIOR_VOID ) );
+        $this->assertTrue( $subscription->notPaused( WithPauseCollection::BEHAVIOR_VOID ) );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_VOID ) );
+        $this->assertNull( $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_VOID ) );
+
+        // Behavior "mark_uncollectible" ...
+        $this->assertFalse( $subscription->paused( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertTrue( $subscription->notPaused( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertNull( $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+
+        // Behavior "keep_as_draft" ...
+        $this->assertFalse( $subscription->paused( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertTrue( $subscription->notPaused( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertNull( $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+    }
+
+    public function test_we_can_check_if_a_subscription_is_paused() {
+        $resumesAt    = Carbon::now()->addWeek();
+        $subscription = new Subscription( [
+            'pause_collection' => [
+                'behavior'   => WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE,
+                'resumes_at' => $resumesAt->timestamp,
+            ],
+        ] );
+
+        // Generally ...
+        $this->assertTrue( $subscription->paused() );
+        $this->assertFalse( $subscription->notPaused() );
+        $this->assertEquals( $resumesAt->timestamp, $subscription->pauseResumesAtTimestamp() );
+        $this->assertEquals( $resumesAt->timestamp, $subscription->pauseResumesAt()->timestamp );
+
+        // Behavior "void" ...
+        $this->assertFalse( $subscription->paused( WithPauseCollection::BEHAVIOR_VOID ) );
+        $this->assertTrue( $subscription->notPaused( WithPauseCollection::BEHAVIOR_VOID ) );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertNull( $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+
+        // Behavior "mark_uncollectible" ...
+        $this->assertTrue( $subscription->paused( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertFalse( $subscription->notPaused( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertEquals( $resumesAt->timestamp, $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE ) );
+        $this->assertEquals( $resumesAt->timestamp, $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE )->timestamp );
+
+        // Behavior "keep_as_draft" ...
+        $this->assertFalse( $subscription->paused( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertTrue( $subscription->notPaused( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertNull( $subscription->pauseResumesAtTimestamp( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
+        $this->assertNull( $subscription->pauseResumesAt( WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT ) );
     }
 }


### PR DESCRIPTION
Support Pausing and Resuming a Subscriptions ([Pause payment collection](https://stripe.com/docs/billing/subscriptions/pause)).

Subscription api:
```
$subscription = $user->subscription( 'main' );

$resumesAt = Carbon::now()->addWeek();
$subscription->pause(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE, $resumesAt);
$subscription->unpause();

$subscription->pauseBehaviorMarkUncollectible($resumesAt);
$subscription->pauseBehaviorKeepAsDraft($resumesAt);
$subscription->pauseBehaviorVoid($resumesAt);

$subscription->syncStripePauseCollection();

$subscription->paused());
$subscription->paused(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE);
$subscription->paused(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT);
$subscription->paused(WithPauseCollection::BEHAVIOR_VOID);

$subscription->pauseResumesAtTimestamp();
$subscription->pauseResumesAtTimestamp(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE);
$subscription->pauseResumesAtTimestamp(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT);
$subscription->pauseResumesAtTimestamp(WithPauseCollection::BEHAVIOR_VOID);

$subscription->pauseResumesAt();
$subscription->pauseResumesAt(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE);
$subscription->pauseResumesAt(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT);
$subscription->pauseResumesAt(WithPauseCollection::BEHAVIOR_VOID);
```

Subscription query api:

```
Subscription::query()->paused()->count();
Subscription::query()->notPaused()->count();

Subscription::query()->paused(WithPauseCollection::BEHAVIOR_VOID)->count();
Subscription::query()->notPaused(WithPauseCollection::BEHAVIOR_VOID)->count();

Subscription::query()->paused(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE)->count();
Subscription::query()->notPaused(WithPauseCollection::BEHAVIOR_MARK_UNCOLLECTIBLE)->count();

Subscription::query()->paused(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT)->count();
Subscription::query()->notPaused(WithPauseCollection::BEHAVIOR_KEEP_AS_DRAFT)->count();
```
