### PR TITLE
[15.x] Rename receipt to invoice

### DIFF
--- a/resources/views/invoice.blade.php
+++ b/resources/views/invoice.blade.php
@@ -51,7 +51,7 @@
         <tr valign="top">
             <td width="160">
                 <span style="font-size: 28px;">
-                    Receipt
+                    Invoice
                 </span>
 
                 <!-- Invoice Info -->

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -767,7 +767,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function view(array $data = [])
     {
-        return View::make('cashier::receipt', array_merge($data, [
+        return View::make('cashier::invoice', array_merge($data, [
             'invoice' => $this,
             'owner' => $this->owner,
             'user' => $this->owner,


### PR DESCRIPTION
This is something I've wanted to do for a long time already and that's to get rid of the last mention of "receipt" in Cashier Stripe. Stripe itself only uses "invoices" in their API's and that's what these documents are actually. Receipts is only a term used for a copy you get on Stripe emails but isn't the exact thing that's stored in Stripe. By consolidating this as "Invoice" we have a better presentation of these objects and documents.

Later on we can also adjust Spark Stripe for this. The migration path for this would be for people to rename their published view from `receipt.blade.php` to `invoice.blade.php`.