### PR TITLE
[13.x] Fix Stripe key not found

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -202,7 +202,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     public function asStripePaymentIntent(array $expand = [])
     {
         if ($expand) {
-            return $this->paymentIntent->retrieve(
+            return $this->customer()->stripe()->paymentIntents->retrieve(
                 $this->paymentIntent->id, ['expand' => $expand]
             );
         }


### PR DESCRIPTION
We need to reference the Stripe SDK directly here instead of using the `retrieve` method on an existing PI. Discovered this while working on https://github.com/laravel/cashier-stripe/pull/1420