### PR TITLE
[13.x] Allow Stripe SDK v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/view": "^8.37|^9.0",
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
-        "stripe/stripe-php": "^7.39|^8.0",
+        "stripe/stripe-php": "^7.39|^8.0|^9.0",
         "symfony/http-kernel": "^5.0|^6.0",
         "symfony/polyfill-intl-icu": "^1.22.1"
     },


### PR DESCRIPTION
At first glance on the changelog, there don't seem to be breaking changes to Cashier v13 or Spark v2.

https://github.com/stripe/stripe-php/blob/master/CHANGELOG.md