### PR TITLE
[15.x] Clarify ignoreMigrations method removal in upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -56,6 +56,8 @@ Cashier 15.0 no longer automatically loads migrations from its own migrations di
 php artisan vendor:publish --tag=cashier-migrations
 ```
 
+Subsequently, the `Cashier::ignoreMigrations()` call has been removed and you should remove it from your service provider if you've added it.
+
 ### Renamed "Name" Column To "Type"
 
 PR: https://github.com/laravel/cashier-stripe/pull/1620

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -56,7 +56,7 @@ Cashier 15.0 no longer automatically loads migrations from its own migrations di
 php artisan vendor:publish --tag=cashier-migrations
 ```
 
-Subsequently, the `Cashier::ignoreMigrations()` call has been removed and you should remove it from your service provider if you've added it.
+Because of this change, the `Cashier::ignoreMigrations` method has been removed.
 
 ### Renamed "Name" Column To "Type"
 


### PR DESCRIPTION
Better if we explicitly mention this. See https://github.com/laravel/framework/issues/49477