### PR TITLE
[14.x] Improve guest Checkout flow

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -41,24 +41,24 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     /**
      * Begin a new guest checkout session.
      *
-     * @param  object|null  $instance
+     * @param  object|null  $parentInstance
      * @return \Laravel\Cashier\CheckoutBuilder
      */
-    public static function guest($instance = null)
+    public static function guest($parentInstance = null)
     {
-        return new CheckoutBuilder(null, $instance);
+        return new CheckoutBuilder(null, $parentInstance);
     }
 
     /**
      * Begin a new customer checkout session.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $owner
-     * @param  object|null  $instance
+     * @param  object|null  $parentInstance
      * @return \Laravel\Cashier\CheckoutBuilder
      */
-    public static function customer($owner, $instance = null)
+    public static function customer($owner, $parentInstance = null)
     {
-        return new CheckoutBuilder($owner, $instance);
+        return new CheckoutBuilder($owner, $parentInstance);
     }
 
     /**

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -41,8 +41,8 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     /**
      * Begin a new guest checkout session.
      *
-     * @return \Laravel\Cashier\CheckoutBuilder
      * @param  object|null  $instance
+     * @return \Laravel\Cashier\CheckoutBuilder
      */
     public static function guest($instance = null)
     {

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -41,12 +41,24 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     /**
      * Begin a new guest checkout session.
      *
-     * @param  array  $sessionOptions
-     * @return \Laravel\Cashier\Checkout
+     * @return \Laravel\Cashier\CheckoutBuilder
+     * @param  object|null  $instance
      */
-    public static function guest(array $sessionOptions = [])
+    public static function guest($instance = null)
     {
-        return static::create(null, $sessionOptions);
+        return new CheckoutBuilder(null, $instance);
+    }
+
+    /**
+     * Begin a new customer checkout session.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  object|null  $instance
+     * @return \Laravel\Cashier\CheckoutBuilder
+     */
+    public static function customer($owner, $instance = null)
+    {
+        return new CheckoutBuilder($owner, $instance);
     }
 
     /**

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Laravel\Cashier;
+
+use Illuminate\Support\Collection;
 use Laravel\Cashier\Concerns\AllowsCoupons;
 use Laravel\Cashier\Concerns\HandlesTaxes;
-use Illuminate\Support\Collection;
 
 class CheckoutBuilder
 {

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Laravel\Cashier;
+use Laravel\Cashier\Concerns\AllowsCoupons;
+use Laravel\Cashier\Concerns\HandlesTaxes;
+use Illuminate\Support\Collection;
+
+class CheckoutBuilder
+{
+    use AllowsCoupons;
+    use HandlesTaxes;
+
+    /**
+     * The Stripe model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model|null
+     */
+    protected $owner;
+
+    /**
+     * Create a new checkout builder instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $owner
+     * @param  object|null  $subject
+     * @return void
+     */
+    public function __construct($owner = null, $subject = null)
+    {
+        $this->owner = $owner;
+
+        if ($subject && in_array(AllowsCoupons::class, class_uses_recursive($subject))) {
+            $this->couponId = $subject->couponId;
+            $this->promotionCodeId = $subject->promotionCodeId;
+            $this->allowPromotionCodes = $subject->allowPromotionCodes;
+        }
+
+        if ($subject && in_array(HandlesTaxes::class, class_uses_recursive($subject))) {
+            $this->customerIpAddress = $subject->customerIpAddress;
+            $this->estimationBillingAddress = $subject->estimationBillingAddress;
+            $this->collectTaxIds = $subject->collectTaxIds;
+        }
+    }
+
+    /**
+     * Create a new checkout builder instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $owner
+     * @param  object|null  $instance
+     * @return \Laravel\Cashier\CheckoutBuilder
+     */
+    public static function make($owner = null, $instance = null)
+    {
+        return new static($owner, $instance);
+    }
+
+    /**
+     * Create a new checkout session.
+     *
+     * @param  array|string  $items
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public function create($items, array $sessionOptions = [], array $customerOptions = [])
+    {
+        $payload = array_filter([
+            'allow_promotion_codes' => $this->allowPromotionCodes,
+            'automatic_tax' => $this->automaticTaxPayload(),
+            'discounts' => $this->checkoutDiscounts(),
+            'line_items' => Collection::make((array) $items)->map(function ($item, $key) {
+                if (is_string($key)) {
+                    return ['price' => $key, 'quantity' => $item];
+                }
+
+                $item = is_string($item) ? ['price' => $item] : $item;
+
+                $item['quantity'] = $item['quantity'] ?? 1;
+
+                return $item;
+            })->values()->all(),
+            'tax_id_collection' => [
+                'enabled' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
+            ],
+        ]);
+
+        return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);
+    }
+}

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -22,23 +22,23 @@ class CheckoutBuilder
      * Create a new checkout builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $owner
-     * @param  object|null  $subject
+     * @param  object|null  $parentInstance
      * @return void
      */
-    public function __construct($owner = null, $subject = null)
+    public function __construct($owner = null, $parentInstance = null)
     {
         $this->owner = $owner;
 
-        if ($subject && in_array(AllowsCoupons::class, class_uses_recursive($subject))) {
-            $this->couponId = $subject->couponId;
-            $this->promotionCodeId = $subject->promotionCodeId;
-            $this->allowPromotionCodes = $subject->allowPromotionCodes;
+        if ($parentInstance && in_array(AllowsCoupons::class, class_uses_recursive($parentInstance))) {
+            $this->couponId = $parentInstance->couponId;
+            $this->promotionCodeId = $parentInstance->promotionCodeId;
+            $this->allowPromotionCodes = $parentInstance->allowPromotionCodes;
         }
 
-        if ($subject && in_array(HandlesTaxes::class, class_uses_recursive($subject))) {
-            $this->customerIpAddress = $subject->customerIpAddress;
-            $this->estimationBillingAddress = $subject->estimationBillingAddress;
-            $this->collectTaxIds = $subject->collectTaxIds;
+        if ($parentInstance && in_array(HandlesTaxes::class, class_uses_recursive($parentInstance))) {
+            $this->customerIpAddress = $parentInstance->customerIpAddress;
+            $this->estimationBillingAddress = $parentInstance->estimationBillingAddress;
+            $this->collectTaxIds = $parentInstance->collectTaxIds;
         }
     }
 

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -9,21 +9,21 @@ trait AllowsCoupons
      *
      * @var string|null
      */
-    protected $couponId;
+    public $couponId;
 
     /**
      * The promotion code ID being applied.
      *
      * @var string|null
      */
-    protected $promotionCodeId;
+    public $promotionCodeId;
 
     /**
      * Determines if user redeemable promotion codes are available in Stripe Checkout.
      *
      * @var bool
      */
-    protected $allowPromotionCodes = false;
+    public $allowPromotionCodes = false;
 
     /**
      * The coupon ID to be applied.

--- a/src/Concerns/HandlesTaxes.php
+++ b/src/Concerns/HandlesTaxes.php
@@ -11,21 +11,21 @@ trait HandlesTaxes
      *
      * @var string|null
      */
-    protected $customerIpAddress;
+    public $customerIpAddress;
 
     /**
      * The pre-collected billing address used to estimate tax rates when performing "one-off" charges.
      *
      * @var array
      */
-    protected $estimationBillingAddress = [];
+    public $estimationBillingAddress = [];
 
     /**
      * Indicates if Tax IDs should be collected during a Stripe Checkout session.
      *
      * @var bool
      */
-    protected $collectTaxIds = false;
+    public $collectTaxIds = false;
 
     /**
      * Set the The IP address of the customer used to determine the tax location.

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Cashier\Concerns;
 
-use Illuminate\Support\Collection;
-use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Checkout;
 use Laravel\Cashier\Payment;
 use LogicException;
@@ -139,27 +137,7 @@ trait PerformsCharges
      */
     public function checkout($items, array $sessionOptions = [], array $customerOptions = [])
     {
-        $payload = array_filter([
-            'allow_promotion_codes' => $this->allowPromotionCodes,
-            'automatic_tax' => $this->automaticTaxPayload(),
-            'discounts' => $this->checkoutDiscounts(),
-            'line_items' => Collection::make((array) $items)->map(function ($item, $key) {
-                if (is_string($key)) {
-                    return ['price' => $key, 'quantity' => $item];
-                }
-
-                $item = is_string($item) ? ['price' => $item] : $item;
-
-                $item['quantity'] = $item['quantity'] ?? 1;
-
-                return $item;
-            })->values()->all(),
-            'tax_id_collection' => [
-                'enabled' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
-            ],
-        ]);
-
-        return Checkout::create($this, array_merge($payload, $sessionOptions), $customerOptions);
+        return Checkout::customer($this, $this)->create($items, $sessionOptions, $customerOptions);
     }
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -350,22 +350,16 @@ class SubscriptionBuilder
         }
 
         $payload = array_filter([
-            'automatic_tax' => $this->automaticTaxPayload(),
-            'mode' => 'subscription',
             'line_items' => Collection::make($this->items)->values()->all(),
-            'allow_promotion_codes' => $this->allowPromotionCodes,
-            'discounts' => $this->checkoutDiscounts(),
+            'mode' => 'subscription',
             'subscription_data' => array_filter([
                 'default_tax_rates' => $this->getTaxRatesForPayload(),
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
                 'metadata' => array_merge($this->metadata, ['name' => $this->name]),
             ]),
-            'tax_id_collection' => [
-                'enabled' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
-            ],
         ]);
 
-        return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);
+        return Checkout::customer($this->owner, $this)->create([], array_merge($payload, $sessionOptions), $customerOptions);
     }
 
     /**

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -132,19 +132,15 @@ class CheckoutTest extends FeatureTestCase
 
     public function test_guest_customers_can_start_a_checkout_session()
     {
-        $checkout = Checkout::guest([
-            'line_items' => [
-                [
-                    'price_data' => [
-                        'currency' => 'USD',
-                        'product_data' => [
-                            'name' => 'PHP Elephant',
-                        ],
-                        'unit_amount' => 200,
-                    ],
-                    'quantity' => 1,
-                ],
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
             ],
+            'unit_amount' => 1500,
+        ]);
+
+        $checkout = Checkout::guest()->create($shirtPrice->id, [
             'success_url' => 'http://example.com',
             'cancel_url' => 'http://example.com',
         ]);


### PR DESCRIPTION
These changes are a followup to the guest checkout PR here: https://github.com/laravel/cashier-stripe/pull/1438. These allow for a more richer Checkout experience and a more fluent one. You can now use any method from the `AllowsCoupons` and `HandlesTaxes` traits:

```php
$checkout = Checkout::guest()
    ->withCoupon('coupon_id')
    ->withTaxAddress('US', '72201', 'Arkansas')
    ->create();
```

Furthermore, I've managed to bring all of resolving of the Checkout Session options into the new `CheckoutBuilder` class which will help in the future when adding new features to the Cashier Stripe Checkout experience.

One thing I needed to change are the property visibilities on the `AllowsCoupons` and `HandlesTaxes` traits so I could more easily copy them over.

A future change I'd like to make is to move the contents of `Checkout::create` over to `CheckoutBuilder::create` but we can do that maybe in the next major release. 