### PR TITLE
[13.x] Discount improvements

### DIFF
--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Laravel\Cashier\PromotionCode;
+
 trait AllowsCoupons
 {
     /**
@@ -49,6 +51,37 @@ trait AllowsCoupons
         $this->promotionCodeId = $promotionCodeId;
 
         return $this;
+    }
+
+    /**
+     * Retrieve a promotion code by its code.
+     *
+     * @param  string  $code
+     * @param  array  $options
+     * @return \Laravel\Cashier\PromotionCode|null
+     */
+    public function retrievePromotionCode($code, array $options = [])
+    {
+        $codes = $this->stripe()->promotionCodes->all(array_merge([
+            'code' => $code,
+            'limit' => 1,
+        ], $options));
+
+        if ($codes && $promotionCode = $codes->first()) {
+            return new PromotionCode($promotionCode);
+        }
+    }
+
+    /**
+     * Retrieve a promotion code by its code.
+     *
+     * @param  string  $code
+     * @param  array  $options
+     * @return \Laravel\Cashier\PromotionCode|null
+     */
+    public function retrieveActivePromotionCode($code, array $options = [])
+    {
+        return $this->retrievePromotionCode($code, array_merge($options, ['active' => true]));
     }
 
     /**

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -60,7 +60,7 @@ trait AllowsCoupons
      * @param  array  $options
      * @return \Laravel\Cashier\PromotionCode|null
      */
-    public function retrievePromotionCode($code, array $options = [])
+    public function findPromotionCode($code, array $options = [])
     {
         $codes = $this->stripe()->promotionCodes->all(array_merge([
             'code' => $code,
@@ -79,9 +79,9 @@ trait AllowsCoupons
      * @param  array  $options
      * @return \Laravel\Cashier\PromotionCode|null
      */
-    public function retrieveActivePromotionCode($code, array $options = [])
+    public function findActivePromotionCode($code, array $options = [])
     {
-        return $this->retrievePromotionCode($code, array_merge($options, ['active' => true]));
+        return $this->findPromotionCode($code, array_merge($options, ['active' => true]));
     }
 
     /**

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Cashier\Concerns;
 
-use Laravel\Cashier\PromotionCode;
-
 trait AllowsCoupons
 {
     /**
@@ -51,37 +49,6 @@ trait AllowsCoupons
         $this->promotionCodeId = $promotionCodeId;
 
         return $this;
-    }
-
-    /**
-     * Retrieve a promotion code by its code.
-     *
-     * @param  string  $code
-     * @param  array  $options
-     * @return \Laravel\Cashier\PromotionCode|null
-     */
-    public function findPromotionCode($code, array $options = [])
-    {
-        $codes = $this->stripe()->promotionCodes->all(array_merge([
-            'code' => $code,
-            'limit' => 1,
-        ], $options));
-
-        if ($codes && $promotionCode = $codes->first()) {
-            return new PromotionCode($promotionCode);
-        }
-    }
-
-    /**
-     * Retrieve a promotion code by its code.
-     *
-     * @param  string  $code
-     * @param  array  $options
-     * @return \Laravel\Cashier\PromotionCode|null
-     */
-    public function findActivePromotionCode($code, array $options = [])
-    {
-        return $this->findPromotionCode($code, array_merge($options, ['active' => true]));
     }
 
     /**

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -9,6 +9,7 @@ use Laravel\Cashier\CustomerBalanceTransaction;
 use Laravel\Cashier\Discount;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
+use Laravel\Cashier\PromotionCode;
 use Stripe\Customer as StripeCustomer;
 use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 
@@ -237,6 +238,37 @@ trait ManagesCustomer
         $this->updateStripeCustomer([
             'promotion_code' => $promotionCodeId,
         ]);
+    }
+
+    /**
+     * Retrieve a promotion code by its code.
+     *
+     * @param  string  $code
+     * @param  array  $options
+     * @return \Laravel\Cashier\PromotionCode|null
+     */
+    public function findPromotionCode($code, array $options = [])
+    {
+        $codes = $this->stripe()->promotionCodes->all(array_merge([
+            'code' => $code,
+            'limit' => 1,
+        ], $options));
+
+        if ($codes && $promotionCode = $codes->first()) {
+            return new PromotionCode($promotionCode);
+        }
+    }
+
+    /**
+     * Retrieve a promotion code by its code.
+     *
+     * @param  string  $code
+     * @param  array  $options
+     * @return \Laravel\Cashier\PromotionCode|null
+     */
+    public function findActivePromotionCode($code, array $options = [])
+    {
+        return $this->findPromotionCode($code, array_merge($options, ['active' => true]));
     }
 
     /**

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -6,6 +6,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\CustomerBalanceTransaction;
+use Laravel\Cashier\Discount;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Stripe\Customer as StripeCustomer;
@@ -195,6 +196,20 @@ trait ManagesCustomer
     }
 
     /**
+     * The discount on the customer if there is one.
+     *
+     * @return \Laravel\Cashier\Discount|null
+     */
+    public function discount()
+    {
+        $customer = $this->asStripeCustomer(['discount.promotion_code']);
+
+        return $customer->discount
+            ? new Discount($customer->discount)
+            : null;
+    }
+
+    /**
      * Apply a coupon to the customer.
      *
      * @param  string  $coupon
@@ -206,6 +221,21 @@ trait ManagesCustomer
 
         $this->updateStripeCustomer([
             'coupon' => $coupon,
+        ]);
+    }
+
+    /**
+     * Apply a promotion code to the customer.
+     *
+     * @param  string  $promotionCodeId
+     * @return void
+     */
+    public function applyPromotionCode($promotionCodeId)
+    {
+        $this->assertCustomerExists();
+
+        $this->updateStripeCustomer([
+            'promotion_code' => $promotionCodeId,
         ]);
     }
 

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -197,7 +197,7 @@ trait ManagesCustomer
     }
 
     /**
-     * The discount on the customer if there is one.
+     * The discount that applies to the customer, if applicable.
      *
      * @return \Laravel\Cashier\Discount|null
      */

--- a/src/Discount.php
+++ b/src/Discount.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
@@ -35,6 +36,40 @@ class Discount implements Arrayable, Jsonable, JsonSerializable
     public function coupon()
     {
         return new Coupon($this->discount->coupon);
+    }
+
+    /**
+     * Get the promotion code applied to create this discount.
+     *
+     * @return \Laravel\Cashier\PromotionCode|null
+     */
+    public function promotionCode()
+    {
+        if (! is_null($this->discount->promotion_code) && ! is_string($this->discount->promotion_code)) {
+            return new PromotionCode($this->discount->promotion_code);
+        }
+    }
+
+    /**
+     * Get the date that the coupon was applied.
+     *
+     * @return \Carbon\Carbon
+     */
+    public function start()
+    {
+        return Carbon::createFromTimestamp($this->discount->start);
+    }
+
+    /**
+     * Get the date that this discount will end.
+     *
+     * @return \Carbon\Carbon|null
+     */
+    public function end()
+    {
+        if (! is_null($this->discount->end)) {
+            return Carbon::createFromTimestamp($this->discount->end);
+        }
     }
 
     /**

--- a/src/PromotionCode.php
+++ b/src/PromotionCode.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use Stripe\PromotionCode as StripePromotionCode;
+
+class PromotionCode implements Arrayable, Jsonable, JsonSerializable
+{
+    /**
+     * The Stripe PromotionCode instance.
+     *
+     * @var \Stripe\PromotionCode
+     */
+    protected $promotionCode;
+
+    /**
+     * Create a new PromotionCode instance.
+     *
+     * @param  \Stripe\PromotionCode  $promotionCode
+     * @return void
+     */
+    public function __construct(StripePromotionCode $promotionCode)
+    {
+        $this->promotionCode = $promotionCode;
+    }
+
+    /**
+     * Get the coupon that belongs to the promotion code.
+     *
+     * @return \Laravel\Cashier\Coupon
+     */
+    public function coupon()
+    {
+        return new Coupon($this->promotionCode->coupon);
+    }
+
+    /**
+     * Get the Stripe PromotionCode instance.
+     *
+     * @return \Stripe\PromotionCode
+     */
+    public function asStripePromotionCode()
+    {
+        return $this->promotionCode;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->asStripePromotionCode()->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Dynamically get values from the Stripe object.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->promotionCode->{$key};
+    }
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1313,6 +1313,46 @@ class Subscription extends Model
     }
 
     /**
+     * The discount on the subscription if there is one.
+     *
+     * @return \Laravel\Cashier\Discount|null
+     */
+    public function discount()
+    {
+        $subscription = $this->asStripeSubscription(['discount.promotion_code']);
+
+        return $subscription->discount
+            ? new Discount($subscription->discount)
+            : null;
+    }
+
+    /**
+     * Apply a coupon to the subscription.
+     *
+     * @param  string  $coupon
+     * @return void
+     */
+    public function applyCoupon($coupon)
+    {
+        $this->updateStripeSubscription([
+            'coupon' => $coupon,
+        ]);
+    }
+
+    /**
+     * Apply a promotion code to the subscription.
+     *
+     * @param  string  $promotionCodeId
+     * @return void
+     */
+    public function applyPromotionCode($promotionCodeId)
+    {
+        $this->updateStripeSubscription([
+            'promotion_code' => $promotionCodeId,
+        ]);
+    }
+
+    /**
      * Make sure a subscription is not incomplete when performing changes.
      *
      * @return void

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1313,7 +1313,7 @@ class Subscription extends Model
     }
 
     /**
-     * The discount on the subscription if there is one.
+     * The discount that applies to the subscription, if applicable.
      *
      * @return \Laravel\Cashier\Discount|null
      */

--- a/tests/Feature/DiscountTest.php
+++ b/tests/Feature/DiscountTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use Illuminate\Support\Str;
+
+class DiscountTest extends FeatureTestCase
+{
+    /**
+     * @var string
+     */
+    protected static $productId;
+
+    /**
+     * @var string
+     */
+    protected static $priceId;
+
+    /**
+     * @var string
+     */
+    protected static $couponId;
+
+    /**
+     * @var string
+     */
+    protected static $secondCouponId;
+
+    /**
+     * @var string
+     */
+    protected static $promotionCodeId;
+
+    /**
+     * @var string
+     */
+    protected static $promotionCodeCode;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (! getenv('STRIPE_SECRET')) {
+            return;
+        }
+
+        parent::setUpBeforeClass();
+
+        static::$productId = self::stripe()->products->create([
+            'name' => 'Laravel Cashier Test Product',
+            'type' => 'service',
+        ])->id;
+
+        static::$priceId = self::stripe()->prices->create([
+            'product' => static::$productId,
+            'nickname' => 'Monthly $10',
+            'currency' => 'USD',
+            'recurring' => [
+                'interval' => 'month',
+            ],
+            'billing_scheme' => 'per_unit',
+            'unit_amount' => 1000,
+        ])->id;
+
+        static::$couponId = self::stripe()->coupons->create([
+            'duration' => 'repeating',
+            'amount_off' => 500,
+            'duration_in_months' => 3,
+            'currency' => 'USD',
+        ])->id;
+
+        static::$secondCouponId = self::stripe()->coupons->create([
+            'duration' => 'once',
+            'percent_off' => 20,
+            'currency' => 'USD',
+        ])->id;
+
+        static::$promotionCodeId = self::stripe()->promotionCodes->create([
+            'coupon' => static::$secondCouponId,
+            'code' => static::$promotionCodeCode = Str::random(16),
+        ])->id;
+    }
+
+    public function test_applying_discounts_to_existing_customers()
+    {
+        $user = $this->createCustomer('applying_coupons_to_existing_customers');
+
+        $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $user->applyCoupon(static::$couponId);
+
+        $this->assertEquals(static::$couponId, $user->discount()->coupon()->id);
+
+        $user->applyPromotionCode(static::$promotionCodeId);
+
+        $this->assertEquals(static::$secondCouponId, $user->discount()->coupon()->id);
+        $this->assertEquals(static::$promotionCodeId, $user->discount()->promotionCode()->id);
+        $this->assertEquals(static::$secondCouponId, $user->discount()->promotionCode()->coupon()->id);
+        $this->assertEquals(static::$promotionCodeCode, $user->discount()->promotionCode()->code);
+    }
+
+    public function test_applying_discounts_to_existing_subscriptions()
+    {
+        $user = $this->createCustomer('applying_coupons_to_existing_subscriptions');
+
+        $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $subscription->applyCoupon(static::$couponId);
+
+        $this->assertEquals(static::$couponId, $subscription->discount()->coupon()->id);
+
+        $subscription->applyPromotionCode(static::$promotionCodeId);
+
+        $this->assertEquals(static::$secondCouponId, $subscription->discount()->coupon()->id);
+        $this->assertEquals(static::$promotionCodeId, $subscription->discount()->promotionCode()->id);
+        $this->assertEquals(static::$secondCouponId, $subscription->discount()->promotionCode()->coupon()->id);
+        $this->assertEquals(static::$promotionCodeCode, $subscription->discount()->promotionCode()->code);
+    }
+
+    public function test_customers_can_retrieve_a_promotion_code()
+    {
+        $user = $this->createCustomer('customers_can_retrieve_a_promotion_code');
+
+        $promotionCode = $user->retrievePromotionCode(static::$promotionCodeCode);
+
+        $this->assertEquals(static::$promotionCodeCode, $promotionCode->code);
+
+        // Inactive promotion codes aren't retrieved with the "active only" method...
+        $inactivePromotionCode = $user->stripe()->promotionCodes->create([
+            'active' => false,
+            'coupon' => static::$couponId,
+            'code' => 'NEWYEAR',
+        ]);
+
+        $promotionCode = $user->retrieveActivePromotionCode($inactivePromotionCode->id);
+
+        $this->assertNull($promotionCode);
+    }
+}

--- a/tests/Feature/DiscountTest.php
+++ b/tests/Feature/DiscountTest.php
@@ -119,7 +119,7 @@ class DiscountTest extends FeatureTestCase
     {
         $user = $this->createCustomer('customers_can_retrieve_a_promotion_code');
 
-        $promotionCode = $user->retrievePromotionCode(static::$promotionCodeCode);
+        $promotionCode = $user->findPromotionCode(static::$promotionCodeCode);
 
         $this->assertEquals(static::$promotionCodeCode, $promotionCode->code);
 
@@ -130,7 +130,7 @@ class DiscountTest extends FeatureTestCase
             'code' => 'NEWYEAR',
         ]);
 
-        $promotionCode = $user->retrieveActivePromotionCode($inactivePromotionCode->id);
+        $promotionCode = $user->findActivePromotionCode($inactivePromotionCode->id);
 
         $this->assertNull($promotionCode);
     }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -198,7 +198,7 @@ class SubscriptionsTest extends FeatureTestCase
             'coupon' => static::$couponId,
         ]);
 
-        $this->assertEquals(static::$couponId, $subscription->asStripeSubscription()->discount->coupon->id);
+        $this->assertEquals(static::$couponId, $subscription->discount()->coupon()->id);
     }
 
     public function test_swapping_subscription_and_preserving_quantity()
@@ -755,19 +755,6 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->endTrial();
 
         $this->assertNull($subscription->trial_ends_at);
-    }
-
-    public function test_applying_coupons_to_existing_customers()
-    {
-        $user = $this->createCustomer('applying_coupons_to_existing_customers');
-
-        $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
-
-        $user->applyCoupon(static::$couponId);
-
-        $customer = $user->asStripeCustomer();
-
-        $this->assertEquals(static::$couponId, $customer->discount->coupon->id);
     }
 
     public function test_subscription_state_scopes()


### PR DESCRIPTION
This PR implements some improvements and new API's for discount handling.

First of all, a new `PromotionCode` class was added that wraps a `Stripe\PromotionCode` object. This object represents a promotion code applied to either a customer or subscription. 

Further, the `Discount` class now also features a `promotionCode` method to easily retrieve the promotion code should one have been used to apply a discount. Besides that, the class got dedicated methods to transform the `start` and `end` timestamps of a discount into `Carbon\Carbon` objects.

Other than that it's now easy to retrieve a `PromotionCode` by its code:

```php
// Find the promotion code with 25OFF...
$promotionCode = $billable->findPromotionCode('25OFF');

// Or find only active promotion codes...
$promotionCode = $billable->findActivePromotionCode('25OFF');
```

It's now also easy to retrieve the applied discount on a customer or subscription:

```php
$discount = $billable->discount();

$discount = $subscription->discount();
````

And it's easy now to apply a new discount or promotion code on either a customer or subscription. These need the ID of their respective object:

```php
$billable->applyDiscount('discount_id');
$billable->applyPromotionCode('promotion_code_id');

$subscription->applyDiscount('discount_id');
$subscription->applyPromotionCode('promotion_code_id');
```

I was thinking to add also some validation rules like `discount`, `promotion_code` or `discount_or_promotion_code` but decided to not extend the scope of this PR any further.

Closes https://github.com/laravel/cashier-stripe/issues/852