### PR TITLE
[14.x] Fix array merge for checkout

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -361,7 +361,8 @@ class SubscriptionBuilder
             ]),
         ]);
 
-        return Checkout::customer($this->owner, $this)->create([], array_merge($payload, $sessionOptions), $customerOptions);
+        return Checkout::customer($this->owner, $this)
+            ->create([], array_merge_recursive($payload, $sessionOptions), $customerOptions);
     }
 
     /**


### PR DESCRIPTION
Makes sure the payload for checkout is recursively merged instead of overwritten. The `create` method of the builder doesn't suffers from this because the default payload doesn't have multidimensional options.

Fixes https://github.com/laravel/cashier-stripe/issues/1578