### PR TITLE
Add the withCurrency and withUserDefaultCurrency SubscriptionBuilderClass Methods

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -38,6 +38,13 @@ class SubscriptionBuilder
     protected $name;
 
     /**
+     * The user currency.
+     *
+     * @var string
+     */
+    protected $currency;
+
+    /**
      * The prices the customer is being subscribed to.
      *
      * @var array
@@ -220,6 +227,40 @@ class SubscriptionBuilder
     }
 
     /**
+     * The currency code to use.
+     *
+     * @param  string  $currency
+     * @return $this
+     */
+    public function withCurrency($currency)
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    /**
+     * Use the customer Stripe default currency.
+     *
+     * @return $this
+     */
+    public function withUserDefaultCurrency()
+    {
+        // Not a Stripe customer yet
+        if (!$this->owner->stripe_id) {
+            return $this;
+        }
+
+        $stripeCustomer = $this->owner->asStripeCustomer();
+
+        if (!empty($stripeCustomer['currency'])) {
+            $this->currency = $stripeCustomer['currency'];
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a new Stripe subscription to the Stripe model.
      *
      * @param  array  $customerOptions
@@ -394,6 +435,7 @@ class SubscriptionBuilder
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => $this->metadata,
             'items' => Collection::make($this->items)->values()->all(),
+            'currency' => $this->currency,
             'payment_behavior' => $this->paymentBehavior(),
             'promotion_code' => $this->promotionCodeId,
             'proration_behavior' => $this->prorateBehavior(),

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -247,13 +247,13 @@ class SubscriptionBuilder
     public function withUserDefaultCurrency()
     {
         // Not a Stripe customer yet
-        if (!$this->owner->stripe_id) {
+        if (! $this->owner->stripe_id) {
             return $this;
         }
 
         $stripeCustomer = $this->owner->asStripeCustomer();
 
-        if (!empty($stripeCustomer['currency'])) {
+        if (! empty($stripeCustomer['currency'])) {
             $this->currency = $stripeCustomer['currency'];
         }
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -104,7 +104,7 @@ class SubscriptionsTest extends FeatureTestCase
             'currency_options' => [
                 'eur' => [
                     'unit_amount' => 900,
-                ] 
+                ], 
             ],
             'recurring' => [
                 'interval' => 'month',
@@ -213,7 +213,7 @@ class SubscriptionsTest extends FeatureTestCase
     public function test_subscriptions_can_be_created_with_existing_currency_option()
     {
         $user = $this->createCustomer('subscriptions_can_be_created_with_existing_currency_option');
-        
+
         // Create Subscription
         $user->newSubscription('main', static::$currencyOptionPriceId)
             ->withCurrency('EUR')

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -104,7 +104,7 @@ class SubscriptionsTest extends FeatureTestCase
             'currency_options' => [
                 'eur' => [
                     'unit_amount' => 900,
-                ], 
+                ],
             ],
             'recurring' => [
                 'interval' => 'month',
@@ -237,7 +237,6 @@ class SubscriptionsTest extends FeatureTestCase
             $user->newSubscription('main', static::$currencyOptionPriceId)
                 ->withCurrency('SEK')
                 ->create('pm_card_visa');
-                
         } catch (Exception $e) {
             $this->assertFalse($user->subscribed('main'));
             $this->assertFalse($user->subscribedToProduct(static::$productId, 'main'));

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -243,7 +243,6 @@ class SubscriptionsTest extends FeatureTestCase
             $this->assertFalse($user->subscribedToProduct(static::$productId, 'main'));
             $this->assertFalse($user->subscribedToPrice(static::$currencyOptionPriceId, 'main'));
         }
-
     }
 
     /** @link https://github.com/laravel/cashier-stripe/issues/1570 */


### PR DESCRIPTION
Now it's possible o specify the currency for the subscriptions, so it's possible to use the customer currency with prices which have values on many currencies.

There are 2 tests included. On the second test, when a subscription is created with X currency, then X become the default currency for the customer. After that, the `withUserDefaultCurrency` method is used with another subscription, selecting the user default currency. Otherwise, the subscription will fail, as the price base currency will be selected, showing:

`The currency of the selected prices (usd) does not match the customer currency (eur).`

Related issue https://github.com/laravel/cashier-stripe/issues/1570