### PR TITLE
[14.x] Add method to reset default payment method properties

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -113,10 +113,7 @@ trait ManagesPaymentMethods
 
         // If the payment method was the default payment method, we'll remove it manually...
         if ($stripePaymentMethod->id === $defaultPaymentMethod) {
-            $this->forceFill([
-                'pm_type' => null,
-                'pm_last_four' => null,
-            ])->save();
+            $this->resetDefaultPaymentMethod();
         }
     }
 
@@ -210,10 +207,7 @@ trait ManagesPaymentMethods
                 $this->fillSourceDetails($defaultPaymentMethod)->save();
             }
         } else {
-            $this->forceFill([
-                'pm_type' => null,
-                'pm_last_four' => null,
-            ])->save();
+            $this->resetDefaultPaymentMethod();
         }
 
         return $this;
@@ -256,6 +250,22 @@ trait ManagesPaymentMethods
             $this->pm_last_four = $source->last4;
         }
 
+        return $this;
+    }
+    
+    /**
+     * Resets the model's deault payment method properties.
+     *
+     * @return $this
+     *
+     */
+    protected function resetDefaultPaymentMethod()
+    {
+        $this->forceFill([
+            'pm_type' => null,
+            'pm_last_four' => null,
+        ])->save();
+        
         return $this;
     }
 

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -264,7 +264,7 @@ trait ManagesPaymentMethods
             'pm_type' => null,
             'pm_last_four' => null,
         ])->save();
-        
+
         return $this;
     }
 

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -252,12 +252,11 @@ trait ManagesPaymentMethods
 
         return $this;
     }
-    
+
     /**
      * Resets the model's deault payment method properties.
      *
      * @return $this
-     *
      */
     protected function resetDefaultPaymentMethod()
     {


### PR DESCRIPTION
The PR allows developers to customize behaviour when default payment method properties are being reset.

In our case, we do not use the `pm_type` and `pm_last_four` model properties. Instead we have a `stripe_default_payment_method` property.

We can already overwrite how payment method details are filled with:
```php
protected function fillPaymentMethodDetails($paymentMethod)
{
    $this->forceFill([
        'stripe_default_payment_method' => $paymentMethod->id ?? null,
    ]);

    return $this;
}
```

This change also allows updating the model when the default payment method is being removed:
```php
protected function resetDefaultPaymentMethod()
{
    $this->forceFill([
        'stripe_default_payment_method' => null,
    ])->save();
        
    return $this;
}
```

I'm targeting the next major version because this could be a breaking change if the method is already present in the billable model.