### PR TITLE
Early return upcoming invoice

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1156,6 +1156,10 @@ class Subscription extends Model
      */
     public function upcomingInvoice(array $options = [])
     {
+        if ($this->canceled()) {
+            return null;
+        }
+
         return $this->owner->upcomingInvoice(array_merge([
             'subscription' => $this->stripe_id,
         ], $options));


### PR DESCRIPTION
Do not perform an API request when retrieving the upcoming invoice of a canceled subscription.