### PR TITLE
[14.x] New prices method

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -122,10 +122,10 @@ class SubscriptionBuilder
 
     /**
      * Set multiple prices on the subscription builder.
-     * 
+     *
      * @param $prices
      */
-    public function prices(array $prices): self 
+    public function prices(array $prices): self
     {
         foreach ((array) $prices as $price) {
             $this->price($price);

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -121,6 +121,20 @@ class SubscriptionBuilder
     }
 
     /**
+     * Set multiple prices on the subscription builder.
+     * 
+     * @param $prices
+     */
+    public function prices(array $prices): self 
+    {
+        foreach ((array) $prices as $price) {
+            $this->price($price);
+        }
+
+        return $this;
+    }
+
+    /**
      * Set a metered price on the subscription builder.
      *
      * @param  string  $price

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -476,6 +476,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertCount(2, $subscription->items);
     }
+
     public function test_creating_subscription_with_inline_price_data()
     {
         $user = $this->createCustomer('creating_subscription_with_inline_price_data');

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -466,6 +466,16 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($coupon->isPercentage());
     }
 
+    public function test_creating_subscription_with_multiple_prices()
+    {
+        $user = $this->createCustomer('creating_subscription_with_inline_price_data'); 
+
+        $subscription = $user->newSubscription('main')
+            ->prices([static::$priceId, static::$otherPriceId])
+            ->create('pm_card_visa');
+
+        $this->assertCount(2, $subscription->items);
+    }
     public function test_creating_subscription_with_inline_price_data()
     {
         $user = $this->createCustomer('creating_subscription_with_inline_price_data');

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -468,7 +468,7 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_creating_subscription_with_multiple_prices()
     {
-        $user = $this->createCustomer('creating_subscription_with_inline_price_data'); 
+        $user = $this->createCustomer('creating_subscription_with_inline_price_data');
 
         $subscription = $user->newSubscription('main')
             ->prices([static::$priceId, static::$otherPriceId])

--- a/tests/Unit/SubscriptionBuilderTest.php
+++ b/tests/Unit/SubscriptionBuilderTest.php
@@ -24,4 +24,11 @@ class SubscriptionBuilderTest extends TestCase
             'price_baz' => ['price' => 'price_baz', 'quantity' => 0],
         ], $builder->getItems());
     }
+
+    public function test_it_can_be_instantiated_with_no_price()
+    {
+        $builder = new SubscriptionBuilder(new User, 'default');
+        
+        $this->assertEmpty($builder->getItems());
+    }
 }

--- a/tests/Unit/SubscriptionBuilderTest.php
+++ b/tests/Unit/SubscriptionBuilderTest.php
@@ -28,7 +28,7 @@ class SubscriptionBuilderTest extends TestCase
     public function test_it_can_be_instantiated_with_no_price()
     {
         $builder = new SubscriptionBuilder(new User, 'default');
-        
+
         $this->assertEmpty($builder->getItems());
     }
 }


### PR DESCRIPTION
Hello!

This PR adds a new method ``->prices()`` allowing to add multiple prices to the ``SubscriptionBuilder``. It is simply a convenient way for users to add an array of prices after instantiating the ``SubscriptionBuilder``.

```php
$this->user()->newSubscription($this->plan)
    ->meteredPrice($this->meteredPrice)
    ->prices($this->prices)
    ->trialDays($this->trialDays)
    ->create($this->paymentMethod);
```  

Following issue #1488 I think it has a use case where users want to interact with the builder and add multiple prices at once.

I promise not to bother with it anymore after this PR 🤭