### PR TITLE
[13.x] Add invoice.payment_succeeded event to WebhookCommand

### DIFF
--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -41,6 +41,7 @@ class WebhookCommand extends Command
                 'customer.updated',
                 'customer.deleted',
                 'invoice.payment_action_required',
+                'invoice.payment_succeeded',
             ],
             'url' => $this->option('url') ?? route('cashier.webhook'),
             'api_version' => $this->option('api-version') ?? Cashier::STRIPE_VERSION,


### PR DESCRIPTION
I realized this webhook isn't added when you update Spark to the latest version. Instead of writing docs so people can add this manually I think it's easier to just add the event to the Cashier webhook even if Cashier itself doesn't handles the event (but Spark does). I'll merge upstream into v14.