### PR TITLE
[14.x] Fix deletion of subscription items in swap()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -699,7 +699,11 @@ class Subscription extends Model
             'ends_at' => null,
         ])->save();
 
+        $stripePrices = [];
+
         foreach ($stripeSubscription->items as $item) {
+            $stripePrices[] = $item->price->id;
+
             $this->items()->updateOrCreate([
                 'stripe_id' => $item->id,
             ], [
@@ -710,7 +714,7 @@ class Subscription extends Model
         }
 
         // Delete items that aren't attached to the subscription anymore...
-        $this->items()->whereNotIn('stripe_price', $items->pluck('price')->filter())->delete();
+        $this->items()->whereNotIn('stripe_price', $stripePrices)->delete();
 
         $this->unsetRelation('items');
 


### PR DESCRIPTION
This pull request fixes an issue in `Subscription::swap()` where subscription item models created using inline prices (via `price_data`) instead of an existing Stripe price are immediately deleted after creation:

```php
// Delete items that aren't attached to the subscription anymore...
$this->items()->whereNotIn('stripe_price', $items->pluck('price')->filter())->delete();
```

Items using inline price data will not be keyed by `price` in `parseSwapPrices()`, meaning they will not be found by `$items->pluck('price')`. This change simply uses the item data returned by the updated Stripe subscription object as the source of truth instead of the array that is initially passed to `swap()`. FWIW, I considered adding post-creation/swapping item relation counts to the feature tests relating to inline prices but saw that you weren't testing for such things anywhere else, so I'll keep them to my local branch for now.

Presumably this hasn't been much of an issue for people who have followed the docs during initial setup, as the deleted items are re-created almost immediately via the `customer.subscription.updated` webhook (I initially started looking into this as I thought I was experiencing some sort of odd race condition in my site's codebase).

This is my first-ever PR, so if I've mucked anything up or can otherwise be of assistance please let me know! 😄