### PR TITLE
On subscription cancel trial_ends_at keeps

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1073,7 +1073,7 @@ class Subscription extends Model
         $this->fill([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
             'ends_at' => Carbon::now(),
-            'trial_ends_at' => NULL
+            'trial_ends_at' => null
         ])->save();
     }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1073,6 +1073,7 @@ class Subscription extends Model
         $this->fill([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
             'ends_at' => Carbon::now(),
+            'trial_ends_at' => NULL
         ])->save();
     }
 


### PR DESCRIPTION
The case when the user subscribed with a trial period and the subscription is canceled then the 'trial_ends_at' value stays there, which causes the check subscription status $user->subscribed('default'))  return true even if the subscription is permanently canceled.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
