### PR TITLE
[14.x] Sync preferred locales

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -186,7 +186,7 @@ trait ManagesCustomer
     }
 
     /**
-     * Get the preferred locales that should be synced to Stripe.
+     * Get the locales that should be synced to Stripe.
      *
      * @return array
      */

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -79,6 +79,10 @@ trait ManagesCustomer
             $options['address'] = $address;
         }
 
+        if (! array_key_exists('preferred_locales', $options) && $locales = $this->stripePreferredLocales()) {
+            $options['preferred_locales'] = $locales;
+        }
+
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances
         // and allow us to retrieve users from Stripe later when we need to work.
@@ -182,6 +186,16 @@ trait ManagesCustomer
     }
 
     /**
+     * Get the preferred locales that should be synced to Stripe.
+     *
+     * @return array
+     */
+    public function stripePreferredLocales()
+    {
+        return [];
+    }
+
+    /**
      * Sync the customer's information to Stripe.
      *
      * @return \Stripe\Customer
@@ -193,6 +207,7 @@ trait ManagesCustomer
             'email' => $this->stripeEmail(),
             'phone' => $this->stripePhone(),
             'address' => $this->stripeAddress(),
+            'preferred_locales' => $this->stripePreferredLocales(),
         ]);
     }
 


### PR DESCRIPTION
This PR adds an easy way to sync preferred locales for customers. By providing this, customers will be able to set their preferred locales so their Stripe receipts are translated as well. 

Targeting master because now that this is part of `syncStripeCustomerDetails` it could reset customer's value with the new default value. We'll note this in the upgrade guide.

Closes https://github.com/laravel/cashier-stripe/issues/1399