### PR TITLE
Fix undefined property id notice

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -569,7 +569,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             'total_tax_amounts.tax_rate',
         ];
 
-        if (property_exists($this->invoice, 'id')) {
+        if (property_exists($this->invoice, 'id') && $this->invoice->id) {
             $this->invoice = $this->owner->stripe()->invoices->retrieve($this->invoice->id, [
                 'expand' => $expand,
             ]);

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -569,7 +569,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             'total_tax_amounts.tax_rate',
         ];
 
-        if ($this->invoice->id) {
+        if (property_exists($this->invoice, 'id')) {
             $this->invoice = $this->owner->stripe()->invoices->retrieve($this->invoice->id, [
                 'expand' => $expand,
             ]);


### PR DESCRIPTION
Fix `PHP message: Stripe Notice: Undefined property of Stripe\Invoice instance: id` when fetching upcoming invoice data