### PR TITLE
invoiceFor was getting an error saying no invoice items.

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -119,7 +119,7 @@ trait ManagesInvoices
     {
         try {
             $invoice = $this->createInvoice(array_merge([
-                'pending_invoice_items_behavior' => 'include_and_require',
+                'pending_invoice_items_behavior' => 'include',
             ], $options));
 
             return $invoice->chargesAutomatically() ? $invoice->pay() : $invoice->send();


### PR DESCRIPTION
here is the item from docs:
pending_invoice_items_behavior
How to handle pending invoice items on invoice creation. One of include or exclude. include will include any pending invoice items, and will create an empty draft invoice if no pending invoice items exist. exclude will always create an empty invoice draft regardless if there are pending invoice items or not. Defaults to exclude if the parameter is omitted.

Current cashier code was using include _and_require causing a "no items found" error.
