### PR TITLE
[13.x] Remove bcmath extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "ext-bcmath": "*",
         "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/console": "^8.0",
         "illuminate/contracts": "^8.0",


### PR DESCRIPTION
Although my reasoning in https://github.com/laravel/cashier-stripe/pull/1280 was correct, we in fact don't need to do this directly in Cashier because `moneyphp/money` will already require this.