### PR TITLE
Fix: Remove reference to `CASHIER_MODEL` enviromment variable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The Laravel contributing guide can be found in the [Laravel documentation](https
 
 You will need to set the Stripe **testing** secret environment variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
-Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `CASHIER_MODEL` environment variable in your new `phpunit.xml` file:
+Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line to the `<php>` section in your new `phpunit.xml` file:
 
     <env name="STRIPE_SECRET" value="Your Stripe Testing Secret Key"/>
 


### PR DESCRIPTION
This pull request

- [x] removes a reference to the `CASHIER_MODEL` environment variable

Replaces #1562.

💁‍♂️ Running

```shell
git grep CASHIER_MODEL
```

on current `14x.` yields

```
.github/CONTRIBUTING.md:9:Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `CASHIER_MODEL` environment variable in your new `phpunit.xml` file:
UPGRADE.md:584:The `STRIPE_MODEL` environment variable has been renamed to `CASHIER_MODEL`.
```

so it does not exist in `phpunit.xml.dist`.