### PR TITLE
Bug 1585 - Tax ID collection requires updating business name on the customer

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -85,7 +85,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
         }
 
         // Make sure to collect address and name when Tax ID collection is enabled...
-        if (isset($data['customer']) && $data['tax_id_collection']['enabled'] ?? false) {
+        if (isset($data['customer']) && ($data['tax_id_collection']['enabled'] ?? false)) {
             $data['customer_update']['address'] = 'auto';
             $data['customer_update']['name'] = 'auto';
         }

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -79,9 +79,9 @@ class CheckoutBuilder
 
                 return $item;
             })->values()->all(),
-            'tax_id_collection' => [
-                'enabled' => Cashier::$calculatesTaxes ?: $this->collectTaxIds,
-            ],
+            'tax_id_collection' => (Cashier::$calculatesTaxes ?: $this->collectTaxIds)
+                ? ['enabled' => true]
+                : [],
         ]);
 
         return Checkout::create($this->owner, array_merge($payload, $sessionOptions), $customerOptions);


### PR DESCRIPTION
Closes #1585 

This PR resolves an issue that appears to have been introduced from a Stripe 2023-10-16 API update, where only the existence of the `tax_id_collection.enabled` parameter requires the addition of the `customer_update` parameters, rather than being able to set it to `false` as it was previously, resulting in the exception:

```
Stripe\Exception\InvalidRequestException

Tax ID collection requires updating business name on the customer. To enable tax ID collection for an existing customer, please set `customer_update[name]` to `auto`.

```

The `tax_id_collection` collection parameter will now be completely omitted when auto-calculation of taxes is disabled.