### PR TITLE
Allow subscribed and other methods to check for any active subscription and not just one with the name "default"

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -24,11 +24,11 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model is on trial.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @param  string|null  $price
      * @return bool
      */
-    public function onTrial($name = 'default', $price = null)
+    public function onTrial($name = null, $price = null)
     {
         if (func_num_args() === 0 && $this->onGenericTrial()) {
             return true;
@@ -46,11 +46,11 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model's trial has ended.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @param  string|null  $price
      * @return bool
      */
-    public function hasExpiredTrial($name = 'default', $price = null)
+    public function hasExpiredTrial($name = null, $price = null)
     {
         if (func_num_args() === 0 && $this->hasExpiredGenericTrial()) {
             return true;
@@ -110,10 +110,10 @@ trait ManagesSubscriptions
     /**
      * Get the ending date of the trial.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Support\Carbon|null
      */
-    public function trialEndsAt($name = 'default')
+    public function trialEndsAt($name = null)
     {
         if (func_num_args() === 0 && $this->onGenericTrial()) {
             return $this->trial_ends_at;
@@ -129,11 +129,11 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model has a given subscription.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @param  string|null  $price
      * @return bool
      */
-    public function subscribed($name = 'default', $price = null)
+    public function subscribed($name = null, $price = null)
     {
         $subscription = $this->subscription($name);
 
@@ -147,12 +147,14 @@ trait ManagesSubscriptions
     /**
      * Get a subscription instance by name.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Laravel\Cashier\Subscription|null
      */
-    public function subscription($name = 'default')
+    public function subscription($name = null)
     {
-        return $this->subscriptions->where('name', $name)->first();
+        return $this->subscriptions->when($name, function ($query) use ($name) {
+            return $query->where('name', $name);
+        })->first();
     }
 
     /**
@@ -168,10 +170,10 @@ trait ManagesSubscriptions
     /**
      * Determine if the customer's subscription has an incomplete payment.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return bool
      */
-    public function hasIncompletePayment($name = 'default')
+    public function hasIncompletePayment($name = null)
     {
         if ($subscription = $this->subscription($name)) {
             return $subscription->hasIncompletePayment();
@@ -184,10 +186,10 @@ trait ManagesSubscriptions
      * Determine if the Stripe model is actively subscribed to one of the given products.
      *
      * @param  string|string[]  $products
-     * @param  string  $name
+     * @param  string|null  $name
      * @return bool
      */
-    public function subscribedToProduct($products, $name = 'default')
+    public function subscribedToProduct($products, $name = null)
     {
         $subscription = $this->subscription($name);
 
@@ -208,10 +210,10 @@ trait ManagesSubscriptions
      * Determine if the Stripe model is actively subscribed to one of the given prices.
      *
      * @param  string|string[]  $prices
-     * @param  string  $name
+     * @param  string|null  $name
      * @return bool
      */
-    public function subscribedToPrice($prices, $name = 'default')
+    public function subscribedToPrice($prices, $name = null)
     {
         $subscription = $this->subscription($name);
 


### PR DESCRIPTION

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently the code always expects a subscription called "default" when checking any of the subscribed, or on trial methods without passing an argument.

For my specific use case (and I do believe many others), we have a few products all with ids `prod_xxxx` with meaningful names like `Monthly Subscription`, and `Annual Subscription`, and we only want to know if a user is subscribed to any one of these by default (i.e to hide links to subscribe, and show subscription functionality) and don't want to do multiple if checks, checking if they are subscribed to one of our specific plans.

We have already solved this on our project, by simply copying the changes in this PR into the User model, to override the Cashier functions, but to me in 2023 it makes no sense to always assume it is titled `default`.

This should not break any existing implementations, unless they have multiple subscriptions, with one called `default`. In this case, the code may or may not return the right subscription with no arguments.
