### PR TITLE
[14.x] Remove unique index from items table

### DIFF
--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -19,6 +19,8 @@ return new class extends Migration
             $table->string('stripe_price');
             $table->integer('quantity')->nullable();
             $table->timestamps();
+
+            $table->index(['subscription_id', 'stripe_price']);
         });
     }
 

--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -19,8 +19,6 @@ return new class extends Migration
             $table->string('stripe_price');
             $table->integer('quantity')->nullable();
             $table->timestamps();
-
-            $table->unique(['subscription_id', 'stripe_price']);
         });
     }
 


### PR DESCRIPTION
I stumbled upon an edge case where Stripe created a new subscription item for the same price ID. This means Cashier attempts to insert this while the unique constraint is active. Although it's unlikely this happens often (we only saw this just a couple of times) we shouldn't rely on this index anymore.