### PR TITLE
Update ManagesCustomer to include optional metadata when creating or syncing a user

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -83,6 +83,10 @@ trait ManagesCustomer
             $options['preferred_locales'] = $locales;
         }
 
+        if (! array_key_exists('metadata', $options) && $metadata = $this->stripeMetadata()) {
+            $options['metadata'] = $metadata;
+        }
+
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances
         // and allow us to retrieve users from Stripe later when we need to work.
@@ -196,6 +200,16 @@ trait ManagesCustomer
     }
 
     /**
+     * Get the metadata that should be synced to Stripe.
+     *
+     * @return array|null
+     */
+    public function stripeMetadata()
+    {
+        // return [];
+    }
+
+    /**
      * Sync the customer's information to Stripe.
      *
      * @return \Stripe\Customer
@@ -208,6 +222,7 @@ trait ManagesCustomer
             'phone' => $this->stripePhone(),
             'address' => $this->stripeAddress(),
             'preferred_locales' => $this->stripePreferredLocales(),
+            'metadata' => $this->stripeMetadata(),
         ]);
     }
 


### PR DESCRIPTION
Our `User` model has the `Billable` trait applied to it. In order to make it easier to search Stripe for the correct user, we've been syncing the user ID in the metadata. I've noticed this has lead to a decent amount of code duplication.

```php
class User extends Model
{
    public function refreshStripeData()
    {
        $options = [
            'metadata' => [
                'user_id' => $this->id,
            ],
        ];

        if ($this->hasStripeId()) {
            $this->syncStripeCustomerDetails($options);
        } else {
            $this->createAsStripeCustomer($options);
        }
        $this->updateDefaultPaymentMethodFromStripe();
    }

    public function ensureStripeUserExists()
    {

        if (!$this->hasStripeId()) {
            $this->createAsStripeCustomer([
                'metadata' => [
                    'user_id' => $this->id,
                ],
            ]);
        }
    }
}
```

This also means that if someone else is writing code that creates/syncs users in Stripe, they need to 1) know it won't send this metadata over and 2) remember to include it. It would be much easier if I could just define the metadata that should be included once on the `User` model and know that it would be included consistently every time.

This PR introduces a `stripeMetadata()` method to the `ManagesCustomers` concern. By default, it will just send over a null object and not set the metadata. However, if I wanted to specify some custom metadata on my `Billable` object, all I would need to do is add:

```php
    public function stripeMetadata()
    {
        return [ 'user_id' => $this->id ];
    }
```

I haven't written any automated tests for this functionality, as I didn't see any for similar methods (e.g. `stripeName()`, `stripeEmail()`, etc.). I did manually test it and verified that it worked as expected for when no metadata is specified, and when custom metadata is provided.