### PR TITLE
[13.x] Fix receipt totals and balance

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -289,23 +289,33 @@
                         @endforeach
                     @endunless
 
-                    <!-- Starting Balance -->
-                    @if ($invoice->hasStartingBalance())
-                        <tr>
-                            <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
-                                Customer Balance
-                            </td>
-                            <td>{{ $invoice->startingBalance() }}</td>
-                        </tr>
-                    @endif
-
                     <!-- Display The Final Total -->
                     <tr>
                         <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
-                            <strong>Total</strong>
+                            Total
                         </td>
                         <td>
-                            <strong>{{ $invoice->total() }}</strong>
+                            {{ $invoice->realTotal() }}
+                        </td>
+                    </tr>
+
+                    <!-- Applied Balance -->
+                    @if ($invoice->hasEndingBalance())
+                        <tr>
+                            <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
+                                Applied balance
+                            </td>
+                            <td>{{ $invoice->appliedBalance() }}</td>
+                        </tr>
+                    @endif
+
+                    <!-- Display The Amount Due -->
+                    <tr>
+                        <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
+                            <strong>Amount due</strong>
+                        </td>
+                        <td>
+                            <strong>{{ $invoice->amountDue() }}</strong>
                         </td>
                     </tr>
                 </table>

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -116,7 +116,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the total amount that was paid (or will be paid).
+     * Get the total amount minus the starting balance that was paid (or will be paid).
      *
      * @return string
      */
@@ -126,13 +126,33 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the raw total amount that was paid (or will be paid).
+     * Get the raw total amount minus the starting balance that was paid (or will be paid).
      *
      * @return int
      */
     public function rawTotal()
     {
         return $this->invoice->total + $this->rawStartingBalance();
+    }
+
+    /**
+     * Get the total amount that was paid (or will be paid).
+     *
+     * @return string
+     */
+    public function realTotal()
+    {
+        return $this->formatAmount($this->rawRealTotal());
+    }
+
+    /**
+     * Get the raw total amount that was paid (or will be paid).
+     *
+     * @return int
+     */
+    public function rawRealTotal()
+    {
+        return $this->invoice->total;
     }
 
     /**
@@ -143,6 +163,26 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     public function subtotal()
     {
         return $this->formatAmount($this->invoice->subtotal);
+    }
+
+    /**
+     * Get the amount due for the invoice.
+     *
+     * @return string
+     */
+    public function amountDue()
+    {
+        return $this->formatAmount($this->rawAmountDue());
+    }
+
+    /**
+     * Get the raw amount due for the invoice.
+     *
+     * @return int
+     */
+    public function rawAmountDue()
+    {
+        return $this->invoice->amount_due ?? 0;
     }
 
     /**
@@ -173,6 +213,60 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     public function rawStartingBalance()
     {
         return $this->invoice->starting_balance ?? 0;
+    }
+
+    /**
+     * Determine if the account had an ending balance.
+     *
+     * @return bool
+     */
+    public function hasEndingBalance()
+    {
+        return ! is_null($this->invoice->ending_balance);
+    }
+
+    /**
+     * Get the ending balance for the invoice.
+     *
+     * @return string
+     */
+    public function endingBalance()
+    {
+        return $this->formatAmount($this->rawEndingBalance());
+    }
+
+    /**
+     * Get the raw ending balance for the invoice.
+     *
+     * @return int
+     */
+    public function rawEndingBalance()
+    {
+        return $this->invoice->ending_balance ?? 0;
+    }
+
+    /**
+     * Get the applied balance for the invoice.
+     *
+     * @return string
+     */
+    public function appliedBalance()
+    {
+        return $this->formatAmount($this->rawAppliedBalance());
+    }
+
+    /**
+     * Get the raw ending balance for the invoice.
+     *
+     * @return int
+     */
+    public function rawAppliedBalance()
+    {
+        if (! $this->hasEndingBalance()) {
+            return 0;
+        }
+
+        return $this->rawStartingBalance() - $this->rawEndingBalance();
     }
 
     /**

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -69,7 +69,7 @@ class InvoiceTest extends TestCase
 
         $invoice = new Invoice($user, $stripeInvoice);
 
-        $total = $invoice->total();
+        $total = $invoice->realTotal();
 
         $this->assertEquals('$10.00', $total);
     }
@@ -86,7 +86,7 @@ class InvoiceTest extends TestCase
 
         $invoice = new Invoice($user, $stripeInvoice);
 
-        $total = $invoice->rawTotal();
+        $total = $invoice->rawRealTotal();
 
         $this->assertEquals(1000, $total);
     }
@@ -166,25 +166,41 @@ class InvoiceTest extends TestCase
 
         $invoice = new Invoice($user, $stripeInvoice);
 
-        $startingBalance = $invoice->startingBalance();
-
-        $this->assertEquals('-$4.50', $startingBalance);
+        $this->assertEquals('-$4.50', $invoice->startingBalance());
+        $this->assertEquals(-450, $invoice->rawStartingBalance());
     }
 
-    public function test_it_can_return_its_raw_starting_balance()
+    public function test_it_can_return_its_ending_balance()
     {
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->customer = 'foo';
-        $stripeInvoice->starting_balance = -450;
+        $stripeInvoice->ending_balance = -450;
+        $stripeInvoice->currency = 'USD';
 
         $user = new User();
         $user->stripe_id = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
-        $startingBalance = $invoice->rawStartingBalance();
+        $this->assertEquals('-$4.50', $invoice->endingBalance());
+        $this->assertEquals(-450, $invoice->rawEndingBalance());
+    }
 
-        $this->assertEquals(-450, $startingBalance);
+    public function test_it_can_return_its_applied_balance()
+    {
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+        $stripeInvoice->ending_balance = -350;
+        $stripeInvoice->starting_balance = -500;
+        $stripeInvoice->currency = 'USD';
+
+        $user = new User();
+        $user->stripe_id = 'foo';
+
+        $invoice = new Invoice($user, $stripeInvoice);
+
+        $this->assertEquals('-$1.50', $invoice->appliedBalance());
+        $this->assertEquals(-150, $invoice->rawAppliedBalance());
     }
 
     public function test_it_can_determine_if_it_has_a_discount_applied()


### PR DESCRIPTION
This PR fixes receipt totals when a balance is applied. 

Here's an example with the current Cashier receipt:

<img width="698" alt="Screenshot 2022-06-30 at 17 23 47" src="https://user-images.githubusercontent.com/594614/176722081-b68435e7-8994-400f-adab-b587fbc23d46.png">

And here's the Stripe invoice:

<img width="487" alt="Screenshot 2022-06-30 at 17 24 03" src="https://user-images.githubusercontent.com/594614/176722171-2d73c185-7d42-419b-b597-0668f3761f17.png">

As you can see these numbers do not match. There's no reason the total customer balance should be displayed and the final total invoice amount isn't correct (should be €12.10). 

With this PR it gets fixed to:

<img width="407" alt="Screenshot 2022-06-30 at 17 45 05" src="https://user-images.githubusercontent.com/594614/176722690-5e605279-0770-489d-bfb8-fc39a7da95cb.png">

So it's the same as the Stripe one. I've added new methods to the Invoice object to accommodate for these changes.

There's one note I'd like to make: the current behavior of the Invoice's `total` method is actually incorrect. I've added a new `realTotal` method to temporarily accommodate for the true value. I did not want to break backwards compatibility which is why I opted for a new method. In Cashier v14, I strongly want to urge to change the behavior of the `total` method and remove the `realTotal` method again.