### PR TITLE
docs: rawDiscountFor returns first() StripeObject from collection

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -224,7 +224,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      * Calculate the raw amount for a given discount.
      *
      * @param  \Laravel\Cashier\Discount  $discount
-     * @return int|null
+     * @return \Stripe\StripeObject|null
      */
     public function rawDiscountFor(Discount $discount)
     {


### PR DESCRIPTION
`rawDiscountFor` returns a StripeObject or null, not an int.  The usage of the return value as an object is displayed in `discountFor`

```php
        if (! is_null($discountAmount = $this->rawDiscountFor($discount))) {
            return $this->formatAmount($discountAmount->amount);
        }
```