### PR TITLE
[14.x] New subscription behavior

### DIFF
--- a/src/Concerns/HandlesPaymentFailures.php
+++ b/src/Concerns/HandlesPaymentFailures.php
@@ -18,6 +18,8 @@ trait HandlesPaymentFailures
      * @return void
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     *
+     * @internal
      */
     public function handlePaymentFailure(Subscription $subscription, $paymentMethod = null)
     {

--- a/src/Concerns/HandlesPaymentFailures.php
+++ b/src/Concerns/HandlesPaymentFailures.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+use Laravel\Cashier\Exceptions\IncompletePayment;
+use Laravel\Cashier\Payment;
+use Laravel\Cashier\Subscription;
+use Stripe\Exception\CardException as StripeCardException;
+use Stripe\PaymentMethod as StripePaymentMethod;
+
+trait HandlesPaymentFailures
+{
+    /**
+     * Handle a failed payment for the given subscription.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
+     * @return void
+     *
+     * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     */
+    public function handlePaymentFailure(Subscription $subscription, $paymentMethod = null)
+    {
+        if ($subscription->hasIncompletePayment()) {
+            try {
+                $subscription->latestPayment()->validate();
+            } catch (IncompletePayment $e) {
+                if ($e->payment->requiresConfirmation()) {
+                    try {
+                        if ($paymentMethod) {
+                            $e->payment->confirm([
+                                'payment_method' => $paymentMethod instanceof StripePaymentMethod
+                                    ? $paymentMethod->id
+                                    : $paymentMethod,
+                            ]);
+                        } else {
+                            $e->payment->confirm();
+                        }
+                    } catch (StripeCardException) {
+                        //
+                    }
+
+                    $stripeSubscription = $subscription->asStripeSubscription(['latest_invoice.payment_intent']);
+
+                    $subscription->fill([
+                        'stripe_status' => $stripeSubscription->status,
+                    ])->save();
+
+                    if ($subscription->hasIncompletePayment()) {
+                        (new Payment(
+                            $stripeSubscription->latest_invoice->payment_intent
+                        ))->validate();
+                    }
+                } else {
+                    throw $e;
+                }
+            }
+        }
+    }
+}

--- a/src/Concerns/InteractsWithPaymentBehavior.php
+++ b/src/Concerns/InteractsWithPaymentBehavior.php
@@ -11,7 +11,19 @@ trait InteractsWithPaymentBehavior
      *
      * @var string
      */
-    protected $paymentBehavior = StripeSubscription::PAYMENT_BEHAVIOR_ALLOW_INCOMPLETE;
+    protected $paymentBehavior = StripeSubscription::PAYMENT_BEHAVIOR_DEFAULT_INCOMPLETE;
+
+    /**
+     * Set any new subscription as incomplete when created.
+     *
+     * @return $this
+     */
+    public function defaultIncomplete()
+    {
+        $this->paymentBehavior = StripeSubscription::PAYMENT_BEHAVIOR_DEFAULT_INCOMPLETE;
+
+        return $this;
+    }
 
     /**
      * Allow subscription changes even if payment fails.

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
+use Laravel\Cashier\Concerns\HandlesPaymentFailures;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
@@ -24,6 +25,7 @@ use Stripe\Subscription as StripeSubscription;
 class Subscription extends Model
 {
     use AllowsCoupons;
+    use HandlesPaymentFailures;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
@@ -526,31 +528,7 @@ class Subscription extends Model
             'quantity' => $stripeSubscription->quantity,
         ])->save();
 
-        if ($this->hasIncompletePayment()) {
-            try {
-                (new Payment(
-                    $stripeSubscription->latest_invoice->payment_intent
-                ))->validate();
-            } catch (IncompletePayment $e) {
-                if ($e->payment->requiresConfirmation()) {
-                    $e->payment->confirm();
-
-                    $stripeSubscription = $this->asStripeSubscription(['latest_invoice.payment_intent']);
-
-                    $this->fill([
-                        'stripe_status' => $stripeSubscription->status,
-                    ])->save();
-
-                    if ($this->hasIncompletePayment()) {
-                        (new Payment(
-                            $stripeSubscription->latest_invoice->payment_intent
-                        ))->validate();
-                    }
-                } else {
-                    throw $e;
-                }
-            }
-        }
+        $this->handlePaymentFailure($this);
 
         return $this;
     }
@@ -698,6 +676,7 @@ class Subscription extends Model
      * @param  array  $options
      * @return $this
      *
+     * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
     public function swap($prices, array $options = [])
@@ -742,11 +721,7 @@ class Subscription extends Model
 
         $this->unsetRelation('items');
 
-        if ($this->hasIncompletePayment()) {
-            (new Payment(
-                $stripeSubscription->latest_invoice->payment_intent
-            ))->validate();
-        }
+        $this->handlePaymentFailure($this);
 
         return $this;
     }
@@ -903,37 +878,13 @@ class Subscription extends Model
             ])->save();
         }
 
-        $stripeSubscription = $this->asStripeSubscription(['latest_invoice.payment_intent']);
+        $stripeSubscription = $this->asStripeSubscription();
 
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
         ])->save();
 
-        if ($this->hasIncompletePayment()) {
-            try {
-                (new Payment(
-                    $stripeSubscription->latest_invoice->payment_intent
-                ))->validate();
-            } catch (IncompletePayment $e) {
-                if ($e->payment->requiresConfirmation()) {
-                    $e->payment->confirm();
-
-                    $stripeSubscription = $this->asStripeSubscription(['latest_invoice.payment_intent']);
-
-                    $this->fill([
-                        'stripe_status' => $stripeSubscription->status,
-                    ])->save();
-
-                    if ($this->hasIncompletePayment()) {
-                        (new Payment(
-                            $stripeSubscription->latest_invoice->payment_intent
-                        ))->validate();
-                    }
-                } else {
-                    throw $e;
-                }
-            }
-        }
+        $this->handlePaymentFailure($this);
 
         return $this;
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -871,14 +871,14 @@ class Subscription extends Model
 
         $this->unsetRelation('items');
 
+        $stripeSubscription = $this->asStripeSubscription();
+
         if ($this->hasSinglePrice()) {
             $this->fill([
                 'stripe_price' => null,
                 'quantity' => null,
-            ])->save();
+            ]);
         }
-
-        $stripeSubscription = $this->asStripeSubscription();
 
         $this->fill([
             'stripe_status' => $stripeSubscription->status,

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -119,17 +119,15 @@ class SubscriptionItem extends Model
 
         $stripeSubscription = $this->subscription->asStripeSubscription();
 
-        $this->subscription->fill([
-            'stripe_status' => $stripeSubscription->status,
-        ]);
-
         if ($this->subscription->hasSinglePrice()) {
             $this->subscription->fill([
                 'quantity' => $stripeSubscriptionItem->quantity,
             ]);
         }
 
-        $this->subscription->save();
+        $this->subscription->fill([
+            'stripe_status' => $stripeSubscription->status,
+        ])->save();
 
         $this->handlePaymentFailure($this->subscription);
 
@@ -169,10 +167,6 @@ class SubscriptionItem extends Model
 
         $stripeSubscription = $this->subscription->asStripeSubscription();
 
-        $this->subscription->fill([
-            'stripe_status' => $stripeSubscription->status,
-        ]);
-
         if ($this->subscription->hasSinglePrice()) {
             $this->subscription->fill([
                 'stripe_price' => $price,
@@ -180,7 +174,9 @@ class SubscriptionItem extends Model
             ]);
         }
 
-        $this->subscription->save();
+        $this->subscription->fill([
+            'stripe_status' => $stripeSubscription->status,
+        ])->save();
 
         $this->handlePaymentFailure($this->subscription);
 

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Laravel\Cashier\Concerns\HandlesPaymentFailures;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
@@ -15,6 +16,7 @@ use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
  */
 class SubscriptionItem extends Model
 {
+    use HandlesPaymentFailures;
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
@@ -115,18 +117,21 @@ class SubscriptionItem extends Model
             'quantity' => $stripeSubscriptionItem->quantity,
         ])->save();
 
+        $stripeSubscription = $this->subscription->asStripeSubscription();
+
+        $this->subscription->fill([
+            'stripe_status' => $stripeSubscription->status,
+        ]);
+
         if ($this->subscription->hasSinglePrice()) {
-            $stripeSubscription = $this->subscription->asStripeSubscription();
-
             $this->subscription->fill([
-                'stripe_status' => $stripeSubscription->status,
                 'quantity' => $stripeSubscriptionItem->quantity,
-            ])->save();
+            ]);
         }
 
-        if ($this->subscription->hasIncompletePayment()) {
-            optional($this->subscription->latestPayment())->validate();
-        }
+        $this->subscription->save();
+
+        $this->handlePaymentFailure($this->subscription);
 
         return $this;
     }
@@ -162,16 +167,22 @@ class SubscriptionItem extends Model
             'quantity' => $stripeSubscriptionItem->quantity,
         ])->save();
 
+        $stripeSubscription = $this->subscription->asStripeSubscription();
+
+        $this->subscription->fill([
+            'stripe_status' => $stripeSubscription->status,
+        ]);
+
         if ($this->subscription->hasSinglePrice()) {
             $this->subscription->fill([
                 'stripe_price' => $price,
                 'quantity' => $stripeSubscriptionItem->quantity,
-            ])->save();
+            ]);
         }
 
-        if ($this->subscription->hasIncompletePayment()) {
-            optional($this->subscription->latestPayment())->validate();
-        }
+        $this->subscription->save();
+
+        $this->handlePaymentFailure($this->subscription);
 
         return $this;
     }


### PR DESCRIPTION
This PR adopts the new recommended `default_incomplete` payment behavior that Stripe now recommends. The main adjustments here are the transition to the new `default_incomplete` value when passing the `payment_behavior` when creating or updating subscriptions or subscription items and confirming the payment intents server-side before throwing the `IncompletePayment` exception.

I've extracted the logic to handle payment failures in a new `HandlesPaymentFailures` trait. In here, we'll check if a subscription has a failed payment. If so, we'll check if it needs confirmation and when it does we'll confirm it server-side. If a payment method has been provided as well (usually when creating a subscription) we'll pass it along. After confirming the payment we'll need to update the subscription status. If no confirmation is needed and there is an incomplete payment we'll cascade the exception immediately. 

I managed to made this PR backwards compatible for existing integrations. Existing integrations are expected to handle failing payments anyway so it should be a smooth upgrade.

The next step I want to take is to update our docs with the flow of how Stripe recommends to handle collecting payment details which is after a subscription has been already created.

More info: https://stripe.com/docs/billing/subscriptions/build-subscriptions?ui=elements#create-subscription