### PR TITLE
[14.x] Add ability to ignore incomplete payments

### DIFF
--- a/src/Concerns/HandlesPaymentFailures.php
+++ b/src/Concerns/HandlesPaymentFailures.php
@@ -11,6 +11,13 @@ use Stripe\PaymentMethod as StripePaymentMethod;
 trait HandlesPaymentFailures
 {
     /**
+     * Indicates if incomplete payments should be confirmed automatically.
+     *
+     * @var bool
+     */
+    protected $confirmIncompletePayment = true;
+
+    /**
      * The options to be used when confirming a payment intent.
      *
      * @var array
@@ -30,7 +37,7 @@ trait HandlesPaymentFailures
      */
     public function handlePaymentFailure(Subscription $subscription, $paymentMethod = null)
     {
-        if ($subscription->hasIncompletePayment()) {
+        if ($this->confirmIncompletePayment && $subscription->hasIncompletePayment()) {
             try {
                 $subscription->latestPayment()->validate();
             } catch (IncompletePayment $e) {
@@ -69,7 +76,20 @@ trait HandlesPaymentFailures
             }
         }
 
+        $this->confirmIncompletePayment = true;
         $this->paymentConfirmationOptions = [];
+    }
+
+    /**
+     * Prevent automatic confirmation of incomplete payments.
+     *
+     * @return $this
+     */
+    public function ignoreIncompletePayment()
+    {
+        $this->confirmIncompletePayment = false;
+
+        return $this;
     }
 
     /**

--- a/src/Concerns/HandlesPaymentFailures.php
+++ b/src/Concerns/HandlesPaymentFailures.php
@@ -85,7 +85,7 @@ trait HandlesPaymentFailures
      *
      * @return $this
      */
-    public function ignoreIncompletePayment()
+    public function ignoreIncompletePayments()
     {
         $this->confirmIncompletePayment = false;
 


### PR DESCRIPTION
Right now, it's not possible to create subscriptions without also automatically confirming them. It would be handy for apps where the frontend like Next.js etc handles the confirmation through Stripe.js for example without providing a payment method up front.

```php
$subscription = $user->newSubscription('default', 'price_xxx')
    ->ignoreIncompletePayment()
    ->create();
```

I'm not 100% sure about the naming of `ignoreIncompletePayment` yet.