### PR TITLE
Added expand option to Subscription latestInvoice()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1139,9 +1139,9 @@ class Subscription extends Model
      *
      * @return \Laravel\Cashier\Invoice|null
      */
-    public function latestInvoice()
+    public function latestInvoice(array $expand = [])
     {
-        $stripeSubscription = $this->asStripeSubscription(['latest_invoice']);
+        $stripeSubscription = $this->asStripeSubscription(['latest_invoice', ...$expand]);
 
         if ($stripeSubscription->latest_invoice) {
             return new Invoice($this->owner, $stripeSubscription->latest_invoice);


### PR DESCRIPTION
Breaking change PR in 14.x moved to 15.x (master)
Added expand option to latestInvoice() method so you can get the payment intent to check for 3DS requires action
When using $invoice->pay() it does not throw an Cashier IncompletePayment exception it throws a native Stripe CardException so the payment intent is not in the error object, it helps to have the payment intent on the invoice so you can check before attempting to pay()
