### PR TITLE
[14.x] Add days until due to sends invoice

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -277,7 +277,9 @@ class SubscriptionBuilder
      */
     public function createAndSendInvoice(array $customerOptions = [], array $subscriptionOptions = [])
     {
-        return $this->create(null, $customerOptions, array_merge($subscriptionOptions, [
+        return $this->create(null, $customerOptions, array_merge([
+            'days_until_due' => 30,
+        ], $subscriptionOptions, [
             'collection_method' => 'send_invoice',
         ]));
     }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -690,9 +690,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $user = $this->createCustomer('no_prorate_on_subscription_create');
 
-        $subscription = $user->newSubscription('main', static::$priceId)->noProrate()->create('pm_card_visa', [], [
-            'collection_method' => 'send_invoice',
-            'days_until_due' => 30,
+        $subscription = $user->newSubscription('main', static::$priceId)->noProrate()->createAndSendInvoice([], [
             'backdate_start_date' => Carbon::now()->addDays(5)->subYear()->startOfDay()->unix(),
             'billing_cycle_anchor' => Carbon::now()->addDays(5)->startOfDay()->unix(),
         ]);
@@ -708,11 +706,9 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_swap_and_invoice_after_no_prorate_with_billing_cycle_anchor_delays_invoicing()
     {
-        $user = $this->createCustomer('always_invoice_after_no_prorate');
+        $user = $this->createCustomer('swap_and_invoice_after_no_prorate_with_billing_cycle_anchor_delays_invoicing');
 
-        $subscription = $user->newSubscription('main', static::$priceId)->noProrate()->create('pm_card_visa', [], [
-            'collection_method' => 'send_invoice',
-            'days_until_due' => 30,
+        $subscription = $user->newSubscription('main', static::$priceId)->noProrate()->createAndSendInvoice([], [
             'backdate_start_date' => Carbon::now()->addDays(5)->subYear()->startOfDay()->unix(),
             'billing_cycle_anchor' => Carbon::now()->addDays(5)->startOfDay()->unix(),
         ]);


### PR DESCRIPTION
This PR adds the `days_until_due` to the `createAndSendInvoice` method since it's apparently required for the `sends_invoice` value of `collection_method`. A sensible default seemed 30 to me like in the Stripe docs: https://stripe.com/docs/invoicing/integration/quickstart