### PR TITLE
fix: Provide findSetupIntent method

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -23,6 +23,19 @@ trait ManagesPaymentMethods
     }
 
     /**
+     * Retrieve a SetupIntent from Stripe
+     *
+     * @param  string $id
+     * @param  array $params
+     * @param  array $options
+     * @return \Stripe\SetupIntent
+     */
+    public function findSetupIntent(string $id, array $params = [], array $options = [])
+    {
+        return $this->stripe()->setupIntents->retrieve($id, $params, $options);
+    }
+
+    /**
      * Determines if the customer currently has a default payment method.
      *
      * @return bool

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -17,6 +17,17 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertInstanceOf(StripeSetupIntent::class, $setupIntent);
     }
 
+    public function test_we_can_retrieve_an_existing_setup_intent()
+    {
+        $user = $this->createCustomer('we_can_retrieve_a_setup_intent');
+
+        $originalSetupIntent = $user->createSetupIntent();
+
+        $retrievedSetupIntent = $user->findSetupIntent($originalSetupIntent->id);
+
+        $this->assertEquals($originalSetupIntent->id, $retrievedSetupIntent->id);
+    }
+
     public function test_we_can_add_payment_methods()
     {
         $user = $this->createCustomer('we_can_add_payment_methods');


### PR DESCRIPTION
The new Payment element requires a redirect to a new page after submitting the payment details, to enable the insertion of intermediate paymentMethod steps (for example bank pages etc.)

When the return_url is reaches, the setupIntent is supplied as a parameter, with the purpose of allowing the code to retrieve the setupIntent, to get the payment_method id.

This PR provides a findSetupIntent method on the billable entity, to enable retrieval of the setupIntent.

Test included.

This is described by @quantumwebco in issue #1491

fixes #1491 