### PR TITLE
createSetupIntent add customer stripe_id option

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -19,6 +19,10 @@ trait ManagesPaymentMethods
      */
     public function createSetupIntent(array $options = [])
     {
+        if ($this->hasStripeId()) {
+            $options['customer'] = $this->stripe_id;
+        }
+        
         return $this->stripe()->setupIntents->create($options);
     }
 

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -22,7 +22,7 @@ trait ManagesPaymentMethods
         if ($this->hasStripeId()) {
             $options['customer'] = $this->stripe_id;
         }
-        
+
         return $this->stripe()->setupIntents->create($options);
     }
 


### PR DESCRIPTION
Similarly to the creation of a `PaymentIntent` using the `$user->pay()` method, the `$user->createSetupIntent()` method should also create a `SetupIntent` attached to the user's Stripe Customer if it exists.

Otherwise, all Setup Intents are created as Stripe guest customers.

So this PR makes both methods for creating intents behave the same way.