### PR TITLE
[14.x] Fix subscription invoicing bug

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -150,6 +150,10 @@ trait ManagesInvoices
             'customer' => $this->stripe_id,
         ], $options);
 
+        if (array_key_exists('subscription', $parameters)) {
+            unset($parameters['pending_invoice_items_behavior']);
+        }
+
         $stripeInvoice = $this->stripe()->invoices->create($parameters);
 
         return new Invoice($this, $stripeInvoice);

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -955,4 +955,18 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame('draft', $invoice->status);
         $this->assertSame(1000, $invoice->total);
     }
+
+    public function test_invoice_subscription_directly()
+    {
+        $user = $this->createCustomer('invoice_subscription_directly');
+        $subscription = $user->newSubscription('main', static::$priceId)
+            ->create('pm_card_visa');
+
+        $subscription->updateQuantity(3);
+
+        $invoice = $subscription->invoice();
+
+        $this->assertSame('paid', $invoice->status);
+        $this->assertSame(2000, $invoice->total);
+    }
 }


### PR DESCRIPTION
Apparently you cannot combine the `pending_invoice_items_behavior` and `subscription` parameters when invoicing a subscription directly. Added a test to check for this.

Fixes https://github.com/laravel/cashier-stripe/issues/1433