### PR TITLE
[14.x] Refactor dates property

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -50,11 +50,9 @@ class Subscription extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
         'ends_at' => 'datetime',
         'quantity' => 'integer',
         'trial_ends_at' => 'datetime',
-        'updated_at' => 'datetime',
     ];
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -50,19 +50,11 @@ class Subscription extends Model
      * @var array
      */
     protected $casts = [
+        'created_at' => 'datetime',
+        'ends_at' => 'datetime',
         'quantity' => 'integer',
-    ];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'created_at',
-        'ends_at',
-        'trial_ends_at',
-        'updated_at',
+        'trial_ends_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
Removes the dates property from the subscriptions model since it's deprecated. Only the ends_at and trial_ends_at attributes are added as casts since created_at and updated_at are already properly handled.