### PR TITLE
[14.x] Add ability to set a description on "one-off" charge checkouts

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -160,9 +160,9 @@ trait PerformsCharges
         return $this->checkout([[
             'price_data' => [
                 'currency' => $this->preferredCurrency(),
-                'product_data' => array_merge([
+                'product_data' => array_merge($productData, [
                     'name' => $name,
-                ], $productData),
+                ]),
                 'unit_amount' => $amount,
             ],
             'quantity' => $quantity,

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -148,9 +148,10 @@ trait PerformsCharges
      * @param  int  $quantity
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
+     * @param  array  $productData
      * @return \Laravel\Cashier\Checkout
      */
-    public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [], $description = null)
+    public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [], array $productData = [])
     {
         if ($this->isAutomaticTaxEnabled()) {
             throw new LogicException('For now, you cannot use checkout charges in combination with automatic tax calculation.');
@@ -159,10 +160,9 @@ trait PerformsCharges
         return $this->checkout([[
             'price_data' => [
                 'currency' => $this->preferredCurrency(),
-                'product_data' => [
+                'product_data' => array_merge([
                     'name' => $name,
-                    '$description' => $description,
-                ],
+                ], $productData),
                 'unit_amount' => $amount,
             ],
             'quantity' => $quantity,

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -150,7 +150,7 @@ trait PerformsCharges
      * @param  array  $customerOptions
      * @return \Laravel\Cashier\Checkout
      */
-    public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    public function checkoutCharge($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [], $description = null)
     {
         if ($this->isAutomaticTaxEnabled()) {
             throw new LogicException('For now, you cannot use checkout charges in combination with automatic tax calculation.');
@@ -161,6 +161,7 @@ trait PerformsCharges
                 'currency' => $this->preferredCurrency(),
                 'product_data' => [
                     'name' => $name,
+                    '$description' => $description,
                 ],
                 'unit_amount' => $amount,
             ],


### PR DESCRIPTION
Right now its not possible to set a description for checkout sessions created with for example
```
$request->user()->checkoutCharge(1200, 'T-Shirt', 5);
```