### PR TITLE
[15.x] Fetch all payment methods

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -50,24 +50,24 @@ trait ManagesPaymentMethods
     }
 
     /**
-     * Determines if the customer currently has at least one payment method of the given type.
+     * Determines if the customer currently has at least one payment method of an optional type.
      *
-     * @param  string  $type
+     * @param  string|null  $type
      * @return bool
      */
-    public function hasPaymentMethod($type = 'card')
+    public function hasPaymentMethod($type = null)
     {
         return $this->paymentMethods($type)->isNotEmpty();
     }
 
     /**
-     * Get a collection of the customer's payment methods of the given type.
+     * Get a collection of the customer's payment methods of an optional type.
      *
-     * @param  string  $type
+     * @param  string|null  $type
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection|\Laravel\Cashier\PaymentMethod[]
      */
-    public function paymentMethods($type = 'card', $parameters = [])
+    public function paymentMethods($type = null, $parameters = [])
     {
         if (! $this->hasStripeId()) {
             return new Collection();
@@ -77,7 +77,7 @@ trait ManagesPaymentMethods
 
         // "type" is temporarily required by Stripe...
         $paymentMethods = static::stripe()->paymentMethods->all(
-            ['customer' => $this->stripe_id, 'type' => $type] + $parameters
+            array_filter(['customer' => $this->stripe_id, 'type' => $type]) + $parameters
         );
 
         return Collection::make($paymentMethods->data)->map(function ($paymentMethod) {
@@ -266,10 +266,10 @@ trait ManagesPaymentMethods
     /**
      * Deletes the customer's payment methods of the given type.
      *
-     * @param  string  $type
+     * @param  string|null  $type
      * @return void
      */
-    public function deletePaymentMethods($type = 'card')
+    public function deletePaymentMethods($type = null)
     {
         $this->paymentMethods($type)->each(function (PaymentMethod $paymentMethod) {
             $paymentMethod->delete();


### PR DESCRIPTION
Closed https://github.com/laravel/cashier-stripe/issues/1569

This PR changes the behaviour of the payment methods to fetch all payment method types, not just card ones. Previously, the Stripe API didn't allow you to do this and we were forced to always filter by a certain type so we chose "card" as a default as it's the most common one. But now we can offer a single way to fetch all payment methods for a customer in one go. This is useful for people to list these and not having to do multiple calls anymore to fetch each type separately.