### PR TITLE
[14.x] Update Subscription.php

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -290,7 +290,7 @@ class Subscription extends Model
      */
     public function canceled()
     {
-        return ! is_null($this->ends_at);
+        return ! is_null($this->ends_at) || $this->stripe_status == StripeSubscription::STATUS_CANCELED;
     }
 
     /**


### PR DESCRIPTION
When the Stripe customer's panel is configured to cancel immediately, the Webhook does not set the "ends_at" field, only the stripe_status is changed to "canceled". 

Therefore, the canceled() method returns false when in fact the subscription is canceled. With this change, the method also takes into account when the "stripe_status" field is canceled.

![image](https://github.com/laravel/cashier-stripe/assets/96078082/5fe11157-3de3-41ca-bc2b-977d7a1ec651)

![image](https://github.com/laravel/cashier-stripe/assets/96078082/e60e9981-bca5-4631-89fe-688c20a5b72e)


