### PR TITLE
Fix: Invoke `static` method statically

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -90,7 +90,7 @@ trait ManagesCustomer
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances
         // and allow us to retrieve users from Stripe later when we need to work.
-        $customer = $this->stripe()->customers->create($options);
+        $customer = self::stripe()->customers->create($options);
 
         $this->stripe_id = $customer->id;
 
@@ -107,7 +107,7 @@ trait ManagesCustomer
      */
     public function updateStripeCustomer(array $options = [])
     {
-        return $this->stripe()->customers->update(
+        return self::stripe()->customers->update(
             $this->stripe_id, $options
         );
     }
@@ -137,7 +137,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return $this->stripe()->customers->retrieve(
+        return self::stripe()->customers->retrieve(
             $this->stripe_id, ['expand' => $expand]
         );
     }
@@ -279,7 +279,7 @@ trait ManagesCustomer
      */
     public function findPromotionCode($code, array $options = [])
     {
-        $codes = $this->stripe()->promotionCodes->all(array_merge([
+        $codes = self::stripe()->promotionCodes->all(array_merge([
             'code' => $code,
             'limit' => 1,
         ], $options));
@@ -338,7 +338,7 @@ trait ManagesCustomer
             return new Collection();
         }
 
-        $transactions = $this->stripe()
+        $transactions = self::stripe()
             ->customers
             ->allBalanceTransactions($this->stripe_id, array_merge(['limit' => $limit], $options));
 
@@ -385,7 +385,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        $transaction = $this->stripe()
+        $transaction = self::stripe()
             ->customers
             ->createBalanceTransaction($this->stripe_id, array_filter(array_merge([
                 'amount' => $amount,
@@ -428,7 +428,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return $this->stripe()->billingPortal->sessions->create(array_merge([
+        return self::stripe()->billingPortal->sessions->create(array_merge([
             'customer' => $this->stripeId(),
             'return_url' => $returnUrl ?? route('home'),
         ], $options))['url'];
@@ -458,7 +458,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         return new Collection(
-            $this->stripe()->customers->allTaxIds($this->stripe_id, $options)->data
+            self::stripe()->customers->allTaxIds($this->stripe_id, $options)->data
         );
     }
 
@@ -472,7 +472,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         try {
-            return $this->stripe()->customers->retrieveTaxId(
+            return self::stripe()->customers->retrieveTaxId(
                 $this->stripe_id, $id, []
             );
         } catch (StripeInvalidRequestException $exception) {
@@ -491,7 +491,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return $this->stripe()->customers->createTaxId($this->stripe_id, [
+        return self::stripe()->customers->createTaxId($this->stripe_id, [
             'type' => $type,
             'value' => $value,
         ]);
@@ -508,7 +508,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         try {
-            $this->stripe()->customers->deleteTaxId($this->stripe_id, $id);
+            self::stripe()->customers->deleteTaxId($this->stripe_id, $id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -90,7 +90,7 @@ trait ManagesCustomer
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances
         // and allow us to retrieve users from Stripe later when we need to work.
-        $customer = self::stripe()->customers->create($options);
+        $customer = static::stripe()->customers->create($options);
 
         $this->stripe_id = $customer->id;
 
@@ -107,7 +107,7 @@ trait ManagesCustomer
      */
     public function updateStripeCustomer(array $options = [])
     {
-        return self::stripe()->customers->update(
+        return static::stripe()->customers->update(
             $this->stripe_id, $options
         );
     }
@@ -137,7 +137,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return self::stripe()->customers->retrieve(
+        return static::stripe()->customers->retrieve(
             $this->stripe_id, ['expand' => $expand]
         );
     }
@@ -279,7 +279,7 @@ trait ManagesCustomer
      */
     public function findPromotionCode($code, array $options = [])
     {
-        $codes = self::stripe()->promotionCodes->all(array_merge([
+        $codes = static::stripe()->promotionCodes->all(array_merge([
             'code' => $code,
             'limit' => 1,
         ], $options));
@@ -338,7 +338,7 @@ trait ManagesCustomer
             return new Collection();
         }
 
-        $transactions = self::stripe()
+        $transactions = static::stripe()
             ->customers
             ->allBalanceTransactions($this->stripe_id, array_merge(['limit' => $limit], $options));
 
@@ -385,7 +385,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        $transaction = self::stripe()
+        $transaction = static::stripe()
             ->customers
             ->createBalanceTransaction($this->stripe_id, array_filter(array_merge([
                 'amount' => $amount,
@@ -428,7 +428,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return self::stripe()->billingPortal->sessions->create(array_merge([
+        return static::stripe()->billingPortal->sessions->create(array_merge([
             'customer' => $this->stripeId(),
             'return_url' => $returnUrl ?? route('home'),
         ], $options))['url'];
@@ -458,7 +458,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         return new Collection(
-            self::stripe()->customers->allTaxIds($this->stripe_id, $options)->data
+            static::stripe()->customers->allTaxIds($this->stripe_id, $options)->data
         );
     }
 
@@ -472,7 +472,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         try {
-            return self::stripe()->customers->retrieveTaxId(
+            return static::stripe()->customers->retrieveTaxId(
                 $this->stripe_id, $id, []
             );
         } catch (StripeInvalidRequestException $exception) {
@@ -491,7 +491,7 @@ trait ManagesCustomer
     {
         $this->assertCustomerExists();
 
-        return self::stripe()->customers->createTaxId($this->stripe_id, [
+        return static::stripe()->customers->createTaxId($this->stripe_id, [
             'type' => $type,
             'value' => $value,
         ]);
@@ -508,7 +508,7 @@ trait ManagesCustomer
         $this->assertCustomerExists();
 
         try {
-            self::stripe()->customers->deleteTaxId($this->stripe_id, $id);
+            static::stripe()->customers->deleteTaxId($this->stripe_id, $id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -51,7 +51,7 @@ trait ManagesInvoices
             $options['amount'] = $amount;
         }
 
-        return $this->stripe()->invoiceItems->create($options);
+        return self::stripe()->invoiceItems->create($options);
     }
 
     /**
@@ -90,7 +90,7 @@ trait ManagesInvoices
             'quantity' => $quantity,
         ], $options);
 
-        return $this->stripe()->invoiceItems->create($options);
+        return self::stripe()->invoiceItems->create($options);
     }
 
     /**
@@ -140,7 +140,7 @@ trait ManagesInvoices
             return $invoice->chargesAutomatically() ? $invoice->pay($payOptions) : $invoice->send();
         } catch (StripeCardException) {
             $payment = new Payment(
-                $this->stripe()->paymentIntents->retrieve(
+                self::stripe()->paymentIntents->retrieve(
                     $invoice->asStripeInvoice()->refresh()->payment_intent,
                     ['expand' => ['invoice.subscription']]
                 )
@@ -169,7 +169,7 @@ trait ManagesInvoices
             unset($parameters['pending_invoice_items_behavior']);
         }
 
-        $stripeInvoice = $this->stripe()->invoices->create($parameters);
+        $stripeInvoice = self::stripe()->invoices->create($parameters);
 
         return new Invoice($this, $stripeInvoice);
     }
@@ -192,7 +192,7 @@ trait ManagesInvoices
         ], $options);
 
         try {
-            $stripeInvoice = $this->stripe()->invoices->upcoming($parameters);
+            $stripeInvoice = self::stripe()->invoices->upcoming($parameters);
 
             return new Invoice($this, $stripeInvoice, $parameters);
         } catch (StripeInvalidRequestException $exception) {
@@ -211,7 +211,7 @@ trait ManagesInvoices
         $stripeInvoice = null;
 
         try {
-            $stripeInvoice = $this->stripe()->invoices->retrieve($id);
+            $stripeInvoice = self::stripe()->invoices->retrieve($id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -275,7 +275,7 @@ trait ManagesInvoices
 
         $parameters = array_merge(['limit' => 24], $parameters);
 
-        $stripeInvoices = $this->stripe()->invoices->all(
+        $stripeInvoices = self::stripe()->invoices->all(
             ['customer' => $this->stripe_id] + $parameters
         );
 

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -51,7 +51,7 @@ trait ManagesInvoices
             $options['amount'] = $amount;
         }
 
-        return self::stripe()->invoiceItems->create($options);
+        return static::stripe()->invoiceItems->create($options);
     }
 
     /**
@@ -90,7 +90,7 @@ trait ManagesInvoices
             'quantity' => $quantity,
         ], $options);
 
-        return self::stripe()->invoiceItems->create($options);
+        return static::stripe()->invoiceItems->create($options);
     }
 
     /**
@@ -140,7 +140,7 @@ trait ManagesInvoices
             return $invoice->chargesAutomatically() ? $invoice->pay($payOptions) : $invoice->send();
         } catch (StripeCardException) {
             $payment = new Payment(
-                self::stripe()->paymentIntents->retrieve(
+                static::stripe()->paymentIntents->retrieve(
                     $invoice->asStripeInvoice()->refresh()->payment_intent,
                     ['expand' => ['invoice.subscription']]
                 )
@@ -169,7 +169,7 @@ trait ManagesInvoices
             unset($parameters['pending_invoice_items_behavior']);
         }
 
-        $stripeInvoice = self::stripe()->invoices->create($parameters);
+        $stripeInvoice = static::stripe()->invoices->create($parameters);
 
         return new Invoice($this, $stripeInvoice);
     }
@@ -192,7 +192,7 @@ trait ManagesInvoices
         ], $options);
 
         try {
-            $stripeInvoice = self::stripe()->invoices->upcoming($parameters);
+            $stripeInvoice = static::stripe()->invoices->upcoming($parameters);
 
             return new Invoice($this, $stripeInvoice, $parameters);
         } catch (StripeInvalidRequestException $exception) {
@@ -211,7 +211,7 @@ trait ManagesInvoices
         $stripeInvoice = null;
 
         try {
-            $stripeInvoice = self::stripe()->invoices->retrieve($id);
+            $stripeInvoice = static::stripe()->invoices->retrieve($id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -275,7 +275,7 @@ trait ManagesInvoices
 
         $parameters = array_merge(['limit' => 24], $parameters);
 
-        $stripeInvoices = self::stripe()->invoices->all(
+        $stripeInvoices = static::stripe()->invoices->all(
             ['customer' => $this->stripe_id] + $parameters
         );
 

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -23,7 +23,7 @@ trait ManagesPaymentMethods
             $options['customer'] = $this->stripe_id;
         }
 
-        return self::stripe()->setupIntents->create($options);
+        return static::stripe()->setupIntents->create($options);
     }
 
     /**
@@ -36,7 +36,7 @@ trait ManagesPaymentMethods
      */
     public function findSetupIntent(string $id, array $params = [], array $options = [])
     {
-        return self::stripe()->setupIntents->retrieve($id, $params, $options);
+        return static::stripe()->setupIntents->retrieve($id, $params, $options);
     }
 
     /**
@@ -76,7 +76,7 @@ trait ManagesPaymentMethods
         $parameters = array_merge(['limit' => 24], $parameters);
 
         // "type" is temporarily required by Stripe...
-        $paymentMethods = self::stripe()->paymentMethods->all(
+        $paymentMethods = static::stripe()->paymentMethods->all(
             ['customer' => $this->stripe_id, 'type' => $type] + $parameters
         );
 
@@ -309,6 +309,6 @@ trait ManagesPaymentMethods
             return $paymentMethod;
         }
 
-        return self::stripe()->paymentMethods->retrieve($paymentMethod);
+        return static::stripe()->paymentMethods->retrieve($paymentMethod);
     }
 }

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -23,7 +23,7 @@ trait ManagesPaymentMethods
             $options['customer'] = $this->stripe_id;
         }
 
-        return $this->stripe()->setupIntents->create($options);
+        return self::stripe()->setupIntents->create($options);
     }
 
     /**
@@ -36,7 +36,7 @@ trait ManagesPaymentMethods
      */
     public function findSetupIntent(string $id, array $params = [], array $options = [])
     {
-        return $this->stripe()->setupIntents->retrieve($id, $params, $options);
+        return self::stripe()->setupIntents->retrieve($id, $params, $options);
     }
 
     /**
@@ -76,7 +76,7 @@ trait ManagesPaymentMethods
         $parameters = array_merge(['limit' => 24], $parameters);
 
         // "type" is temporarily required by Stripe...
-        $paymentMethods = $this->stripe()->paymentMethods->all(
+        $paymentMethods = self::stripe()->paymentMethods->all(
             ['customer' => $this->stripe_id, 'type' => $type] + $parameters
         );
 
@@ -309,6 +309,6 @@ trait ManagesPaymentMethods
             return $paymentMethod;
         }
 
-        return $this->stripe()->paymentMethods->retrieve($paymentMethod);
+        return self::stripe()->paymentMethods->retrieve($paymentMethod);
     }
 }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -90,7 +90,7 @@ trait PerformsCharges
         }
 
         return new Payment(
-            self::stripe()->paymentIntents->create($options)
+            static::stripe()->paymentIntents->create($options)
         );
     }
 
@@ -105,7 +105,7 @@ trait PerformsCharges
         $stripePaymentIntent = null;
 
         try {
-            $stripePaymentIntent = self::stripe()->paymentIntents->retrieve($id);
+            $stripePaymentIntent = static::stripe()->paymentIntents->retrieve($id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -122,7 +122,7 @@ trait PerformsCharges
      */
     public function refund($paymentIntent, array $options = [])
     {
-        return self::stripe()->refunds->create(
+        return static::stripe()->refunds->create(
             ['payment_intent' => $paymentIntent] + $options
         );
     }

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -90,7 +90,7 @@ trait PerformsCharges
         }
 
         return new Payment(
-            $this->stripe()->paymentIntents->create($options)
+            self::stripe()->paymentIntents->create($options)
         );
     }
 
@@ -105,7 +105,7 @@ trait PerformsCharges
         $stripePaymentIntent = null;
 
         try {
-            $stripePaymentIntent = $this->stripe()->paymentIntents->retrieve($id);
+            $stripePaymentIntent = self::stripe()->paymentIntents->retrieve($id);
         } catch (StripeInvalidRequestException $exception) {
             //
         }
@@ -122,7 +122,7 @@ trait PerformsCharges
      */
     public function refund($paymentIntent, array $options = [])
     {
-        return $this->stripe()->refunds->create(
+        return self::stripe()->refunds->create(
             ['payment_intent' => $paymentIntent] + $options
         );
     }


### PR DESCRIPTION
This pull request


- [x] invokes a `static` method statically

💁‍♂️ For reference, see

https://github.com/laravel/cashier-stripe/blob/635f8b81cacdcc963dc55d124916a8a65553f639/src/Concerns/ManagesCustomer.php#L553-L556
