### PR TITLE
[14.x] Return null if attribute isn't found

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -145,7 +145,7 @@ trait ManagesCustomer
      */
     public function stripeName()
     {
-        return $this->name;
+        return $this->name ?? null;
     }
 
     /**
@@ -155,7 +155,7 @@ trait ManagesCustomer
      */
     public function stripeEmail()
     {
-        return $this->email;
+        return $this->email ?? null;
     }
 
     /**
@@ -165,7 +165,7 @@ trait ManagesCustomer
      */
     public function stripePhone()
     {
-        return $this->phone;
+        return $this->phone ?? null;
     }
 
     /**


### PR DESCRIPTION
In some cases, people might not have a phone, email or name attribute. In those cases we should return `null` by default.