### PR TITLE
[13.x] Extract Stripe ID features to `BelongsToStripe` trait, allowing `stripe_id` key customization

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -31,7 +31,7 @@ class SubscriptionFactory extends Factory
         return [
             (new $model)->getForeignKey() => ($model)::factory(),
             'name' => 'default',
-            'stripe_id' => 'sub_'.Str::random(40),
+            (new $model)->stripeKey() => 'sub_'.Str::random(40),
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,
             'quantity' => null,

--- a/database/factories/SubscriptionItemFactory.php
+++ b/database/factories/SubscriptionItemFactory.php
@@ -23,9 +23,11 @@ class SubscriptionItemFactory extends Factory
      */
     public function definition()
     {
+        $stripeKey = $this->newModel()->stripeKey();
+
         return [
             'subscription_id' => Subscription::factory(),
-            'stripe_id' => 'si_'.Str::random(40),
+            $stripeKey => 'si_'.Str::random(40),
             'stripe_product' => 'prod_'.Str::random(40),
             'stripe_price' => 'price_'.Str::random(40),
             'quantity' => null,

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -100,7 +100,7 @@ class Cashier
     {
         $stripeId = $stripeId instanceof StripeCustomer ? $stripeId->id : $stripeId;
 
-        return $stripeId ? (new static::$customerModel)->where('stripe_id', $stripeId)->first() : null;
+        return $stripeId ? ($model = new static::$customerModel)->where($model->stripeKey(), $stripeId)->first() : null;
     }
 
     /**

--- a/src/Concerns/BelongsToStripe.php
+++ b/src/Concerns/BelongsToStripe.php
@@ -24,6 +24,16 @@ trait BelongsToStripe
     }
 
     /**
+     * Retrieve the Stripe attribute key.
+     *
+     * @return string
+     */
+    public function stripeKey()
+    {
+        return $this->stripeKey;
+    }
+
+    /**
      * Determine if the customer has a Stripe ID.
      *
      * @return bool

--- a/src/Concerns/BelongsToStripe.php
+++ b/src/Concerns/BelongsToStripe.php
@@ -14,16 +14,6 @@ trait BelongsToStripe
     protected $stripeKey = 'stripe_id';
 
     /**
-     * Retrieve the Stripe ID.
-     *
-     * @return string|null
-     */
-    public function stripeId()
-    {
-        return $this->{$this->stripeKey};
-    }
-
-    /**
      * Retrieve the Stripe attribute key.
      *
      * @return string
@@ -34,7 +24,17 @@ trait BelongsToStripe
     }
 
     /**
-     * Determine if the customer has a Stripe ID.
+     * Retrieve the Stripe ID.
+     *
+     * @return string|null
+     */
+    public function stripeId()
+    {
+        return $this->{$this->stripeKey};
+    }
+
+    /**
+     * Determine if the instance has a Stripe ID.
      *
      * @return bool
      */

--- a/src/Concerns/BelongsToStripe.php
+++ b/src/Concerns/BelongsToStripe.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+use Laravel\Cashier\Cashier;
+
+trait BelongsToStripe
+{
+    /**
+     * The attribute key containing the Stripe ID.
+     *
+     * @var string
+     */
+    protected $stripeKey = 'stripe_id';
+
+    /**
+     * Retrieve the Stripe ID.
+     *
+     * @return string|null
+     */
+    public function stripeId()
+    {
+        return $this->{$this->stripeKey};
+    }
+
+    /**
+     * Determine if the customer has a Stripe ID.
+     *
+     * @return bool
+     */
+    public function hasStripeId()
+    {
+        return ! is_null($this->{$this->stripeKey});
+    }
+
+    /**
+     * Set the Stripe ID.
+     *
+     * @param string $stripeId
+     *
+     * @return $this
+     */
+    public function setStripeId($stripeId)
+    {
+        $this->{$this->stripeKey} = $stripeId;
+
+        return $this;
+    }
+
+    /**
+     * Get the Stripe SDK client.
+     *
+     * @param  array  $options
+     * @return \Stripe\StripeClient
+     */
+    public static function stripe(array $options = [])
+    {
+        return Cashier::stripe($options);
+    }
+}

--- a/src/Concerns/BelongsToStripe.php
+++ b/src/Concerns/BelongsToStripe.php
@@ -46,8 +46,7 @@ trait BelongsToStripe
     /**
      * Set the Stripe ID.
      *
-     * @param string $stripeId
-     *
+     * @param  string  $stripeId
      * @return $this
      */
     public function setStripeId($stripeId)

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -417,7 +417,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return $this->stripe()->customers->createTaxId($this->stripe_id, [
+        return $this->stripe()->customers->createTaxId($this->stripeId(), [
             'type' => $type,
             'value' => $value,
         ]);
@@ -434,7 +434,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         try {
-            $this->stripe()->customers->deleteTaxId($this->stripe_id, $id);
+            $this->stripe()->customers->deleteTaxId($this->stripeId(), $id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -32,7 +32,7 @@ trait ManagesInvoices
         $this->assertCustomerExists();
 
         $options = array_merge([
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
             'currency' => $this->preferredCurrency(),
             'description' => $description,
         ], $options);
@@ -82,7 +82,7 @@ trait ManagesInvoices
         $this->assertCustomerExists();
 
         $options = array_merge([
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
             'price' => $price,
             'quantity' => $quantity,
         ], $options);
@@ -122,7 +122,7 @@ trait ManagesInvoices
 
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
         ], $options);
 
         try {
@@ -164,7 +164,7 @@ trait ManagesInvoices
 
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
         ], $options);
 
         try {
@@ -252,7 +252,7 @@ trait ManagesInvoices
         $parameters = array_merge(['limit' => 24], $parameters);
 
         $stripeInvoices = $this->stripe()->invoices->all(
-            ['customer' => $this->stripe_id] + $parameters
+            ['customer' => $this->stripeId()] + $parameters
         );
 
         // Here we will loop through the Stripe invoices and create our own custom Invoice

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -58,7 +58,7 @@ trait ManagesPaymentMethods
 
         // "type" is temporarily required by Stripe...
         $paymentMethods = $this->stripe()->paymentMethods->all(
-            ['customer' => $this->stripe_id, 'type' => $type] + $parameters
+            ['customer' => $this->stripeId(), 'type' => $type] + $parameters
         );
 
         return Collection::make($paymentMethods->data)->map(function ($paymentMethod) {
@@ -78,9 +78,9 @@ trait ManagesPaymentMethods
 
         $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
 
-        if ($stripePaymentMethod->customer !== $this->stripe_id) {
+        if ($stripePaymentMethod->customer !== $this->stripeId()) {
             $stripePaymentMethod = $stripePaymentMethod->attach(
-                ['customer' => $this->stripe_id]
+                ['customer' => $this->stripeId()]
             );
         }
 
@@ -99,7 +99,7 @@ trait ManagesPaymentMethods
 
         $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
 
-        if ($stripePaymentMethod->customer !== $this->stripe_id) {
+        if ($stripePaymentMethod->customer !== $this->stripeId()) {
             return;
         }
 

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -88,7 +88,7 @@ trait PerformsCharges
         $options['amount'] = $amount;
 
         if ($this->hasStripeId()) {
-            $options['customer'] = $this->stripe_id;
+            $options['customer'] = $this->stripeId();
         }
 
         return new Payment(

--- a/src/CustomerBalanceTransaction.php
+++ b/src/CustomerBalanceTransaction.php
@@ -32,7 +32,7 @@ class CustomerBalanceTransaction
      */
     public function __construct($owner, StripeCustomerBalanceTransaction $transaction)
     {
-        if ($owner->stripe_id !== $transaction->customer) {
+        if ($owner->stripeId() !== $transaction->customer) {
             throw InvalidCustomerBalanceTransaction::invalidOwner($transaction, $owner);
         }
 

--- a/src/Exceptions/CustomerAlreadyCreated.php
+++ b/src/Exceptions/CustomerAlreadyCreated.php
@@ -14,6 +14,6 @@ class CustomerAlreadyCreated extends Exception
      */
     public static function exists($owner)
     {
-        return new static(class_basename($owner)." is already a Stripe customer with ID {$owner->stripe_id}.");
+        return new static(class_basename($owner)." is already a Stripe customer with ID {$owner->stripeId()}.");
     }
 }

--- a/src/Exceptions/InvalidCustomerBalanceTransaction.php
+++ b/src/Exceptions/InvalidCustomerBalanceTransaction.php
@@ -16,6 +16,6 @@ class InvalidCustomerBalanceTransaction extends Exception
      */
     public static function invalidOwner(StripeCustomerBalanceTransaction $transaction, $owner)
     {
-        return new static("The transaction `{$transaction->id}` does not belong to customer `$owner->stripe_id`.");
+        return new static("The transaction `{$transaction->id}` does not belong to customer `{$owner->stripeId()}`.");
     }
 }

--- a/src/Exceptions/InvalidInvoice.php
+++ b/src/Exceptions/InvalidInvoice.php
@@ -16,6 +16,6 @@ class InvalidInvoice extends Exception
      */
     public static function invalidOwner(StripeInvoice $invoice, $owner)
     {
-        return new static("The invoice `{$invoice->id}` does not belong to this customer `$owner->stripe_id`.");
+        return new static("The invoice `{$invoice->id}` does not belong to this customer `{$owner->stripeId()}`.");
     }
 }

--- a/src/Exceptions/InvalidPaymentMethod.php
+++ b/src/Exceptions/InvalidPaymentMethod.php
@@ -17,7 +17,7 @@ class InvalidPaymentMethod extends Exception
     public static function invalidOwner(StripePaymentMethod $paymentMethod, $owner)
     {
         return new static(
-            "The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`."
+            "The payment method `{$paymentMethod->id}` does not belong to this customer `{$owner->stripeId()}`."
         );
     }
 }

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -16,7 +16,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function incompleteSubscription(Subscription $subscription)
     {
         return new static(
-            "The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete."
+            "The subscription \"{$subscription->stripeId()}\" cannot be updated because its payment is incomplete."
         );
     }
 
@@ -30,7 +30,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function duplicatePrice(Subscription $subscription, $price)
     {
         return new static(
-            "The price \"$price\" is already attached to subscription \"{$subscription->stripe_id}\"."
+            "The price \"$price\" is already attached to subscription \"{$subscription->stripeId()}\"."
         );
     }
 
@@ -43,7 +43,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function cannotDeleteLastPrice(Subscription $subscription)
     {
         return new static(
-            "The price on subscription \"{$subscription->stripe_id}\" cannot be removed because it is the last one."
+            "The price on subscription \"{$subscription->stripeId()}\" cannot be removed because it is the last one."
         );
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -127,7 +127,7 @@ class WebhookController extends Controller
     {
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             $data = $payload['data']['object'];
-            
+
             $stripeKey = $user->subscriptions()->getModel()->stripeKey();
 
             $subscription = $user->subscriptions()->firstOrNew([$stripeKey => $data['id']]);

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -78,7 +78,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function __construct($owner, StripeInvoice $invoice, array $refreshData = [])
     {
-        if ($owner->stripe_id !== $invoice->customer) {
+        if ($owner->stripeId() !== $invoice->customer) {
             throw InvalidInvoice::invalidOwner($invoice, $owner);
         }
 
@@ -409,7 +409,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
         } else {
             // If no invoice ID is present then assume this is the customer's upcoming invoice...
             $this->invoice = Cashier::stripe()->invoices->upcoming(array_merge($this->refreshData, [
-                'customer' => $this->owner->stripe_id,
+                'customer' => $this->owner->stripeId(),
                 'expand' => $expand,
             ]));
         }

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -35,7 +35,7 @@ class PaymentMethod implements Arrayable, Jsonable, JsonSerializable
      */
     public function __construct($owner, StripePaymentMethod $paymentMethod)
     {
-        if ($owner->stripe_id !== $paymentMethod->customer) {
+        if ($owner->stripeId() !== $paymentMethod->customer) {
             throw InvalidPaymentMethod::invalidOwner($paymentMethod, $owner);
         }
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -292,7 +292,9 @@ class SubscriptionBuilder
      */
     protected function createSubscription(StripeSubscription $stripeSubscription)
     {
-        if ($subscription = $this->owner->subscriptions()->where('stripe_id', $stripeSubscription->id)->first()) {
+        $stripeKey = $this->owner->subscriptions()->getModel()->stripeKey();
+        
+        if ($subscription = $this->owner->subscriptions()->where($stripeKey, $stripeSubscription->id)->first()) {
             return $subscription;
         }
 
@@ -303,7 +305,7 @@ class SubscriptionBuilder
         /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $this->owner->subscriptions()->create([
             'name' => $this->name,
-            'stripe_id' => $stripeSubscription->id,
+            $stripeKey => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
             'quantity' => $isSinglePrice ? $firstItem->quantity : null,
@@ -314,7 +316,7 @@ class SubscriptionBuilder
         /** @var \Stripe\SubscriptionItem $item */
         foreach ($stripeSubscription->items as $item) {
             $subscription->items()->create([
-                'stripe_id' => $item->id,
+                $stripeKey => $item->id,
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity ?? null,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -293,7 +293,7 @@ class SubscriptionBuilder
     protected function createSubscription(StripeSubscription $stripeSubscription)
     {
         $stripeKey = $this->owner->subscriptions()->getModel()->stripeKey();
-        
+
         if ($subscription = $this->owner->subscriptions()->where($stripeKey, $stripeSubscription->id)->first()) {
             return $subscription;
         }

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Laravel\Cashier\Concerns\BelongsToStripe;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
@@ -15,6 +16,7 @@ use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
  */
 class SubscriptionItem extends Model
 {
+    use BelongsToStripe;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
@@ -204,7 +206,7 @@ class SubscriptionItem extends Model
     {
         $timestamp = $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp;
 
-        return $this->subscription->owner->stripe()->subscriptionItems->createUsageRecord($this->stripe_id, [
+        return $this->subscription->owner->stripe()->subscriptionItems->createUsageRecord($this->stripeId(), [
             'quantity' => $quantity,
             'action' => $timestamp ? 'set' : 'increment',
             'timestamp' => $timestamp ?? time(),
@@ -220,7 +222,7 @@ class SubscriptionItem extends Model
     public function usageRecords($options = [])
     {
         return new Collection($this->subscription->owner->stripe()->subscriptionItems->allUsageRecordSummaries(
-            $this->stripe_id, $options
+            $this->stripeId(), $options
         )->data);
     }
 
@@ -233,7 +235,7 @@ class SubscriptionItem extends Model
     public function updateStripeSubscriptionItem(array $options = [])
     {
         return $this->subscription->owner->stripe()->subscriptionItems->update(
-            $this->stripe_id, $options
+            $this->stripeId(), $options
         );
     }
 
@@ -246,7 +248,7 @@ class SubscriptionItem extends Model
     public function asStripeSubscriptionItem(array $expand = [])
     {
         return $this->subscription->owner->stripe()->subscriptionItems->retrieve(
-            $this->stripe_id, ['expand' => $expand]
+            $this->stripeId(), ['expand' => $expand]
         );
     }
 

--- a/tests/Fixtures/UserWithCustomStripeKey.php
+++ b/tests/Fixtures/UserWithCustomStripeKey.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Fixtures;
+
+class UserWithCustomStripeKey extends User
+{
+    protected $stripeKey = 'stripe_customer_id';
+}

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Laravel\Cashier\Tests\Fixtures\UserWithCustomStripeKey;
 use PHPUnit\Framework\TestCase;
 
 class CustomerTest extends TestCase
@@ -72,5 +73,17 @@ class CustomerTest extends TestCase
         $this->expectException(CustomerAlreadyCreated::class);
 
         $user->createAsStripeCustomer();
+    }
+    
+    public function test_stripe_id_can_be_customized()
+    {
+        $user = new UserWithCustomStripeKey();
+
+        $user->setStripeId('foo');
+
+        $this->assertEquals('foo', $user->stripeId());
+        $this->assertEquals('foo', $user->stripe_customer_id);
+
+        $this->assertEquals('stripe_customer_id', $user->stripeKey());
     }
 }

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -74,7 +74,7 @@ class CustomerTest extends TestCase
 
         $user->createAsStripeCustomer();
     }
-    
+
     public function test_stripe_id_can_be_customized()
     {
         $user = new UserWithCustomStripeKey();


### PR DESCRIPTION
## Description

This PR extracts existing Stripe ID methods to another trait, so developers can apply this same trait to other models that they may want to synchronize in Stripe, such as Products.

It will provide a shortcut for developers to leverage a Cashier-like API with their own implementations.

This PR also provides a way for developers to alter the `stripe_id` column in the `users` update table migration, as well as in the `subscriptions` and `subscription_items` table migrations. Once updated in the migration, the users may set the `$stripeKey` property on the model to reference its new attribute location.

## Examples

**Custom Product Model**:

```php
namespace App\Models;

use Laravel\Cashier\Concerns\BelongsToStripe;

class Product extends Model
{
    use BelongsToStripe;

    public function createAsStripeProduct()
    {
        $product = $this->stripe()->products->create(['name' => $this->name]);

        $this->setStripeId($product->id);

        $this->save();

        return $product;
    }
}
```

**Custom Stripe Key**:

```php
class User extends Model
{
    use Billable;

    protected $stripeKey = 'stripe_customer_id';
}
```

Let me know your thoughts! No hard feelings on closure ❤️ 