### PR TITLE
[14.x] Allow metered prices in subscription builder

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -837,7 +837,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
-    public function addPrice($price, $quantity = 1, array $options = [])
+    public function addPrice($price, $quantity = null, array $options = [])
     {
         $this->guardAgainstIncomplete();
 
@@ -886,14 +886,14 @@ class Subscription extends Model
      * Add a new Stripe price to the subscription, and invoice immediately.
      *
      * @param  string  $price
-     * @param  int  $quantity
+     * @param  int|null  $quantity
      * @param  array  $options
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
-    public function addPriceAndInvoice($price, $quantity = 1, array $options = [])
+    public function addPriceAndInvoice($price, $quantity = null, array $options = [])
     {
         $this->alwaysInvoice();
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -97,7 +97,7 @@ class SubscriptionBuilder
      * @param  int|null  $quantity
      * @return $this
      */
-    public function price($price, $quantity = 1)
+    public function price($price, $quantity = null)
     {
         $options = is_array($price) ? $price : ['price' => $price];
 
@@ -128,7 +128,7 @@ class SubscriptionBuilder
      */
     public function meteredPrice($price)
     {
-        return $this->price($price, null);
+        return $this->price($price);
     }
 
     /**

--- a/tests/Unit/SubscriptionBuilderTest.php
+++ b/tests/Unit/SubscriptionBuilderTest.php
@@ -18,8 +18,8 @@ class SubscriptionBuilderTest extends TestCase
         ]);
 
         $this->assertSame([
-            'price_foo' => ['price' => 'price_foo', 'quantity' => 1],
-            'price_bux' => ['price' => 'price_bux', 'quantity' => 1],
+            'price_foo' => ['price' => 'price_foo'],
+            'price_bux' => ['price' => 'price_bux'],
             'price_bar' => ['price' => 'price_bar', 'quantity' => 1],
             'price_baz' => ['price' => 'price_baz', 'quantity' => 0],
         ], $builder->getItems());


### PR DESCRIPTION
This PR allows metered prices to be added to the subscription builder's construct. This means users are no longer obligated to explicitly use the `meteredPrice` on the subscription builder. 

This PR technically contains breaking changes to method signatures. However, I do not believe people are overwriting these. If you want, I can send this to master instead.

Closes https://github.com/laravel/cashier-stripe/issues/1488