### PR TITLE
[13.x] Throw deprecations in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, bcmath
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 

--- a/src/Coupon.php
+++ b/src/Coupon.php
@@ -126,6 +126,7 @@ class Coupon implements Arrayable, Jsonable, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/CustomerBalanceTransaction.php
+++ b/src/CustomerBalanceTransaction.php
@@ -139,6 +139,7 @@ class CustomerBalanceTransaction
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Discount.php
+++ b/src/Discount.php
@@ -73,6 +73,7 @@ class Discount implements Arrayable, Jsonable, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -258,6 +258,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
By enabling deprecation throwing in tests, we can solve them early-on.