### PR TITLE
Fix StripeObject values problem

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -569,7 +569,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             'total_tax_amounts.tax_rate',
         ];
 
-        if (property_exists($this->invoice, 'id') && $this->invoice->id) {
+        if (isset($this->invoice->id) && $this->invoice->id) {
             $this->invoice = $this->owner->stripe()->invoices->retrieve($this->invoice->id, [
                 'expand' => $expand,
             ]);


### PR DESCRIPTION
StripeObject saves the value to the array, not a property. This PR also fixes tests.

https://github.com/stripe/stripe-php/blob/e73d05039943e3bbcd0f068f220ee55f88e8952c/lib/StripeObject.php#L152-L160

test result:
<img width="768" alt="圖片" src="https://user-images.githubusercontent.com/8276290/194225881-ee39add8-b3f4-426e-a295-67a51b2879a6.png">
