### PR TITLE
[13.x] Improve test key check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,6 @@ You will need to set the Stripe **testing** secret environment variable in a cus
 
 Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `CASHIER_MODEL` environment variable in your new `phpunit.xml` file:
 
-    <env name="STRIPE_SECRET" value="Your Stripe Secret Key"/>
+    <env name="STRIPE_SECRET" value="Your Stripe Testing Secret Key"/>
 
-Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.
+**Make sure to use your testing secret key and never your production secret key.** Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,4 +10,4 @@ Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the follow
 
     <env name="STRIPE_SECRET" value="Your Stripe Testing Secret Key"/>
 
-**Make sure to use your testing secret key and never your production secret key.** Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.
+**Make sure to use your "testing" secret key and not your production secret key.** Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -13,7 +13,7 @@ use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
-use Stripe\Stripe as Stripe;
+use Stripe\Stripe;
 use Stripe\Subscription as StripeSubscription;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Http/Middleware/VerifyRedirectUrl.php
+++ b/src/Http/Middleware/VerifyRedirectUrl.php
@@ -18,7 +18,9 @@ class VerifyRedirectUrl
      */
     public function handle($request, Closure $next)
     {
-        $redirect = $request->get('redirect');
+        if (! $redirect = $request->get('redirect')) {
+            return $next($request);
+        }
 
         $url = parse_url($redirect);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ abstract class TestCase extends OrchestraTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $apiKey = getenv('STRIPE_SECRET');
+        $apiKey = config('cashier.secret');
 
         if ($apiKey && ! Str::startsWith($apiKey, 'sk_test_')) {
             throw new InvalidArgumentException('Tests may not be run with a production Stripe key.');


### PR DESCRIPTION
Improve https://github.com/laravel/cashier-stripe/pull/1314 a bit by using the config helper instead. Also add some extra safeguarding in the contribution docs.

PS.: I also had to push a fix for the redirect url middleware that was suddenly failing on PHP 8.1