### PR TITLE
Add support for Payment cancelation

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -120,7 +120,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Cancels a payment that is being held for the customer.
+     * Cancel the payment.
      *
      * @param  array  $options
      * @return \Stripe\PaymentIntent

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -120,6 +120,17 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Cancels a payment that is being held for the customer.
+     *
+     * @param  array  $options
+     * @return \Stripe\PaymentIntent
+     */
+    public function cancel(array $options = [])
+    {
+        return $this->paymentIntent->cancel($options);
+    }
+
+    /**
      * Determine if the payment was canceled.
      *
      * @return bool


### PR DESCRIPTION
I am suggesting here a method very similar to `capture()` but for `cancel()`.

It simply call the `cancel()` method on the associated `PaymentIntent`.