### PR TITLE
[15.x] Change "name" column to "type"

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -30,7 +30,7 @@ class SubscriptionFactory extends Factory
 
         return [
             (new $model)->getForeignKey() => ($model)::factory(),
-            'name' => 'default',
+            'type' => 'default',
             'stripe_id' => 'sub_'.Str::random(40),
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id');
-            $table->string('name');
+            $table->string('type');
             $table->string('stripe_id')->unique();
             $table->string('stripe_status');
             $table->string('stripe_price')->nullable();

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -12,29 +12,29 @@ trait ManagesSubscriptions
     /**
      * Begin creating a new subscription.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @param  string|string[]  $prices
      * @return \Laravel\Cashier\SubscriptionBuilder
      */
-    public function newSubscription($name, $prices = [])
+    public function newSubscription($type, $prices = [])
     {
-        return new SubscriptionBuilder($this, $name, $prices);
+        return new SubscriptionBuilder($this, $type, $prices);
     }
 
     /**
      * Determine if the Stripe model is on trial.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @param  string|null  $price
      * @return bool
      */
-    public function onTrial($name = 'default', $price = null)
+    public function onTrial($type = 'default', $price = null)
     {
         if (func_num_args() === 0 && $this->onGenericTrial()) {
             return true;
         }
 
-        $subscription = $this->subscription($name);
+        $subscription = $this->subscription($type);
 
         if (! $subscription || ! $subscription->onTrial()) {
             return false;
@@ -46,17 +46,17 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model's trial has ended.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @param  string|null  $price
      * @return bool
      */
-    public function hasExpiredTrial($name = 'default', $price = null)
+    public function hasExpiredTrial($type = 'default', $price = null)
     {
         if (func_num_args() === 0 && $this->hasExpiredGenericTrial()) {
             return true;
         }
 
-        $subscription = $this->subscription($name);
+        $subscription = $this->subscription($type);
 
         if (! $subscription || ! $subscription->hasExpiredTrial()) {
             return false;
@@ -110,16 +110,16 @@ trait ManagesSubscriptions
     /**
      * Get the ending date of the trial.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @return \Illuminate\Support\Carbon|null
      */
-    public function trialEndsAt($name = 'default')
+    public function trialEndsAt($type = 'default')
     {
         if (func_num_args() === 0 && $this->onGenericTrial()) {
             return $this->trial_ends_at;
         }
 
-        if ($subscription = $this->subscription($name)) {
+        if ($subscription = $this->subscription($type)) {
             return $subscription->trial_ends_at;
         }
 
@@ -129,13 +129,13 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model has a given subscription.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @param  string|null  $price
      * @return bool
      */
-    public function subscribed($name = 'default', $price = null)
+    public function subscribed($type = 'default', $price = null)
     {
-        $subscription = $this->subscription($name);
+        $subscription = $this->subscription($type);
 
         if (! $subscription || ! $subscription->valid()) {
             return false;
@@ -145,14 +145,14 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Get a subscription instance by name.
+     * Get a subscription instance by $type.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @return \Laravel\Cashier\Subscription|null
      */
-    public function subscription($name = 'default')
+    public function subscription($type = 'default')
     {
-        return $this->subscriptions->where('name', $name)->first();
+        return $this->subscriptions->where('type', $type)->first();
     }
 
     /**
@@ -168,12 +168,12 @@ trait ManagesSubscriptions
     /**
      * Determine if the customer's subscription has an incomplete payment.
      *
-     * @param  string  $name
+     * @param  string  $type
      * @return bool
      */
-    public function hasIncompletePayment($name = 'default')
+    public function hasIncompletePayment($type = 'default')
     {
-        if ($subscription = $this->subscription($name)) {
+        if ($subscription = $this->subscription($type)) {
             return $subscription->hasIncompletePayment();
         }
 
@@ -184,12 +184,12 @@ trait ManagesSubscriptions
      * Determine if the Stripe model is actively subscribed to one of the given products.
      *
      * @param  string|string[]  $products
-     * @param  string  $name
+     * @param  string  $type
      * @return bool
      */
-    public function subscribedToProduct($products, $name = 'default')
+    public function subscribedToProduct($products, $type = 'default')
     {
-        $subscription = $this->subscription($name);
+        $subscription = $this->subscription($type);
 
         if (! $subscription || ! $subscription->valid()) {
             return false;
@@ -208,12 +208,12 @@ trait ManagesSubscriptions
      * Determine if the Stripe model is actively subscribed to one of the given prices.
      *
      * @param  string|string[]  $prices
-     * @param  string  $name
+     * @param  string  $type
      * @return bool
      */
-    public function subscribedToPrice($prices, $name = 'default')
+    public function subscribedToPrice($prices, $type = 'default')
     {
-        $subscription = $this->subscription($name);
+        $subscription = $this->subscription($type);
 
         if (! $subscription || ! $subscription->valid()) {
             return false;

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -89,10 +89,6 @@ trait PerformsCharges
             $options['customer'] = $this->stripe_id;
         }
 
-        if ($options['confirm'] ?? false) {
-            $options['return_url'] ??= route('home');
-        }
-
         return new Payment(
             static::stripe()->paymentIntents->create($options)
         );

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -81,7 +81,7 @@ class WebhookController extends Controller
                 $isSinglePrice = count($data['items']['data']) === 1;
 
                 $subscription = $user->subscriptions()->create([
-                    'name' => $data['metadata']['name'] ?? $this->newSubscriptionName($payload),
+                    'type' => $data['metadata']['type'] ?? $data['metadata']['name'] ?? $this->newSubscriptionType($payload),
                     'stripe_id' => $data['id'],
                     'stripe_status' => $data['status'],
                     'stripe_price' => $isSinglePrice ? $firstItem['price']['id'] : null,
@@ -105,12 +105,12 @@ class WebhookController extends Controller
     }
 
     /**
-     * Determines the name that should be used when new subscriptions are created from the Stripe dashboard.
+     * Determines the type that should be used when new subscriptions are created from the Stripe dashboard.
      *
      * @param  array  $payload
      * @return string
      */
-    protected function newSubscriptionName(array $payload)
+    protected function newSubscriptionType(array $payload)
     {
         return 'default';
     }
@@ -138,7 +138,7 @@ class WebhookController extends Controller
                 return;
             }
 
-            $subscription->name = $subscription->name ?? $data['metadata']['name'] ?? $this->newSubscriptionName($payload);
+            $subscription->type = $subscription->type ?? $data['metadata']['type'] ?? $data['metadata']['name'] ?? $this->newSubscriptionType($payload);
 
             $firstItem = $data['items']['data'][0];
             $isSinglePrice = count($data['items']['data']) === 1;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -33,11 +33,11 @@ class SubscriptionBuilder
     protected $owner;
 
     /**
-     * The name of the subscription.
+     * The type of the subscription.
      *
      * @var string
      */
-    protected $name;
+    protected $type;
 
     /**
      * The prices the customer is being subscribed to.
@@ -78,13 +78,13 @@ class SubscriptionBuilder
      * Create a new subscription builder instance.
      *
      * @param  mixed  $owner
-     * @param  string  $name
+     * @param  string  $type
      * @param  string|string[]|array[]  $prices
      * @return void
      */
-    public function __construct($owner, $name, $prices = [])
+    public function __construct($owner, $type, $prices = [])
     {
-        $this->name = $name;
+        $this->type = $type;
         $this->owner = $owner;
 
         foreach ((array) $prices as $price) {
@@ -304,7 +304,7 @@ class SubscriptionBuilder
 
         /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $this->owner->subscriptions()->create([
-            'name' => $this->name,
+            'type' => $this->type,
             'stripe_id' => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
@@ -357,7 +357,10 @@ class SubscriptionBuilder
             'subscription_data' => array_filter([
                 'default_tax_rates' => $this->getTaxRatesForPayload(),
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
-                'metadata' => array_merge($this->metadata, ['name' => $this->name]),
+                'metadata' => array_merge($this->metadata, [
+                    'name' => $this->type,
+                    'type' => $this->type,
+                ]),
             ]),
         ]);
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -759,7 +759,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         // Start with an incomplete subscription.
         $subscription = $user->subscriptions()->create([
-            'name' => 'yearly',
+            'type' => 'yearly',
             'stripe_id' => 'xxxx',
             'stripe_status' => StripeSubscription::STATUS_INCOMPLETE,
             'stripe_price' => 'stripe-yearly',
@@ -897,7 +897,7 @@ class SubscriptionsTest extends FeatureTestCase
         $user = $this->createCustomer('subscriptions_with_options_can_be_created');
 
         $subscription = $user->subscriptions()->create([
-            'name' => 'default',
+            'type' => 'default',
             'stripe_id' => 'sub_'.Str::random(10),
             'stripe_status' => 'active',
             'stripe_price' => 'price_xxx',
@@ -915,7 +915,7 @@ class SubscriptionsTest extends FeatureTestCase
         $subscription->markAsCanceled();
 
         $user->subscriptions()->create([
-            'name' => 'default',
+            'type' => 'default',
             'stripe_id' => 'sub_'.Str::random(10),
             'stripe_status' => 'active',
             'stripe_price' => 'price_xxx',

--- a/tests/Feature/SubscriptionsWithMultiplePricesTest.php
+++ b/tests/Feature/SubscriptionsWithMultiplePricesTest.php
@@ -329,7 +329,7 @@ class SubscriptionsWithMultiplePricesTest extends FeatureTestCase
     {
         /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $user->subscriptions()->create([
-            'name' => 'main',
+            'type' => 'main',
             'stripe_id' => 'sub_foo',
             'stripe_price' => self::$priceId,
             'quantity' => 1,

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -72,7 +72,7 @@ class WebhooksTest extends FeatureTestCase
         ])->assertOk();
 
         $this->assertDatabaseHas('subscriptions', [
-            'name' => 'default',
+            'type' => 'default',
             'user_id' => $user->id,
             'stripe_id' => 'sub_foo',
             'stripe_status' => 'active',
@@ -92,7 +92,7 @@ class WebhooksTest extends FeatureTestCase
         $user = $this->createCustomer('subscriptions_are_updated', ['stripe_id' => 'cus_foo']);
 
         $subscription = $user->subscriptions()->create([
-            'name' => 'main',
+            'type' => 'main',
             'stripe_id' => 'sub_foo',
             'stripe_price' => 'price_foo',
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
@@ -150,7 +150,7 @@ class WebhooksTest extends FeatureTestCase
         $cancelDate = Carbon::now()->addMonths(6);
 
         $subscription = $user->subscriptions()->create([
-            'name' => 'main',
+            'type' => 'main',
             'stripe_id' => 'sub_foo',
             'stripe_price' => 'price_foo',
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,


### PR DESCRIPTION
I know this PR is opinionated but hope it can be considered. Right now, we regularly get issues about people being confused about this column's actual usage. People seem to be using this column as user-readable representation of the subscription product ("Gym Subscription") rather than what it actual is: a single internal subscription type (`gym`).

I've already patched Cashier Paddle v2 with this change and would like to make the same one in Cashier Stripe. This will require a single DB migration on the user's end to rename the column.

I know we try to avoid breaking changes but I think this one will be beneficial as it more closely indicates this column's purpose.