### PR TITLE
Remove invoice.payment_succeeded webhook

### DIFF
--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -15,7 +15,6 @@ class WebhookCommand extends Command
         'customer.deleted',
         'payment_method.automatically_updated',
         'invoice.payment_action_required',
-        'invoice.payment_succeeded',
     ];
 
     /**


### PR DESCRIPTION
It looks like the webhook `invoice.payment_succeeded` is not used anymore.

So this PR removes it from the default list of webhooks that are registered when running:

```bash
php artisan cashier:webhook
```

See documentation: https://laravel.com/docs/10.x/billing#handling-stripe-webhooks