### PR TITLE
[14.x] Fallback for empty pm_type object on fillPaymentMethodDetails

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -232,7 +232,7 @@ trait ManagesPaymentMethods
             $this->pm_last_four = $paymentMethod->card->last4;
         } else {
             $this->pm_type = $type = $paymentMethod->type;
-            $this->pm_last_four = optional($paymentMethod)->$type->last4;
+            $this->pm_last_four = $paymentMethod?->$type->last4 ?? null;
         }
 
         return $this;


### PR DESCRIPTION
This should fix issue https://github.com/laravel/cashier-stripe/issues/1530 by falling back to null for the `last4` attribute when it is not accessible on certain payment method types including `cashapp`, allowing support for Cash App Pay.