### PR TITLE
[13.x] Fix applied balance on receipts

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -300,7 +300,7 @@
                     </tr>
 
                     <!-- Applied Balance -->
-                    @if ($invoice->hasEndingBalance())
+                    @if ($invoice->rawAppliedBalance() > 0)
                         <tr>
                             <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
                                 Applied balance


### PR DESCRIPTION
Only show the applied balance when there is any. Otherwise it doesn't really has any meaning.