### PR TITLE
[15.x] Stops using `loadMigrationsFrom`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Migration Changes
 
-Cashier 15.0 no longer automatically loads migrations from its own migrations directory, so be sure to run the following command to publish Cashier's migrations to your application:
+Cashier 15.0 no longer automatically loads migrations from its own migrations directory. Instead, you should run the following command to publish Cashier's migrations to your application:
 
 ```bash
 php artisan vendor:publish --tag=cashier-migrations

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## Upgrading To 15.0 From 14.x
+
+### Migration Changes
+
+Cashier 15.0 no longer automatically loads migrations from its own migrations directory, so be sure to run the following command to publish Cashier's migrations to your application:
+
+```bash
+php artisan vendor:publish --tag=cashier-migrations
+```
+
 ## Upgrading To 14.12.2 From 14.12
 
 ### Webhook Added

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "dompdf/dompdf": "^2.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^7.14|^8.14",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.0"
     },

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -43,13 +43,6 @@ class Cashier
     protected static $formatCurrencyUsing;
 
     /**
-     * Indicates if Cashier migrations will be run.
-     *
-     * @var bool
-     */
-    public static $runsMigrations = true;
-
-    /**
      * Indicates if Cashier routes will be registered.
      *
      * @var bool
@@ -171,18 +164,6 @@ class Cashier
         $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
 
         return $moneyFormatter->format($money);
-    }
-
-    /**
-     * Configure Cashier to not register its migrations.
-     *
-     * @return static
-     */
-    public static function ignoreMigrations()
-    {
-        static::$runsMigrations = false;
-
-        return new static;
     }
 
     /**

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -22,7 +22,6 @@ class CashierServiceProvider extends ServiceProvider
         $this->registerLogger();
         $this->registerRoutes();
         $this->registerResources();
-        $this->registerMigrations();
         $this->registerPublishing();
         $this->registerCommands();
 
@@ -121,18 +120,6 @@ class CashierServiceProvider extends ServiceProvider
     protected function registerResources()
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
-    }
-
-    /**
-     * Register the package migrations.
-     *
-     * @return void
-     */
-    protected function registerMigrations()
-    {
-        if (Cashier::$runsMigrations && $this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        }
     }
 
     /**

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,5 @@
+providers:
+  - Laravel\Cashier\CashierServiceProvider
+
+migrations:
+  - database/migrations

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -6,13 +6,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Tests\TestCase;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Stripe\ApiRequestor as StripeApiRequestor;
 use Stripe\HttpClient\CurlClient as StripeCurlClient;
 use Stripe\StripeClient;
 
 abstract class FeatureTestCase extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, WithLaravelMigrations;
 
     protected function setUp(): void
     {
@@ -25,11 +26,6 @@ abstract class FeatureTestCase extends TestCase
         $curl = new StripeCurlClient([CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1]);
         $curl->setEnableHttp2(false);
         StripeApiRequestor::setHttpClient($curl);
-    }
-
-    protected function defineDatabaseMigrations()
-    {
-        $this->loadLaravelMigrations();
     }
 
     protected static function stripe(array $options = []): StripeClient

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,14 @@ namespace Laravel\Cashier\Tests;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\CashierServiceProvider;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    use WithWorkbench;
+
     protected function getEnvironmentSetUp($app)
     {
         $apiKey = config('cashier.secret');
@@ -20,10 +22,5 @@ abstract class TestCase extends OrchestraTestCase
         }
 
         Cashier::useCustomerModel(User::class);
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return [CashierServiceProvider::class];
     }
 }


### PR DESCRIPTION
This pull request makes cashier stops using `loadMigrationsFrom` on the next major version. Laravel 11 support will be shipped after 15.x is out, as regular minor version.