### PR TITLE
[13.x] Re-add support for Sources API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -140,14 +140,6 @@ public function boot()
 }
 ```
 
-### Stripe Sources Support Removed
-
-PR: https://github.com/laravel/cashier-stripe/pull/1077
-
-All support for the deprecated Stripe Sources API has been removed from Cashier. If you haven't already, we recommend that you upgrade to [the Payment Methods API](https://stripe.com/docs/payments/payment-methods).
-
-This also means that the `defaultPaymentMethod` method no longer returns the `default_source` of a customer. 
-
 ### New Payment Methods Support
 
 PR: https://github.com/laravel/cashier-stripe/pull/1074

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -5,6 +5,8 @@ namespace Laravel\Cashier\Concerns;
 use Exception;
 use Illuminate\Support\Collection;
 use Laravel\Cashier\PaymentMethod;
+use Stripe\BankAccount as StripeBankAccount;
+use Stripe\Card as StripeCard;
 use Stripe\PaymentMethod as StripePaymentMethod;
 
 trait ManagesPaymentMethods
@@ -134,7 +136,7 @@ trait ManagesPaymentMethods
     /**
      * Get the default payment method for the customer.
      *
-     * @return \Laravel\Cashier\PaymentMethod|null
+     * @return \Laravel\Cashier\PaymentMethod|\Stripe\Card|\Stripe\BankAccount|null
      */
     public function defaultPaymentMethod()
     {
@@ -142,11 +144,15 @@ trait ManagesPaymentMethods
             return;
         }
 
-        $customer = $this->asStripeCustomer(['invoice_settings.default_payment_method']);
+        /** @var \Stripe\Customer */
+        $customer = $this->asStripeCustomer(['default_source', 'invoice_settings.default_payment_method']);
 
         if ($customer->invoice_settings->default_payment_method) {
             return new PaymentMethod($this, $customer->invoice_settings->default_payment_method);
         }
+
+        // If we can't find a payment method, try to return a legacy source...
+        return $customer->default_source;
     }
 
     /**
@@ -195,10 +201,14 @@ trait ManagesPaymentMethods
     {
         $defaultPaymentMethod = $this->defaultPaymentMethod();
 
-        if ($defaultPaymentMethod && $defaultPaymentMethod instanceof PaymentMethod) {
-            $this->fillPaymentMethodDetails(
-                $defaultPaymentMethod->asStripePaymentMethod()
-            )->save();
+        if ($defaultPaymentMethod) {
+            if ($defaultPaymentMethod instanceof PaymentMethod) {
+                $this->fillPaymentMethodDetails(
+                    $defaultPaymentMethod->asStripePaymentMethod()
+                )->save();
+            } else {
+                $this->fillSourceDetails($defaultPaymentMethod)->save();
+            }
         } else {
             $this->forceFill([
                 'pm_type' => null,
@@ -223,6 +233,27 @@ trait ManagesPaymentMethods
         } else {
             $this->pm_type = $type = $paymentMethod->type;
             $this->pm_last_four = optional($paymentMethod)->$type->last4;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fills the model's properties with the source from Stripe.
+     *
+     * @param  \Stripe\Card|\Stripe\BankAccount|null  $source
+     * @return $this
+     *
+     * @deprecated Will be removed in a future Cashier update. You should use the new payment methods API instead.
+     */
+    protected function fillSourceDetails($source)
+    {
+        if ($source instanceof StripeCard) {
+            $this->pm_type = $source->brand;
+            $this->pm_last_four = $source->last4;
+        } elseif ($source instanceof StripeBankAccount) {
+            $this->pm_type = 'Bank Account';
+            $this->pm_last_four = $source->last4;
         }
 
         return $this;

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Tests\Feature;
 
 use Laravel\Cashier\PaymentMethod;
+use Stripe\Card as StripeCard;
 use Stripe\SetupIntent as StripeSetupIntent;
 
 class PaymentMethodsTest extends FeatureTestCase
@@ -113,6 +114,22 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertEquals('visa', $user->pm_type);
         $this->assertEquals('4242', $paymentMethod->card->last4);
         $this->assertEquals('4242', $user->pm_last_four);
+    }
+
+    public function test_legacy_we_can_retrieve_an_old_default_source_as_a_default_payment_method()
+    {
+        $user = $this->createCustomer('we_can_retrieve_an_old_default_source_as_a_default_payment_method');
+        $customer = $user->createAsStripeCustomer(['expand' => ['sources']]);
+
+        $card = $customer->sources->create(['source' => 'tok_visa']);
+        $customer->default_source = $card->id;
+        $customer->save();
+
+        $paymentMethod = $user->defaultPaymentMethod();
+
+        $this->assertInstanceOf(StripeCard::class, $paymentMethod);
+        $this->assertEquals('Visa', $paymentMethod->brand);
+        $this->assertEquals('4242', $paymentMethod->last4);
     }
 
     public function test_we_can_retrieve_all_payment_methods()


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/laravel/cashier-stripe/pull/1077. Because Stripe underneath still uses the Sources API themselves in some situations (adding a card through the dashboard, using the hosted payment page, ...) cards, etc get added as a `default_source`. This is unfortunate but the best course to proceed is to simply continuing to sync the default source Stripe sets and return it when it's available. This will provide the least friction to users.

We should still encourage people to not use the Sources API themselves like we do here: https://github.com/laravel/docs/pull/7997

Also see https://github.com/laravel/cashier-stripe/issues/1310