### PR TITLE
[14.x] Cursor pagination for invoices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "illuminate/http": "^9.21",
         "illuminate/log": "^9.21",
         "illuminate/notifications": "^9.21",
+        "illuminate/pagination": "^9.21",
         "illuminate/routing": "^9.21",
         "illuminate/support": "^9.21",
         "illuminate/view": "^9.21",


### PR DESCRIPTION
This PR adds cursor pagination for customer invoices. Using the `starting_after` and `ending_before` fields on [the invoices list API endpoint](https://stripe.com/docs/api/invoices/list) by Stripe, we can easily paginate through a customer's invoices using cursors.

```php
$paginator = $billable->cursorPaginateInvoices();
```