### PR TITLE
[14.x] Use container to resolve `StripeClient`

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -125,11 +125,13 @@ class Cashier
      */
     public static function stripe(array $options = [])
     {
-        return new StripeClient(array_merge([
+        $config = array_merge([
             'api_key' => $options['api_key'] ?? config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
             'api_base' => static::$apiBaseUrl,
-        ], $options));
+        ], $options);
+
+        return app(StripeClient::class, ['config' => $config]);
     }
 
     /**


### PR DESCRIPTION
This PR uses the Laravel container to resolve `StripeClient` instead of initializing it in the Cashier class.

In complex test scenarios, this would allow us to mock the StripeClient instead of sending actual requests to Stripe and make those test cases focus only on actual business logic.