### PR TITLE
[14.x] Fix wrong foreignKey on SubscriptionItem

### DIFF
--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -44,7 +44,8 @@ class SubscriptionItem extends Model
      */
     public function subscription()
     {
-        return $this->belongsTo(Cashier::$subscriptionModel);
+        $model = Cashier::$subscriptionModel;
+        return $this->belongsTo($model, (new $model)->getForeignKey());
     }
 
     /**

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -45,6 +45,7 @@ class SubscriptionItem extends Model
     public function subscription()
     {
         $model = Cashier::$subscriptionModel;
+
         return $this->belongsTo($model, (new $model)->getForeignKey());
     }
 


### PR DESCRIPTION
This pull request fixes an error in the relationship between **items** and **subscription** when using _custom models_ 

i.e. using 
```
        Cashier::useSubscriptionModel(StripeSubscription::class);
        Cashier::useSubscriptionItemModel(StripeSubscriptionItem::class);
```

With these I think "licit" migrations
```
        Schema::create('stripe_subscriptions', function (Blueprint $table) {
            $table->id();
            ....
        });
        Schema::create('stripe_subscription_items', function (Blueprint $table) {
            $table->id();
            $table->foreignId('stripe_subscription_id');
            ...
        });

```

current codebase works in finding the items from the subscription, but not in finding the subscription from the items.
so $item->subscription will never works without this fix.


Of course, it can be solved by overriding the relation in our custom SubscriptionItemModel..
but I think that is a correct pr.

