### PR TITLE
Fix: Use constants for HTTP response status codes

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Facades\Redirect;
 use JsonSerializable;
 use Stripe\Checkout\Session;
+use Symfony\Component\HttpFoundation\Response;
 
 class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
 {
@@ -102,7 +103,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      */
     public function redirect()
     {
-        return Redirect::to($this->session->url, 303);
+        return Redirect::to($this->session->url, Response::HTTP_SEE_OTHER);
     }
 
     /**

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -319,7 +319,7 @@ class WebhookController extends Controller
      */
     protected function successMethod($parameters = [])
     {
-        return new Response('Webhook Handled', 200);
+        return new Response('Webhook Handled', Response::HTTP_OK);
     }
 
     /**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -824,7 +824,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function downloadAs($filename, array $data = [])
     {
-        return new Response($this->pdf($data), 200, [
+        return new Response($this->pdf($data), Response::HTTP_OK, [
             'Content-Description' => 'File Transfer',
             'Content-Disposition' => 'attachment; filename="'.$filename.'.pdf"',
             'Content-Transfer-Encoding' => 'binary',


### PR DESCRIPTION
This pull request

- [x] uses constants instead of magic numbers for HTTP response status codes