### PR TITLE
Exception Attempt to read property "percentage" on string

### DIFF
--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -136,11 +136,11 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
             })
             ->sum(function (object $taxAmount) {
                 $taxRate = $taxAmount->tax_rate;
-                
+
                 if (is_string($taxRate)) {
                     $taxRate = Cashier::stripe()->taxRates->retrieve($taxRate);
                 }
-                
+
                 return $taxRate->percentage;
             });
     }

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -135,7 +135,13 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
                 return $taxAmount->inclusive === (bool) $inclusive;
             })
             ->sum(function (object $taxAmount) {
-                return $taxAmount->tax_rate->percentage;
+                $taxRate = $taxAmount->tax_rate;
+                
+                if (is_string($taxRate)) {
+                    $taxRate = Cashier::stripe()->taxRates->retrieve($taxRate);
+                }
+                
+                return $taxRate->percentage;
             });
     }
 


### PR DESCRIPTION
When i try:

`$user->downloadInvoice($invoiceId);`

I receive the following exception:

```
production.ERROR: Attempt to read property "percentage" on string (View: /var/app/current/vendor/laravel/cashier/resources/views/receipt.blade.php) {"exception":"[object] (Illuminate\\View\\ViewException(code: 0): Attempt to read property \"percentage\" on string (View: /var/app/current/vendor/laravel/cashier/resources/views/receipt.blade.php) at /var/app/current/vendor/laravel/cashier/src/InvoiceLineItem.php:146)
[stacktrace]
#0 /var/app/current/vendor/livewire/livewire/src/ComponentConcerns/RendersLivewireComponents.php(106): Illuminate\\View\\Engines\\CompilerEngine->handleViewException(Object(ErrorException), 1)
#1 /var/app/current/vendor/laravel/framework/src/Illuminate/View/Engines/PhpEngine.php(60): Livewire\\LivewireViewCompilerEngine->handleViewException(Object(ErrorException), 1)
#2 /var/app/current/vendor/livewire/livewire/src/ComponentConcerns/RendersLivewireComponents.php(69): Illuminate\\View\\Engines\\PhpEngine->evaluatePath('/var/app/curren...', Array)
#3 /var/app/current/vendor/laravel/framework/src/Illuminate/View/Engines/CompilerEngine.php(70): Livewire\\LivewireViewCompilerEngine->evaluatePath('/var/app/curren...', Array)
#4 /var/app/current/vendor/livewire/livewire/src/ComponentConcerns/RendersLivewireComponents.php(35): Illuminate\\View\\Engines\\CompilerEngine->get('/var/app/curren...', Array)
#5 /var/app/current/vendor/laravel/framework/src/Illuminate/View/View.php(152): Livewire\\LivewireViewCompilerEngine->get('/var/app/curren...', Array)
#6 /var/app/current/vendor/laravel/framework/src/Illuminate/View/View.php(135): Illuminate\\View\\View->getContents()
#7 /var/app/current/vendor/laravel/framework/src/Illuminate/View/View.php(104): Illuminate\\View\\View->renderContents()
#8 /var/app/current/vendor/laravel/cashier/src/Invoices/DompdfInvoiceRenderer.php(26): Illuminate\\View\\View->render()
#9 /var/app/current/vendor/laravel/cashier/src/Invoice.php(787): Laravel\\Cashier\\Invoices\\DompdfInvoiceRenderer->render(Object(Laravel\\Cashier\\Invoice), Array, Array)
#10 /var/app/current/vendor/laravel/cashier/src/Invoice.php(813): Laravel\\Cashier\\Invoice->pdf(Array)
#11 /var/app/current/vendor/laravel/cashier/src/Concerns/ManagesInvoices.php(255): Laravel\\Cashier\\Invoice->downloadAs('9B35A9EA-0057', Array)

```

Because $taxAmount can be:

Stripe\StripeObject JSON: {
    "amount": 41,
    "inclusive": false,
    "tax_rate": {
        "id": "txr_1KxZESCelkdgTLAvmlfA4gHl",
        "object": "tax_rate",
        "active": false,
        "country": "ES",
        "created": 1652112888,
        "description": null,
        "display_name": "VAT",
        "inclusive": false,
        "jurisdiction": "Spain",
        "livemode": false,
        "metadata": [],
        "percentage": 21,
        "state": null,
        "tax_type": "vat"
    }

or

 Stripe\StripeObject JSON: {
    "amount": 41,
    "inclusive": false,
    "tax_rate": "txr_1KxZESCelkdgTLAvmlfA4gHl"
}  

