### PR TITLE
add useStripeClient method to make StripeClient mockable

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -255,6 +255,6 @@ class Cashier
      */
     public static function useStripeClient($client)
     {
-        self::$stripeClientInstance = $client;
+        static::$stripeClientInstance = $client;
     }
 }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -91,6 +91,13 @@ class Cashier
     public static $subscriptionItemModel = SubscriptionItem::class;
 
     /**
+     * The stripe client instance.
+     *
+     * @var StripeClient
+     */
+    public static $stripeClientInstance = null;
+
+    /**
      * Get the customer instance by its Stripe ID.
      *
      * @param  \Stripe\Customer|string|null  $stripeId
@@ -111,7 +118,7 @@ class Cashier
      */
     public static function stripe(array $options = [])
     {
-        return new StripeClient(array_merge([
+        return self::$stripeClientInstance ?? new StripeClient(array_merge([
             'api_key' => $options['api_key'] ?? config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
             'api_base' => static::$apiBaseUrl,
@@ -238,5 +245,16 @@ class Cashier
     public static function useSubscriptionItemModel($subscriptionItemModel)
     {
         static::$subscriptionItemModel = $subscriptionItemModel;
+    }
+
+    /**
+     * Set the stripe client instance.
+     *
+     * @param  string  $stripeClient
+     * @return void
+     */
+    public static function useStripeClient($client)
+    {
+        self::$stripeClientInstance = $client;
     }
 }

--- a/tests/Unit/CashierTest.php
+++ b/tests/Unit/CashierTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Tests\Unit;
 
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Tests\TestCase;
+use Stripe\StripeClient;
 
 class CashierTest extends TestCase
 {
@@ -16,4 +17,16 @@ class CashierTest extends TestCase
     {
         $this->assertSame('$10', Cashier::formatAmount(1000, null, null, ['min_fraction_digits' => 0]));
     }
+
+    public function test_stripe_client_can_be_overridden()
+    {
+        $fakeClient = new class {};
+
+        $this->assertInstanceOf(StripeClient::class, Cashier::stripe());
+
+        Cashier::useStripeClient($fakeClient);
+
+        $this->assertInstanceOf($fakeClient::class, Cashier::stripe());
+    }
 }
+


### PR DESCRIPTION
Hello, 

I noticed in the documentation it says [Cashier hits stripe api](https://laravel.com/docs/9.x/billing#testing:~:text=When%20testing%20an%20application%20that%20uses%20Cashier%2C%20you%20may%20mock%20the%20actual%20HTTP%20requests%20to%20the%20Stripe%20API) with testing secrets and it's recommended way.  and If I want to mock I should [partially re-implement Cashier's own behavior](https://laravel.com/docs/9.x/billing#testing:~:text=partially%20re%2Dimplement%20Cashier%27s%20own%20behavior). 

so for my case, I had to implement a fake user class to do that like below for every case.
```php
class UserWithStripeFake extends User
{
    protected $table = 'users';

    protected $primaryKey = 'id';

    public static function stripe(array $options = [])
    {
        return Mockery::mock(StripeClient::class)->expects('request')->andReturn((object)[
            'status' => 'past_due',
        ]);
    }
}
```
but It would be much nicer if Cashier provides a way to make it easy to mock/replace `StripeClient` class. so in this PR I'm allowing this by following an existing convention to override [User model](https://github.com/laravel/cashier-stripe/blob/13.x/src/Cashier.php#L216) and [Subscription model](https://github.com/laravel/cashier-stripe/blob/13.x/src/Cashier.php#L227), that makes it easy to just have the code like below
```php
$stripeClient = $this->mock(StripeClient::class)->expects('request')->andReturn((object)[
    'status' => 'past_due',
]);

Cashier::useStripeClient($stripeClient);
```