### PR TITLE
Added Stripe Delete Customer method on ManageCustomer

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -124,6 +124,21 @@ trait ManagesCustomer
     }
 
     /**
+     * Delete the Stripe customer for the current user.
+     * @return void
+     */
+    public function deleteStripeCustomer()
+    {
+        $this->assertCustomerExists();
+
+        $this->stripe()->customers->delete($this->stripe_id);
+
+        $this->stripe_id = null;
+
+        $this->save();
+    }
+
+    /**
      * Get the Stripe customer for the model.
      *
      * @param  array  $expand

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -125,6 +125,7 @@ trait ManagesCustomer
 
     /**
      * Delete the Stripe customer for the current user.
+     * 
      * @return void
      */
     public function deleteStripeCustomer()

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -125,7 +125,7 @@ trait ManagesCustomer
 
     /**
      * Delete the Stripe customer for the current user.
-     * 
+     *
      * @return void
      */
     public function deleteStripeCustomer()

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -132,6 +132,7 @@ class CustomerTest extends FeatureTestCase
         $this->assertFalse($user->query()->onGenericTrial()->exists());
         $this->assertTrue($user->query()->hasExpiredGenericTrial()->exists());
     }
+    
     public function test_customer_can_be_deleted() {
 
         $customer = $user->createAsStripeCustomer();
@@ -139,7 +140,7 @@ class CustomerTest extends FeatureTestCase
         $user->deleteAsStripeCustomer();
 
         $test = $user->asStripeCustomer();
-        
+
         $this->assertNull($test);
     }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -132,4 +132,14 @@ class CustomerTest extends FeatureTestCase
         $this->assertFalse($user->query()->onGenericTrial()->exists());
         $this->assertTrue($user->query()->hasExpiredGenericTrial()->exists());
     }
+    public function test_customer_can_be_deleted() {
+
+        $customer = $user->createAsStripeCustomer();
+
+        $user->deleteAsStripeCustomer();
+
+        $test = $user->asStripeCustomer();
+        
+        $this->assertNull($test);
+    }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -132,8 +132,9 @@ class CustomerTest extends FeatureTestCase
         $this->assertFalse($user->query()->onGenericTrial()->exists());
         $this->assertTrue($user->query()->hasExpiredGenericTrial()->exists());
     }
-    
-    public function test_customer_can_be_deleted() {
+
+    public function test_customer_can_be_deleted() 
+    {
 
         $customer = $user->createAsStripeCustomer();
 

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -133,9 +133,8 @@ class CustomerTest extends FeatureTestCase
         $this->assertTrue($user->query()->hasExpiredGenericTrial()->exists());
     }
 
-    public function test_customer_can_be_deleted() 
+    public function test_customer_can_be_deleted()
     {
-
         $customer = $user->createAsStripeCustomer();
 
         $user->deleteAsStripeCustomer();


### PR DESCRIPTION
This adds a method to the ManagesCustomer Concern called deleteStripeCustomer which deletes the customer from stripe and nulls the reference to that user in the current object.
This is helpful for when you need to delete the stripe customer.

I've provided tests but am unable to run them as my account is not configured to run all of the tests.
For implementation:
It should be calling the following method:
https://github.com/stripe/stripe-php/blob/b7744ede8a959b06f05859da10bdfbe561411267/lib/Service/CustomerService.php#L209

Based on this documentation, there is no need for parameters beyond the customer id.
https://stripe.com/docs/api/customers/delete

It shouldn't break anything because this is a new feature and no current methods have been changed. But I have not tested to see if it works because I hesitate to put in my stripe id and run ALL of the tests.

Issue Reference: #1526

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
