### PR TITLE
Add new method trialMonths

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -161,6 +161,19 @@ class SubscriptionBuilder
 
         return $this;
     }
+    
+    /**
+     * Specify the number of months of the trial.
+     *
+     * @param  int  $trialMonths
+     * @return $this
+     */
+    public function trialMonths($trialMonths)
+    {
+        $this->trialExpires = Carbon::now()->addMonths($trialMonths);
+
+        return $this;
+    }
 
     /**
      * Specify the ending date of the trial.


### PR DESCRIPTION
There are a lot of times that our customers have several months of trial period. I always have to use trialUntil():

### Before:

```
$user->newSubscription('default', 'price_monthly')
            ->trialUntil(Carbon::now()->addMonths(3))
            ->create($paymentMethod);
```
### After

```
$user->newSubscription('default', 'price_monthly')
           ->trialMonths(3)
            ->create($paymentMethod);
```