### PR TITLE
[14.x] Update to new Stripe version

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -25,7 +25,7 @@ class Cashier
      *
      * @var string
      */
-    const STRIPE_VERSION = '2020-08-27';
+    const STRIPE_VERSION = '2022-08-01';
 
     /**
      * The base URL for the Stripe API.

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -118,7 +118,9 @@ trait ManagesInvoices
     public function invoice(array $options = [])
     {
         try {
-            $invoice = $this->createInvoice($options);
+            $invoice = $this->createInvoice(array_merge([
+                'pending_invoice_items_behavior' => 'include',
+            ], $options));
 
             return $invoice->chargesAutomatically() ? $invoice->pay() : $invoice->send();
         } catch (StripeCardException) {

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -118,12 +118,10 @@ trait ManagesInvoices
     public function invoice(array $options = [])
     {
         try {
-            $invoice = $this->createInvoice(array_merge([
-                'pending_invoice_items_behavior' => 'include_and_require',
-            ], $options));
+            $invoice = $this->createInvoice($options);
 
             return $invoice->chargesAutomatically() ? $invoice->pay() : $invoice->send();
-        } catch (StripeCardException $exception) {
+        } catch (StripeCardException) {
             $payment = new Payment(
                 $this->stripe()->paymentIntents->retrieve(
                     $invoice->asStripeInvoice()->refresh()->payment_intent,
@@ -148,7 +146,6 @@ trait ManagesInvoices
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
             'customer' => $this->stripe_id,
-            'pending_invoice_items_behavior' => 'exclude',
         ], $options);
 
         $stripeInvoice = $this->stripe()->invoices->create($parameters);

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Cashier\Tests\Feature;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Laravel\Cashier\Invoice;
-use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
 use Stripe\InvoiceItem as StripeInvoiceItem;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -16,17 +15,6 @@ class InvoicesTest extends FeatureTestCase
         $user = $this->createCustomer('require_stripe_customer_for_invoicing');
 
         $this->expectException(InvalidCustomer::class);
-
-        $user->invoice();
-    }
-
-    public function test_invoicing_fails_with_nothing_to_invoice()
-    {
-        $user = $this->createCustomer('invoicing_fails_with_nothing_to_invoice');
-        $user->createAsStripeCustomer();
-        $user->updateDefaultPaymentMethod('pm_card_visa');
-
-        $this->expectException(StripeInvalidRequestException::class);
 
         $user->invoice();
     }


### PR DESCRIPTION
This PR bumps the Stripe API version to the latest 2022-08-01 version: https://stripe.com/docs/upgrades#2022-08-01

The most notable breaking change is that no exception will be thrown anymore when an invoice is attempted to be made while there are no pending invoice items. Instead, a new draft invoice will be created.