### PR TITLE
[13.x] Bump Dompdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "dompdf/dompdf": "^0.8.6|^1.0.1",
+        "dompdf/dompdf": "^1.2.1",
         "illuminate/console": "^8.37|^9.0",
         "illuminate/contracts": "^8.37|^9.0",
         "illuminate/database": "^8.37|^9.0",


### PR DESCRIPTION
This is to prevent people from installing versions that are affected by https://github.com/advisories/GHSA-x752-qjv4-c4hc