### PR TITLE
[15.x] Remove isDeleted method

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -760,16 +760,6 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Determine if the invoice is deleted.
-     *
-     * @return bool
-     */
-    public function isDeleted()
-    {
-        return $this->invoice->status === StripeInvoice::STATUS_DELETED;
-    }
-
-    /**
      * Get the View instance for the invoice.
      *
      * @param  array  $data


### PR DESCRIPTION
This PR removes the `isDeleted` method from the invoice object because the status doesn't exists anymore in Stripe.