### PR TITLE
[13.x] Allow dompdf v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "dompdf/dompdf": "^1.2.1",
+        "dompdf/dompdf": "^1.2.1|^2.0",
         "illuminate/console": "^8.37|^9.0",
         "illuminate/contracts": "^8.37|^9.0",
         "illuminate/database": "^8.37|^9.0",


### PR DESCRIPTION
This is to add the change from #1391 to the `13.x` branch. The last version of domdpf v1 has a [security vulnerability](https://github.com/advisories/GHSA-pf6p-25r2-fx45) and it doesn't look like they intend to patch v1.
