### PR TITLE
[14.x] Renders the invoice item dates on invoices when set

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -187,7 +187,19 @@
                     <!-- Display The Invoice Items -->
                     @foreach ($invoice->invoiceItems() as $item)
                         <tr class="row">
-                            <td colspan="2">{{ $item->description }}</td>
+                            @if($item->period?->start === $item->period?->end)
+                                <td colspan="2">
+                                    {{ $item->description }}
+                                </td>
+                            @else
+                                <td>
+                                    {{ $item->description }}
+                                </td>
+                                <td>
+                                    {{ \Carbon\Carbon::parse($item->period->start)->toFormattedDateString() }}
+                                    - {{ \Carbon\Carbon::parse($item->period->end)->toFormattedDateString() }}
+                                </td>
+                            @endif
 
                             @if ($invoice->hasTax())
                                 <td>

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -184,10 +184,10 @@
                         <th align="right">Amount</th>
                     </tr>
 
-                    <!-- Display The Invoice Items -->
-                    @foreach ($invoice->invoiceItems() as $item)
+                    <!-- Display The Invoice Line Items -->
+                    @foreach ($invoice->invoiceLineItems() as $item)
                         <tr class="row">
-                            @if($item->period?->start === $item->period?->end)
+                            @if (! $item->hasPeriod() || $item->hasEqualPeriod())
                                 <td colspan="2">
                                     {{ $item->description }}
                                 </td>
@@ -196,8 +196,7 @@
                                     {{ $item->description }}
                                 </td>
                                 <td>
-                                    {{ \Carbon\Carbon::parse($item->period->start)->toFormattedDateString() }}
-                                    - {{ \Carbon\Carbon::parse($item->period->end)->toFormattedDateString() }}
+                                    {{ $item->startDate() }} - {{ $item->endDate() }}
                                 </td>
                             @endif
 
@@ -218,35 +217,6 @@
                             @endif
 
                             <td>{{ $item->total() }}</td>
-                        </tr>
-                    @endforeach
-
-                    <!-- Display The Subscriptions -->
-                    @foreach ($invoice->subscriptions() as $subscription)
-                        <tr class="row">
-                            <td>{{ $subscription->description }}</td>
-                            <td>
-                                {{ $subscription->startDateAsCarbon()->toFormattedDateString() }} -
-                                {{ $subscription->endDateAsCarbon()->toFormattedDateString() }}
-                            </td>
-
-                            @if ($invoice->hasTax())
-                                <td>
-                                    @if ($inclusiveTaxPercentage = $subscription->inclusiveTaxPercentage())
-                                        {{ $inclusiveTaxPercentage }}% incl.
-                                    @endif
-
-                                    @if ($subscription->hasBothInclusiveAndExclusiveTax())
-                                        +
-                                    @endif
-
-                                    @if ($exclusiveTaxPercentage = $subscription->exclusiveTaxPercentage())
-                                        {{ $exclusiveTaxPercentage }}%
-                                    @endif
-                                </td>
-                            @endif
-
-                            <td>{{ $subscription->total() }}</td>
                         </tr>
                     @endforeach
 

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -187,7 +187,7 @@
                     <!-- Display The Invoice Line Items -->
                     @foreach ($invoice->invoiceLineItems() as $item)
                         <tr class="row">
-                            @if (! $item->hasPeriod() || $item->hasEqualPeriod())
+                            @if (! $item->hasPeriod() || $item->periodStartAndEndAreEqual())
                                 <td colspan="2">
                                     {{ $item->description }}
                                 </td>

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -144,26 +144,6 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Determine if the invoice line item has a period set.
-     *
-     * @return bool
-     */
-    public function hasPeriod()
-    {
-        return ! is_null($this->item->period);
-    }
-
-    /**
-     * Determine if the invoice line item has a period with the same start and end date.
-     *
-     * @return bool
-     */
-    public function hasEqualPeriod()
-    {
-        return $this->hasPeriod() ? $this->item->period->start === $this->item->period->end : false;
-    }
-
-    /**
      * Get a human readable date for the start date.
      *
      * @return string|null
@@ -209,6 +189,26 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
         if ($this->hasPeriod()) {
             return Carbon::createFromTimestampUTC($this->item->period->end);
         }
+    }
+
+    /**
+     * Determine if the invoice line item has a defined period.
+     *
+     * @return bool
+     */
+    public function hasPeriod()
+    {
+        return ! is_null($this->item->period);
+    }
+
+    /**
+     * Determine if the invoice line item has a period with the same start and end date.
+     *
+     * @return bool
+     */
+    public function periodStartAndEndAreEqual()
+    {
+        return $this->hasPeriod() ? $this->item->period->start === $this->item->period->end : false;
     }
 
     /**

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -144,13 +144,33 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Determine if the invoice line item has a period set.
+     *
+     * @return bool
+     */
+    public function hasPeriod()
+    {
+        return ! is_null($this->item->period);
+    }
+
+    /**
+     * Determine if the invoice line item has a period with the same start and end date.
+     *
+     * @return bool
+     */
+    public function hasEqualPeriod()
+    {
+        return $this->hasPeriod() ? $this->item->period->start === $this->item->period->end : false;
+    }
+
+    /**
      * Get a human readable date for the start date.
      *
-     * @return string
+     * @return string|null
      */
     public function startDate()
     {
-        if ($this->isSubscription()) {
+        if ($this->hasPeriod()) {
             return $this->startDateAsCarbon()->toFormattedDateString();
         }
     }
@@ -158,11 +178,11 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
     /**
      * Get a human readable date for the end date.
      *
-     * @return string
+     * @return string|null
      */
     public function endDate()
     {
-        if ($this->isSubscription()) {
+        if ($this->hasPeriod()) {
             return $this->endDateAsCarbon()->toFormattedDateString();
         }
     }
@@ -170,11 +190,11 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
     /**
      * Get a Carbon instance for the start date.
      *
-     * @return \Carbon\Carbon
+     * @return \Carbon\Carbon|null
      */
     public function startDateAsCarbon()
     {
-        if ($this->isSubscription()) {
+        if ($this->hasPeriod()) {
             return Carbon::createFromTimestampUTC($this->item->period->start);
         }
     }
@@ -182,11 +202,11 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
     /**
      * Get a Carbon instance for the end date.
      *
-     * @return \Carbon\Carbon
+     * @return \Carbon\Carbon|null
      */
     public function endDateAsCarbon()
     {
-        if ($this->isSubscription()) {
+        if ($this->hasPeriod()) {
             return Carbon::createFromTimestampUTC($this->item->period->end);
         }
     }


### PR DESCRIPTION
This fixes #1431, following the stripe "when are dates shown" on invoices as per https://stripe.com/docs/api/invoiceitems/object#invoiceitem_object-period