### PR TITLE
[14.x] Fix invoice line items

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -13,7 +13,6 @@ use Laravel\Cashier\Contracts\InvoiceRenderer;
 use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Stripe\Customer as StripeCustomer;
 use Stripe\Invoice as StripeInvoice;
-use Stripe\InvoiceLineItem as StripeInvoiceLineItem;
 use Symfony\Component\HttpFoundation\Response;
 
 class Invoice implements Arrayable, Jsonable, JsonSerializable


### PR DESCRIPTION
This PR ensures all line items are shown on a invoice, even the ones with lots of them (+10). This is a workaround for a bug in Stripe atm with their auto paginator: https://github.com/stripe/stripe-php/issues/1422