### PR TITLE
Fix #1296

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -97,7 +97,7 @@ trait ManagesSubscriptions
      */
     public function subscription($name = 'default')
     {
-        return $this->subscriptions->where('name', $name)->first();
+        return $this->subscriptions->where('name', $name)->last();
     }
 
     /**


### PR DESCRIPTION
The `subscription()` method does not behave as expected [as per the documentation](https://laravel.com/docs/8.x/billing#checking-subscription-status).

> If a user has two subscriptions with the same name, **the most recent subscription will always be returned by the subscription method**. For example, a user might have two subscription records named default; however, one of the subscriptions may be an old, expired subscription, while the other is the current, active subscription. The most recent subscription will always be returned while older subscriptions are kept in the database for historical review.

I fixed it by returning the last subscription instead of the first one.