### PR TITLE
Check all subscriptions when running `$user->subscribed('name')`

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -135,13 +135,14 @@ trait ManagesSubscriptions
      */
     public function subscribed($name = 'default', $price = null)
     {
-        $subscription = $this->subscription($name);
-
-        if (! $subscription || ! $subscription->valid()) {
-            return false;
+        $subscriptions = $this->subscriptions()->where('name', $name)->get();
+        foreach ($subscriptions as $subscription){
+            if ($subscription->valid() && (!$price || $subscription->hasPrice($price))) {
+                return true;
+            }
         }
 
-        return ! $price || $subscription->hasPrice($price);
+        return false;
     }
 
     /**

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -136,8 +136,8 @@ trait ManagesSubscriptions
     public function subscribed($name = 'default', $price = null)
     {
         $subscriptions = $this->subscriptions()->where('name', $name)->get();
-        foreach ($subscriptions as $subscription){
-            if ($subscription->valid() && (!$price || $subscription->hasPrice($price))) {
+        foreach ($subscriptions as $subscription) {
+            if ($subscription->valid() && (! $price || $subscription->hasPrice($price))) {
                 return true;
             }
         }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -107,6 +107,24 @@ class SubscriptionsTest extends FeatureTestCase
         ])->id;
     }
 
+
+    public function test_subscribed_when_multiple_subscriptions_of_same_name_exist(){
+        $user = $this->createCustomer('subscriptions_can_be_created');
+
+        // Create Subscription
+        $user->newSubscription('main', static::$priceId)
+            ->withMetadata($metadata = ['order_id' => '8'])
+            ->create('pm_card_visa');
+
+        // Create Canceled Subscription
+        $user->newSubscription('main', static::$priceId)
+            ->withMetadata($metadata = ['order_id' => '8'])
+            ->create('pm_card_visa');
+        $user->subscription('main')->cancelNow();
+
+
+        $this->assertTrue($user->subscribed('main'));
+    }
     public function test_subscriptions_can_be_created()
     {
         $user = $this->createCustomer('subscriptions_can_be_created');

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -108,7 +108,8 @@ class SubscriptionsTest extends FeatureTestCase
     }
 
 
-    public function test_subscribed_when_multiple_subscriptions_of_same_name_exist(){
+    public function test_subscribed_when_multiple_subscriptions_of_same_name_exist()
+    {
         $user = $this->createCustomer('subscriptions_can_be_created');
 
         // Create Subscription

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -107,7 +107,6 @@ class SubscriptionsTest extends FeatureTestCase
         ])->id;
     }
 
-
     public function test_subscribed_when_multiple_subscriptions_of_same_name_exist()
     {
         $user = $this->createCustomer('subscriptions_can_be_created');
@@ -123,9 +122,9 @@ class SubscriptionsTest extends FeatureTestCase
             ->create('pm_card_visa');
         $user->subscription('main')->cancelNow();
 
-
         $this->assertTrue($user->subscribed('main'));
     }
+
     public function test_subscriptions_can_be_created()
     {
         $user = $this->createCustomer('subscriptions_can_be_created');


### PR DESCRIPTION
Currently, if a user has multiple subscriptions with the same name where one is canceled and another is active and the canceled subscription was created after the active subscription cashier will return that the user is not subscribed.  This is due to the subscription pulling just the `first()` model out of the database.  Instead we should check every subscription with the same name and return if any of them are active.

As an example, cashier was returning false for `subscribed('unlimited')` with the following database state:
<img width="818" alt="image" src="https://github.com/laravel/cashier-stripe/assets/2235621/19775145-9589-41ee-ae62-aeb7268f921f">
