### PR TITLE
[13.x] Add new hasTrialExpired methods

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -49,15 +49,15 @@ trait ManagesSubscriptions
      * @param  string|null  $price
      * @return bool
      */
-    public function hasTrialExpired($name = 'default', $price = null)
+    public function hasExpiredTrial($name = 'default', $price = null)
     {
-        if (func_num_args() === 0 && $this->hasGenericTrialExpired()) {
+        if (func_num_args() === 0 && $this->hasExpiredGenericTrial()) {
             return true;
         }
 
         $subscription = $this->subscription($name);
 
-        if (! $subscription || ! $subscription->hasTrialExpired()) {
+        if (! $subscription || ! $subscription->hasExpiredTrial()) {
             return false;
         }
 
@@ -79,7 +79,7 @@ trait ManagesSubscriptions
      *
      * @return bool
      */
-    public function hasGenericTrialExpired()
+    public function hasExpiredGenericTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isPast();
     }

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -43,6 +43,28 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Determine if the Stripe model's trial has ended.
+     *
+     * @param  string  $name
+     * @param  string|null  $price
+     * @return bool
+     */
+    public function hasTrialExpired($name = 'default', $price = null)
+    {
+        if (func_num_args() === 0 && $this->hasGenericTrialExpired()) {
+            return true;
+        }
+
+        $subscription = $this->subscription($name);
+
+        if (! $subscription || ! $subscription->hasTrialExpired()) {
+            return false;
+        }
+
+        return ! $price || $subscription->hasPrice($price);
+    }
+
+    /**
      * Determine if the Stripe model is on a "generic" trial at the model level.
      *
      * @return bool
@@ -50,6 +72,16 @@ trait ManagesSubscriptions
     public function onGenericTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isFuture();
+    }
+
+    /**
+     * Determine if the Stripe model's "generic" trial at the model level has expired.
+     *
+     * @return bool
+     */
+    public function hasGenericTrialExpired()
+    {
+        return $this->trial_ends_at && $this->trial_ends_at->isPast();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -405,18 +405,18 @@ class Subscription extends Model
      *
      * @return bool
      */
-    public function hasTrialExpired()
+    public function hasExpiredTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isPast();
     }
 
     /**
-     * Filter query by trial expired.
+     * Filter query by expired trial.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeTrialExpired($query)
+    public function scopeExpiredTrial($query)
     {
         $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '<', Carbon::now());
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -401,6 +401,27 @@ class Subscription extends Model
     }
 
     /**
+     * Determine if the subscription's trial has expired.
+     *
+     * @return bool
+     */
+    public function hasTrialExpired()
+    {
+        return $this->trial_ends_at && $this->trial_ends_at->isPast();
+    }
+
+    /**
+     * Filter query by trial expired.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeTrialExpired($query)
+    {
+        $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '<', Carbon::now());
+    }
+
+    /**
      * Filter query by not on trial.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -16,13 +16,24 @@ class CustomerTest extends TestCase
 
         $this->assertFalse($user->onGenericTrial());
 
-        $user->trial_ends_at = $tomorrow = Carbon::tomorrow();
+        $user->trial_ends_at = Carbon::tomorrow();
 
+        $this->assertTrue($user->onTrial());
         $this->assertTrue($user->onGenericTrial());
 
         $user->trial_ends_at = Carbon::today()->subDays(5);
 
         $this->assertFalse($user->onGenericTrial());
+    }
+
+    public function test_we_can_check_if_a_generic_trial_has_expired()
+    {
+        $user = new User;
+
+        $user->trial_ends_at = Carbon::yesterday();
+
+        $this->assertTrue($user->hasTrialExpired());
+        $this->assertTrue($user->hasGenericTrialExpired());
     }
 
     public function test_we_can_determine_if_it_has_a_payment_method()

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -32,8 +32,8 @@ class CustomerTest extends TestCase
 
         $user->trial_ends_at = Carbon::yesterday();
 
-        $this->assertTrue($user->hasTrialExpired());
-        $this->assertTrue($user->hasGenericTrialExpired());
+        $this->assertTrue($user->hasExpiredTrial());
+        $this->assertTrue($user->hasExpiredGenericTrial());
     }
 
     public function test_we_can_determine_if_it_has_a_payment_method()

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -126,6 +126,36 @@ class SubscriptionTest extends TestCase
         (new Subscription)->extendTrial(now()->subDay());
     }
 
+    public function test_it_can_determine_if_the_subscription_is_on_trial()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->trial_ends_at = now()->addDay();
+
+        $this->assertTrue($subscription->onTrial());
+
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->trial_ends_at = now()->subDay();
+
+        $this->assertFalse($subscription->onTrial());
+    }
+
+    public function test_it_can_determine_if_a_trial_has_expired()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->trial_ends_at = now()->subDay();
+
+        $this->assertTrue($subscription->hasTrialExpired());
+
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->trial_ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->hasTrialExpired());
+    }
+
     public function test_we_can_check_if_it_has_a_single_price()
     {
         $subscription = new Subscription(['stripe_price' => 'foo']);

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -147,13 +147,13 @@ class SubscriptionTest extends TestCase
         $subscription->setDateFormat('Y-m-d H:i:s');
         $subscription->trial_ends_at = now()->subDay();
 
-        $this->assertTrue($subscription->hasTrialExpired());
+        $this->assertTrue($subscription->hasExpiredTrial());
 
         $subscription = new Subscription();
         $subscription->setDateFormat('Y-m-d H:i:s');
         $subscription->trial_ends_at = now()->addDay();
 
-        $this->assertFalse($subscription->hasTrialExpired());
+        $this->assertFalse($subscription->hasExpiredTrial());
     }
 
     public function test_we_can_check_if_it_has_a_single_price()


### PR DESCRIPTION
Currently, there isn't a convenient way to check if a trial period has expired. We can't simply wo `! $user->onTrial()` because it could be that the user didn't have a trial to begin with.

To, for example, display a banner that a billable's trial has expired we need to know that they were trialing in the first place and that the period has expired.

Closes https://github.com/laravel/cashier-stripe/issues/1361