### PR TITLE
[13.x] Fix deprecation with Carbon on receipts

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -214,8 +214,8 @@
                         <tr class="row">
                             <td>{{ $subscription->description }}</td>
                             <td>
-                                {{ $subscription->startDateAsCarbon()->formatLocalized('%B %e, %Y') }} -
-                                {{ $subscription->endDateAsCarbon()->formatLocalized('%B %e, %Y') }}
+                                {{ $subscription->startDateAsCarbon()->toFormattedDateString() }} -
+                                {{ $subscription->endDateAsCarbon()->toFormattedDateString() }}
                             </td>
 
                             @if ($invoice->hasTax())


### PR DESCRIPTION
This PR fixes a deprecation in Cashier Stripe with Carbon.

See #1355
