### PR TITLE
Fixed undefined quantity notice

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -741,7 +741,7 @@ class Subscription extends Model
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
-            'quantity' => $isSinglePrice ? $firstItem->quantity ?? null : null,
+            'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
             'ends_at' => null,
         ])->save();
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -741,7 +741,7 @@ class Subscription extends Model
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
-            'quantity' => $isSinglePrice ? $firstItem->quantity : null,
+            'quantity' => $isSinglePrice ? $firstItem->quantity ?? null : null,
             'ends_at' => null,
         ])->save();
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -306,7 +306,7 @@ class SubscriptionBuilder
             'stripe_id' => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
-            'quantity' => $isSinglePrice ? $firstItem->quantity : null,
+            'quantity' => $isSinglePrice ? $firstItem->quantity ?? null : null,
             'trial_ends_at' => ! $this->skipTrial ? $this->trialExpires : null,
             'ends_at' => null,
         ]);

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -306,7 +306,7 @@ class SubscriptionBuilder
             'stripe_id' => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
-            'quantity' => $isSinglePrice ? $firstItem->quantity ?? null : null,
+            'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
             'trial_ends_at' => ! $this->skipTrial ? $this->trialExpires : null,
             'ends_at' => null,
         ]);


### PR DESCRIPTION
Fixed `Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity` when creating or swapping to a single metered price.

Related: #1254 

Test:

```
cashier-stripe % ./vendor/bin/phpunit --filter test_swap_metered_price_to_different_price
PHPUnit 9.5.20

Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity
Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity
.Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity
Stripe Notice: Undefined property of Stripe\SubscriptionItem instance: quantity
.                                                                  2 / 2 (100%)

Time: 00:23.421, Memory: 28.00 MB

OK (2 tests, 24 assertions)
```
