### PR TITLE
[14.x] Drop PHP 7.4 and Laravel v8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, '8.0', 8.1]
-        laravel: [8, 9]
-        exclude:
-          - php: 7.4
-            laravel: 9
+        php: ['8.0', 8.1]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## Upgrading To 14.0 From 13.x
+
+### Minimum Versions
+
+The following required dependency versions have been updated:
+
+- The minimum PHP version is now v8.0
+- The minimum Laravel version is now v9.0
+
+
 ## Upgrading To 13.0 From 12.x
 
 ### Minimum Versions

--- a/composer.json
+++ b/composer.json
@@ -14,26 +14,26 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "illuminate/console": "^8.37|^9.0",
-        "illuminate/contracts": "^8.37|^9.0",
-        "illuminate/database": "^8.37|^9.0",
-        "illuminate/http": "^8.37|^9.0",
-        "illuminate/log": "^8.37|^9.0",
-        "illuminate/notifications": "^8.37|^9.0",
-        "illuminate/routing": "^8.37|^9.0",
-        "illuminate/support": "^8.37|^9.0",
-        "illuminate/view": "^8.37|^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/contracts": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/http": "^9.0",
+        "illuminate/log": "^9.0",
+        "illuminate/notifications": "^9.0",
+        "illuminate/routing": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/view": "^9.0",
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^7.39",
-        "symfony/http-kernel": "^5.0|^6.0",
+        "symfony/http-kernel": "^6.0",
         "symfony/polyfill-intl-icu": "^1.22.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.0"
     },
     "suggest": {


### PR DESCRIPTION
Drop support for old PHP and Laravel versions for the next major release.
