### PR TITLE
[13.x] Create invoices separately

### DIFF
--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -30,6 +30,21 @@ class InvoicesTest extends FeatureTestCase
         $this->assertFalse($response);
     }
 
+    public function test_invoices_can_be_created()
+    {
+        $user = $this->createCustomer('invoices_can_be_created');
+        $user->createAsStripeCustomer();
+
+        $invoice = $user->createInvoice();
+
+        $this->assertInstanceOf(Invoice::class, $invoice);
+        $this->assertEquals(0, $invoice->rawTotal());
+
+        $invoice->tab('Laracon', 49900);
+
+        $this->assertEquals(49900, $invoice->rawTotal());
+    }
+
     public function test_customer_can_be_invoiced()
     {
         $user = $this->createCustomer('customer_can_be_invoiced');


### PR DESCRIPTION
This PR adds some new functionality to Cashier to allow to create invoices separately without sending them (draft state) as well as a few methods to add new items to invoices directly.

```php
// Creates a new empty draft invoice...
$invoice = $user->createInvoice();

// Add a new price line item to the invoice...
$invoice->tabPrice('price_xxx', 5);
```

Closes https://github.com/laravel/cashier-stripe/issues/1397