### PR TITLE
[14.x] Allow creation of checkouts with ui_mode=embedded

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -94,7 +94,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['subscription_data']['metadata']['is_on_session_checkout'] = true;
         }
 
-        // Make sure appropriate urls for ui_mode are set
+        // Remove success and cancel url if ui_mode is "embedded"...
         if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
         } else {

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -72,8 +72,6 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
     {
         $data = array_merge([
             'mode' => Session::MODE_PAYMENT,
-            'success_url' => $sessionOptions['success_url'] ?? route('home').'?checkout=success',
-            'cancel_url' => $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled',
         ], $sessionOptions);
 
         if ($owner) {
@@ -94,6 +92,14 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['invoice_creation']['invoice_data']['metadata']['is_on_session_checkout'] = true;
         } elseif ($data['mode'] === Session::MODE_SUBSCRIPTION) {
             $data['subscription_data']['metadata']['is_on_session_checkout'] = true;
+        }
+
+        // Make sure appropriate urls for ui_mode are set
+        if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
+            $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
+        } else {
+            $data['success_url'] = $sessionOptions['success_url'] ?? route('home').'?checkout=success';
+            $data['cancel_url'] = $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled';
         }
 
         $session = $stripe->checkout->sessions->create($data);

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -94,7 +94,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['subscription_data']['metadata']['is_on_session_checkout'] = true;
         }
 
-        // Remove success and cancel url if ui_mode is "embedded"...
+        // Remove success and cancel URLs if "ui_mode" is "embedded"...
         if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
         } else {

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -147,4 +147,26 @@ class CheckoutTest extends FeatureTestCase
 
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
+
+    public function test_customers_can_start_an_embedded_product_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_an_embedded_product_checkout_session');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $items = [$shirtPrice->id => 5];
+
+        $checkout = $user->checkout($items, [
+            'ui_mode' => 'embedded',
+            'return_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It is currently not possible to create embedded checkouts with cashier-stripe (see  #1590). Creating such a checkout requires a parameter `ui_mode` to be set to `embedded`.

This fails, because Stripe does not accept a `success_url` or `cancel_url` in this mode. Since these are added by the `Checkout` class on every creation, there is no way of preventing these parameters from being sent to Stripe and causing an error.

My minimal solution only adds `success_url` and `cancel_url` if `ui_mode` is not explicitly set to `embedded`, otherwise it enforces the existence of the `return_url` parameter.

A limitation of this solution is, that if the user explicitly set the `success_url` or `cancel_url` and is using the embedded mode, an error by Stripe will still appear, since these values are not removed from the payload if incompatible.