### PR TITLE
[14.x] Make dompdf optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "dompdf/dompdf": "^0.8.6|^1.0.1",
         "illuminate/console": "^8.0|^9.0",
         "illuminate/contracts": "^8.0|^9.0",
         "illuminate/database": "^8.0|^9.0",
@@ -38,7 +37,8 @@
         "phpunit/phpunit": "^9.0"
     },
     "suggest": {
-        "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."
+        "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values.",
+        "dompdf/dompdf": "Required when generating and downloading invoice PDF's (^0.8.6|^1.0.1)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This makes dompdf an optional dependency. Now that we have decoupled it behind an interface it can be an optional dependency. And if people want to use their own renderers they can choose not to install it: https://github.com/laravel/cashier-stripe/issues/1311