### PR TITLE
Add `Conditionable` trait to subscription builder

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
 use Laravel\Cashier\Concerns\HandlesPaymentFailures;
@@ -18,6 +19,7 @@ use Stripe\Subscription as StripeSubscription;
 class SubscriptionBuilder
 {
     use AllowsCoupons;
+    use Conditionable;
     use HandlesPaymentFailures;
     use HandlesTaxes;
     use InteractsWithPaymentBehavior;


### PR DESCRIPTION
Example code:

```php
return $tenant->newSubscription($plan, $priceId)
    ->allowPromotionCodes()
    ->when($trailDays, fn (SubscriptionBuilder $builder) => $builder->trialUntil(Carbon::now()->endOfDay()->addDays($trialDays)))
    ->collectTaxIds()
    ->checkout([
        'success_url' => Dashboard::getUrl(),
        'cancel_url' => Dashboard::getUrl(),
    ])
    ->redirect();
```
