### PR TITLE
[13.x] Fix swapping metered price of subscription item to existing su…

### DIFF
--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -151,9 +151,9 @@ class SubscriptionItem extends Model
                 'payment_behavior' => $this->paymentBehavior(),
                 'proration_behavior' => $this->prorateBehavior(),
                 'tax_rates' => $this->subscription->getPriceTaxRatesForPayload($price),
-            ], function($value) {
+            ], function ($value) {
                 return $value !== null;
-            }), 
+            }),
         $options));
 
         $this->fill([

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -144,13 +144,17 @@ class SubscriptionItem extends Model
     {
         $this->subscription->guardAgainstIncomplete();
 
-        $stripeSubscriptionItem = $this->updateStripeSubscriptionItem(array_merge([
-            'price' => $price,
-            'quantity' => $this->quantity,
-            'payment_behavior' => $this->paymentBehavior(),
-            'proration_behavior' => $this->prorateBehavior(),
-            'tax_rates' => $this->subscription->getPriceTaxRatesForPayload($price),
-        ], $options));
+        $stripeSubscriptionItem = $this->updateStripeSubscriptionItem(array_merge(
+            array_filter([
+                'price' => $price,
+                'quantity' => $this->quantity,
+                'payment_behavior' => $this->paymentBehavior(),
+                'proration_behavior' => $this->prorateBehavior(),
+                'tax_rates' => $this->subscription->getPriceTaxRatesForPayload($price),
+            ], function($value) {
+                return $value !== null;
+            }), 
+        $options));
 
         $this->fill([
             'stripe_product' => $stripeSubscriptionItem->price->product,

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -152,7 +152,7 @@ class SubscriptionItem extends Model
                 'proration_behavior' => $this->prorateBehavior(),
                 'tax_rates' => $this->subscription->getPriceTaxRatesForPayload($price),
             ], function ($value) {
-                return $value !== null;
+                return ! is_null($value);
             }),
         $options));
 


### PR DESCRIPTION
Fix swapping metered price (with quantity null) to existing subscription. Stripe don't accept null value for quantity (integer required) so it has to be removed from request if it's null.

Fix for #1326

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
