### PR TITLE
Update PaymentMethod.php

### DIFF
--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -51,7 +51,7 @@ class PaymentMethod implements Arrayable, Jsonable, JsonSerializable
     /**
      * Delete the payment method.
      *
-     * @return \Stripe\PaymentMethod
+     * @return void
      */
     public function delete()
     {


### PR DESCRIPTION
Update the docstring to return `void`, since that is what the `deletePaymentMethod` function actually returns

Reason for change: We had assumed from VSCode's reference to the `delete` method that something was returned. As such, we checked the truthy-ness of that return to flag if there were any issues.

The issue is that the true return was `void`. A better solution would be to actually add the return hint as part of the function itself, but this is the lightest lift with no code changes I could think of. And it fixes any future confusion for this function.

See https://github.com/laravel/cashier-stripe/issues/1568 for documentation of the issue