### PR TITLE
[14.x] Manage Checkout PM from Dashboard

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -61,7 +61,6 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             'mode' => 'payment',
             'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
             'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
-            'payment_method_types' => ['card'],
         ], $sessionOptions));
 
         return new static($owner, $session);


### PR DESCRIPTION
In Cashier v14 I'd like to make a change to the default payment methods used on a Checkout session by allowing to manage them from the Dashboard by default. Removing this parameter will allow vendors to turn off and on payment methods from the dashboard as they please.

See https://stripe.com/docs/payments/dashboard-payment-methods#update

Closes https://github.com/laravel/cashier-stripe/issues/1379