### PR TITLE
Use empty() instead of is_null() to check for empty stripe ID

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -32,7 +32,7 @@ trait ManagesCustomer
      */
     public function hasStripeId()
     {
-        return ! is_null($this->stripe_id);
+        return ! empty($this->stripe_id);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Cashier currently regards `""` (empty string) and `false` as valid Stripe IDs. This results in methods like `$user->createOrGetStripeCustomer();` returning a Stripe exception for `"The resource ID cannot be null or whitespace"` instead of creating a stripe user.
Cashier itself uses `NULL` to indicate an empty value, depending on how the data is stored or how other scripts process it, the value could possible another empty-type value. This makes it hard to debug the reason Cashier is not creating a new stripe user.

To achieve this, this PR changes the `is_null` check to `empty` to also regard other empty-like types as an empty Stripe ID - including `null`, making a separate `is_null` check unneeded. 