### PR TITLE
Prevent Sync From Deleting Existing Metadata

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -206,7 +206,7 @@ trait ManagesCustomer
      */
     public function stripeMetadata()
     {
-        // return [];
+        return [];
     }
 
     /**


### PR DESCRIPTION
When your Billable does not overload stripeMetadata() and a billable is synced, any existing metadata on the Stripe customer is lost. 

The default behavior should be to preserve the existing metadata -- an empty array will accomplish this.

Deleting existing Stripe customer metadata is potentially devastating if you're using Stripe as a store for data that isn't persisted to your billable model.