### PR TITLE
[15.x] Stripe API and SDK update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/view": "^9.21|^10.0",
         "moneyphp/money": "^4.0",
         "nesbot/carbon": "^2.0",
-        "stripe/stripe-php": "^7.39|^8.0|^9.0|^10.0",
+        "stripe/stripe-php": "^13.0",
         "symfony/http-kernel": "^6.0",
         "symfony/polyfill-intl-icu": "^1.22.1"
     },

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -26,7 +26,7 @@ class Cashier
      *
      * @var string
      */
-    const STRIPE_VERSION = '2022-11-15';
+    const STRIPE_VERSION = '2023-10-16';
 
     /**
      * The base URL for the Stripe API.

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -160,10 +160,17 @@ trait ManagesInvoices
     {
         $this->assertCustomerExists();
 
+        $stripeCustomer = $this->asStripeCustomer();
+
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
             'customer' => $this->stripe_id,
+            'currency' => $stripeCustomer->currency ?? config('cashier.currency'),
         ], $options);
+
+        if (isset($parameters['subscription'])) {
+            unset($parameters['currency']);
+        }
 
         if (array_key_exists('subscription', $parameters)) {
             unset($parameters['pending_invoice_items_behavior']);

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -17,12 +17,11 @@ trait PerformsCharges
      * @param  int  $amount
      * @param  string  $paymentMethod
      * @param  array  $options
-     * @param  string|null  $returnUrl
      * @return \Laravel\Cashier\Payment
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      */
-    public function charge($amount, $paymentMethod, array $options = [], $returnUrl = null)
+    public function charge($amount, $paymentMethod, array $options = [])
     {
         $options = array_merge([
             'confirmation_method' => 'automatic',
@@ -31,7 +30,7 @@ trait PerformsCharges
 
         $options['payment_method'] = $paymentMethod;
 
-        $payment = $this->createPayment($amount, $options, $returnUrl);
+        $payment = $this->createPayment($amount, $options);
 
         $payment->validate();
 
@@ -43,16 +42,15 @@ trait PerformsCharges
      *
      * @param  int  $amount
      * @param  array  $options
-     * @param  string|null  $returnUrl
      * @return \Laravel\Cashier\Payment
      */
-    public function pay($amount, array $options = [], $returnUrl = null)
+    public function pay($amount, array $options = [])
     {
         $options['automatic_payment_methods'] = ['enabled' => true];
 
         unset($options['payment_method_types']);
 
-        return $this->createPayment($amount, $options, $returnUrl);
+        return $this->createPayment($amount, $options);
     }
 
     /**
@@ -61,16 +59,15 @@ trait PerformsCharges
      * @param  int  $amount
      * @param  array  $paymentMethods
      * @param  array  $options
-     * @param  string|null  $returnUrl
      * @return \Laravel\Cashier\Payment
      */
-    public function payWith($amount, array $paymentMethods, array $options = [], $returnUrl = null)
+    public function payWith($amount, array $paymentMethods, array $options = [])
     {
         $options['payment_method_types'] = $paymentMethods;
 
         unset($options['automatic_payment_methods']);
 
-        return $this->createPayment($amount, $options, $returnUrl);
+        return $this->createPayment($amount, $options);
     }
 
     /**
@@ -78,10 +75,9 @@ trait PerformsCharges
      *
      * @param  int  $amount
      * @param  array  $options
-     * @param  string|null  $returnUrl
      * @return \Laravel\Cashier\Payment
      */
-    public function createPayment($amount, array $options = [], $returnUrl = null)
+    public function createPayment($amount, array $options = [])
     {
         $options = array_merge([
             'currency' => $this->preferredCurrency(),
@@ -94,7 +90,7 @@ trait PerformsCharges
         }
 
         if ($options['confirm'] ?? false) {
-            $options['return_url'] ??= $returnUrl ?? url('/');
+            $options['return_url'] ??= route('home');
         }
 
         return new Payment(

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -528,9 +528,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function tab($description, $amount, array $options = [])
     {
-        $item = $this->owner()->tab($description, $amount, array_merge($options, [
-            'invoice' => $this->invoice->id,
-        ]));
+        $item = $this->owner()->tab($description, $amount, array_merge($options, ['invoice' => $this->invoice->id]));
 
         $this->refresh();
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -528,7 +528,9 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function tab($description, $amount, array $options = [])
     {
-        $item = $this->owner()->tab($description, $amount, array_merge($options, ['invoice' => $this->invoice->id]));
+        $item = $this->owner()->tab($description, $amount, array_merge($options, [
+            'invoice' => $this->invoice->id,
+        ]));
 
         $this->refresh();
 

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -12,7 +12,9 @@ class ChargesTest extends FeatureTestCase
         $user = $this->createCustomer('customer_can_be_charged');
         $user->createAsStripeCustomer();
 
-        $response = $user->charge(1000, 'pm_card_visa');
+        $response = $user->charge(1000, 'pm_card_visa', [
+            'return_url' => 'https://example.com/return',
+        ]);
 
         $this->assertInstanceOf(Payment::class, $response);
         $this->assertEquals(1000, $response->rawAmount());
@@ -23,7 +25,9 @@ class ChargesTest extends FeatureTestCase
     {
         $user = $this->createCustomer('non_stripe_customer_can_be_charged');
 
-        $response = $user->charge(1000, 'pm_card_visa');
+        $response = $user->charge(1000, 'pm_card_visa', [
+            'return_url' => 'https://example.com/return',
+        ]);
 
         $this->assertInstanceOf(Payment::class, $response);
         $this->assertEquals(1000, $response->rawAmount());
@@ -81,7 +85,9 @@ class ChargesTest extends FeatureTestCase
         $user->createAsStripeCustomer();
 
         try {
-            $user->charge(1000, 'pm_card_threeDSecure2Required');
+            $user->charge(1000, 'pm_card_threeDSecure2Required', [
+                'return_url' => 'https://example.com/return',
+            ]);
 
             $this->fail('Expected exception '.IncompletePayment::class.' was not thrown.');
         } catch (IncompletePayment $e) {


### PR DESCRIPTION
This updates the Stripe API to the most recent one `2023-10-16` as well as update the SDK version to v13 which is compatible with it.

I also decided to drop support for older SDK versions because v13 is the one that's compatible with this API version.

Closes #1556