### PR TITLE
Allow options with formatAmount

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -135,12 +135,13 @@ class Cashier
      * @param  int  $amount
      * @param  string|null  $currency
      * @param  string|null  $locale
+     * @param  array  $options
      * @return string
      */
-    public static function formatAmount($amount, $currency = null, $locale = null)
+    public static function formatAmount($amount, $currency = null, $locale = null, array $options = [])
     {
         if (static::$formatCurrencyUsing) {
-            return call_user_func(static::$formatCurrencyUsing, $amount, $currency, $locale);
+            return call_user_func(static::$formatCurrencyUsing, $amount, $currency, $locale, $options);
         }
 
         $money = new Money($amount, new Currency(strtoupper($currency ?? config('cashier.currency'))));
@@ -148,6 +149,11 @@ class Cashier
         $locale = $locale ?? config('cashier.currency_locale');
 
         $numberFormatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+
+        if ($options['min_fraction_digits'] ?? false) {
+            $numberFormatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $options['min_fraction_digits']);
+        }
+
         $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
 
         return $moneyFormatter->format($money);


### PR DESCRIPTION
This PR adds a new $options array to the formatAmount method. By using this, we can make this formatter function more powerful with additional features.

Specifically, in Spark, we may use the new min_fraction_digits option to limit the amount of digits for a money value in one specific place.

This is a breaking change to the method signature, however, since Cashier is a standalone class I don't expect that this will impact anyone.
