### PR TITLE
[14.x] Handle automatic payment method updates

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade Guide
 
+## Upgrading To 14.13 From 14.12
+
+### Webhook Added
+
+PR: https://github.com/laravel/cashier-stripe/pull/1534
+
+The webhook endpoint details [in your Stripe dashboard](https://dashboard.stripe.com/webhooks) should be updated to add `payment_method.automatically_updated` as one of the events sent to ensure that a user's payment method stays in sync between Cashier and Stripe when automatically updated by the issuer.
+
 ## Upgrading To 14.4 From 14.3
 
 ### Stripe API Version
@@ -80,7 +88,7 @@ You may use the following upgrade checklist to properly enable the new webhook:
 
 After following this process, your new webhook will be active and ready to receive events.
 
-### Optionally Dompdf Dependency
+### Optional Dompdf Dependency
 
 PR: https://github.com/laravel/cashier-stripe/pull/1312
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,7 @@
 
 PR: https://github.com/laravel/cashier-stripe/pull/1534
 
-The webhook endpoint details [in your Stripe dashboard](https://dashboard.stripe.com/webhooks) should be updated to add `payment_method.automatically_updated` as one of the events sent to ensure that a user's payment method stays in sync between Cashier and Stripe when automatically updated by the issuer.
+[Your Stripe webhook](https://dashboard.stripe.com/webhooks) should be updated to include `payment_method.automatically_updated` as one of the events sent to your application. This will ensure that user payment method information stays in sync between Cashier and Stripe when the information is automatically updated by the card issuer.
 
 ## Upgrading To 14.4 From 14.3
 

--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -13,6 +13,7 @@ class WebhookCommand extends Command
         'customer.subscription.deleted',
         'customer.updated',
         'customer.deleted',
+        'payment_method.automatically_updated',
         'invoice.payment_action_required',
         'invoice.payment_succeeded',
     ];

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -259,6 +259,21 @@ class WebhookController extends Controller
 
         return $this->successMethod();
     }
+    
+    /**
+     * Handle payment method automatically updated by vendor.
+     *
+     * @param  array  $payload
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function handlePaymentMethodAutomaticallyUpdated(array $payload)
+    {
+        if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
+            $user->updateDefaultPaymentMethodFromStripe();
+        }
+
+        return $this->successMethod();
+    }
 
     /**
      * Handle payment action required for invoice.

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -259,7 +259,7 @@ class WebhookController extends Controller
 
         return $this->successMethod();
     }
-    
+
     /**
      * Handle payment method automatically updated by vendor.
      *


### PR DESCRIPTION
Vendors, including Visa and Mastercard, often reissue and update stored payment methods in place for Stripe users. This can involve updating the expiration date, but frequently also changes the entire card number as well.

The [Stripe events log](https://dashboard.stripe.com/events?type=payment_method.automatically_updated) filtered for this type of event shows how often it happens, which we are seeing several times per day in our own apps (more than I would have expected).

These automatic updates allow the payment methods to continue to be successfully charged by Stripe, but has the side effect of causing the Cashier user model to become out of sync with the outdated `pm_last_four` stored.

Fortunately, Stripe sends a `payment_method.automatically_updated` webhook when this happens that can be listened to for triggering an update of the locally stored payment method to ensure it stays in sync, which is the purpose of this PR.

Since this is a non-breaking change, I believe it is a good candidate for a 14.x release to benefit users right away. Enabling it does require adding that webhook in the Stripe dashboard though, which I can note in the upgrade guide and docs upon merge.