### PR TITLE
[14.x] Fix default sync

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -179,6 +179,8 @@ trait ManagesCustomer
      */
     public function stripeAddress()
     {
+        return [];
+
         // return [
         //     'city' => 'Little Rock',
         //     'country' => 'US',
@@ -196,6 +198,8 @@ trait ManagesCustomer
      */
     public function stripePreferredLocales()
     {
+        return [];
+
         // return ['en'];
     }
 


### PR DESCRIPTION
Returning an empty array instead of a `null` value will keep existing data from being overwritten.