### PR TITLE
[14.x] Add generic trial scopes

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Carbon\Carbon;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\SubscriptionBuilder;
@@ -75,6 +76,17 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Filter query by on generic trial.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeOnGenericTrial($query)
+    {
+        $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '>', Carbon::now());
+    }
+
+    /**
      * Determine if the Stripe model's "generic" trial at the model level has expired.
      *
      * @return bool
@@ -82,6 +94,17 @@ trait ManagesSubscriptions
     public function hasExpiredGenericTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isPast();
+    }
+
+    /**
+     * Filter query by expired generic trial.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeHasExpiredGenericTrial($query)
+    {
+        $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '<', Carbon::now());
     }
 
     /**

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -76,7 +76,7 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Filter query by on generic trial.
+     * Filter the given query for generic trials.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
@@ -97,7 +97,7 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Filter query by expired generic trial.
+     * Filter the given query for expired generic trials.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Cashier\Tests\Feature;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Laravel\Cashier\CustomerBalanceTransaction;
-use Laravel\Cashier\Tests\Fixtures\User;
 use Stripe\TaxId as StripeTaxId;
 
 class CustomerTest extends FeatureTestCase

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
+use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Laravel\Cashier\CustomerBalanceTransaction;
+use Laravel\Cashier\Tests\Fixtures\User;
 use Stripe\TaxId as StripeTaxId;
 
 class CustomerTest extends FeatureTestCase
@@ -114,5 +116,22 @@ class CustomerTest extends FeatureTestCase
         $this->assertSame('-$2.00', $transaction->amount());
         $this->assertSame(300, $transaction->rawEndingBalance());
         $this->assertSame(300, $user->rawBalance());
+    }
+
+
+    public function test_on_generic_trial_scopes()
+    {
+        $user = $this->createCustomer('on_generic_trial', ['trial_ends_at' => Carbon::tomorrow()]);
+
+        $this->assertTrue($user->query()->onGenericTrial()->exists());
+        $this->assertFalse($user->query()->hasExpiredGenericTrial()->exists());
+    }
+
+    public function test_expired_generic_trial_scopes()
+    {
+        $user = $this->createCustomer('on_generic_trial', ['trial_ends_at' => Carbon::yesterday()]);
+
+        $this->assertFalse($user->query()->onGenericTrial()->exists());
+        $this->assertTrue($user->query()->hasExpiredGenericTrial()->exists());
     }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -117,7 +117,6 @@ class CustomerTest extends FeatureTestCase
         $this->assertSame(300, $user->rawBalance());
     }
 
-
     public function test_on_generic_trial_scopes()
     {
         $user = $this->createCustomer('on_generic_trial', ['trial_ends_at' => Carbon::tomorrow()]);


### PR DESCRIPTION
This pull requests adds two scopes to the Billable model to scope by the generic trial state. These scopes are similar to those introduced in https://github.com/laravel/cashier-stripe/pull/609.

It allows you to grab any Billable that is on, or has had a generic trial.

```php
$onGenericTrial = Customer::query()->onGenericTrial()->get();

$hasExpiredGenericTrial = Customer::query()->hasExpiredGenericTrial()->get();
```