### PR TITLE
[14.x] Prevent confirm email when in Checkout

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -71,7 +71,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     public static function create($owner, array $sessionOptions = [], array $customerOptions = [])
     {
         $data = array_merge([
-            'mode' => 'payment',
+            'mode' => Session::MODE_PAYMENT,
             'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
             'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
         ], $sessionOptions);
@@ -88,6 +88,12 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
         if (isset($data['customer']) && ($data['tax_id_collection']['enabled'] ?? false)) {
             $data['customer_update']['address'] = 'auto';
             $data['customer_update']['name'] = 'auto';
+        }
+
+        if ($data['mode'] === Session::MODE_PAYMENT && ($data['invoice_creation']['enabled'] ?? false)) {
+            $data['invoice_creation']['invoice_data']['metadata']['is_on_session_checkout'] = true;
+        } elseif ($data['mode'] === Session::MODE_SUBSCRIPTION) {
+            $data['subscription_data']['metadata']['is_on_session_checkout'] = true;
         }
 
         $session = $stripe->checkout->sessions->create($data);

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -287,6 +287,14 @@ class WebhookController extends Controller
             return $this->successMethod();
         }
 
+        if ($payload['data']['object']['metadata']['on_session_checkout'] ?? false) {
+            return $this->successMethod();
+        }
+
+        if ($payload['data']['object']['subscription_details']['metadata']['is_on_session_checkout'] ?? false) {
+            return $this->successMethod();
+        }
+
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             if (in_array(Notifiable::class, class_uses_recursive($user))) {
                 $payment = new Payment($user->stripe()->paymentIntents->retrieve(

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -287,7 +287,7 @@ class WebhookController extends Controller
             return $this->successMethod();
         }
 
-        if ($payload['data']['object']['metadata']['on_session_checkout'] ?? false) {
+        if ($payload['data']['object']['metadata']['is_on_session_checkout'] ?? false) {
             return $this->successMethod();
         }
 


### PR DESCRIPTION
This will prevent confirmation emails from being sent when the customer is on-session in a Stripe Checkout.