### PR TITLE
[14.x] Add fallback for null value in unitAmountExcludingTax method

### DIFF
--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -56,7 +56,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
      */
     public function unitAmountExcludingTax()
     {
-        return $this->formatAmount($this->item->unit_amount_excluding_tax);
+        return $this->formatAmount($this->item->unit_amount_excluding_tax ?? 0);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Why

I updated my installation of Cashier to `v14.2.0` and noticed that my invoices can't be downloaded. Did some digging around and found that the newly added `unitAmountExcludingTax` method in the `InvoiceLineItem` class doesn't handle `null` values coming through from the Stripe PHP library. This pull request aims to fix the issue by setting `null` values to `0` (int), this will ensure that values passed to `Cashier::formatAmount()` is always a `int` or `string` type.

### Context

For some context around why I am likely to get a `null` value. My application charges a fixed price per `website` and a fixed price per `user` (team members). This means that a `team` in my application can possibly have `0` websites but always have 1 or more users, this would mean their subscription would still be active but have a $0 charge on the website line item for a given month. This situation usually only happens when a `team` is new or rarely has published websites.
