### PR TITLE
[14.x] Allow incomplete subscriptions as active

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -63,6 +63,13 @@ class Cashier
     public static $deactivatePastDue = true;
 
     /**
+     * Indicates if Cashier will mark incomplete subscriptions as inactive.
+     *
+     * @var bool
+     */
+    public static $deactivateIncomplete = true;
+
+    /**
      * Indicates if Cashier will automatically calculate taxes using Stripe Tax.
      *
      * @var bool
@@ -191,6 +198,18 @@ class Cashier
     public static function keepPastDueSubscriptionsActive()
     {
         static::$deactivatePastDue = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Cashier to maintain incomplete subscriptions as active.
+     *
+     * @return static
+     */
+    public static function keepIncompleteSubscriptionsActive()
+    {
+        static::$deactivateIncomplete = false;
 
         return new static;
     }


### PR DESCRIPTION
This PR allows subscriptions to stay active as long as they're in an `incomplete` status. The reason for this is that it could be that subscriptions are pending on SCA confirmation etc. During this window, customers could miss out on any access to the product they're using. In normal situations, that's what you want since at this point, they're not paying for the product. However, often this can be disruptive as well to the customer experience. Therefor allowing apps to keep these incomplete subscriptions as active is a valid option to provide. Works exactly the same as `keepPastDueSubscriptionsActive`.

The default behavior is unchanged as it should be. As soon as a subscription hits `incomplete_expired` the subscription is no longer active.

https://github.com/laravel/cashier-stripe/issues/1454