### PR TITLE
Added expand option to Subscription latestInvoice()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1139,9 +1139,9 @@ class Subscription extends Model
      *
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function latestInvoice()
+    public function latestInvoice(array $expand = [])
     {
-        $stripeSubscription = $this->asStripeSubscription(['latest_invoice']);
+        $stripeSubscription = $this->asStripeSubscription(['latest_invoice', ...$expand]);
 
         if ($stripeSubscription->latest_invoice) {
             return new Invoice($this->owner, $stripeSubscription->latest_invoice);


### PR DESCRIPTION
Non breaking change, added expand option to the ```latestInvoice()``` method of the ```Subscription``` class
This is useful as when getting the latest invoice to check for 'requires_action' 3DS it's helpful to be able to return the payment intent. We could also have a method on the Invoice, ```requiresConfirmation()```
Invoice ```pay()``` does not throw an ```IncompletePayment``` exception, it throws a native Stripe ```CardException``` so the payment intent is not in the error object
