### PR TITLE
[14.x] Fix applied balance on invoices

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -282,7 +282,7 @@
                     </tr>
 
                     <!-- Applied Balance -->
-                    @if ($invoice->rawAppliedBalance() > 0)
+                    @if ($invoice->hasAppliedBalance())
                         <tr>
                             <td colspan="{{ $invoice->hasTax() ? 3 : 2 }}" style="text-align: right;">
                                 Applied balance

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -247,6 +247,16 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Determine if the invoice has balance applied.
+     *
+     * @return bool
+     */
+    public function hasAppliedBalance()
+    {
+        return $this->rawAppliedBalance() < 0;
+    }
+
+    /**
      * Get the applied balance for the invoice.
      *
      * @return string
@@ -257,16 +267,12 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the raw ending balance for the invoice.
+     * Get the raw applied balance for the invoice.
      *
      * @return int
      */
     public function rawAppliedBalance()
     {
-        if (! $this->hasEndingBalance()) {
-            return 0;
-        }
-
         return $this->rawStartingBalance() - $this->rawEndingBalance();
     }
 

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -199,8 +199,27 @@ class InvoiceTest extends TestCase
 
         $invoice = new Invoice($user, $stripeInvoice);
 
+        $this->assertTrue($invoice->hasAppliedBalance());
         $this->assertEquals('-$1.50', $invoice->appliedBalance());
         $this->assertEquals(-150, $invoice->rawAppliedBalance());
+    }
+
+    public function test_it_can_return_its_applied_balance_when_depleted()
+    {
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+        $stripeInvoice->ending_balance = 0;
+        $stripeInvoice->starting_balance = -500;
+        $stripeInvoice->currency = 'USD';
+
+        $user = new User();
+        $user->stripe_id = 'foo';
+
+        $invoice = new Invoice($user, $stripeInvoice);
+
+        $this->assertTrue($invoice->hasAppliedBalance());
+        $this->assertEquals('-$5.00', $invoice->appliedBalance());
+        $this->assertEquals(-500, $invoice->rawAppliedBalance());
     }
 
     public function test_it_can_determine_if_it_has_a_discount_applied()


### PR DESCRIPTION
This PR fixes a small issue I ran into when a balance is applied to an invoice but not shown on the receipt.