### PR TITLE
[15.x] Clear the generic trial upon subscription creation

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -99,6 +99,11 @@ class WebhookController extends Controller
                     ]);
                 }
             }
+
+            // Terminate the billable's generic trial if it exists...
+            if (! is_null($user->trial_ends_at)) {
+                $user->update(['trial_ends_at' => null]);
+            }
         }
 
         return $this->successMethod();


### PR DESCRIPTION
These code changes will make sure a billable's generic trial is cleared when they start their subscription. As soon as a customer starts their subscription there's no need for the trial to continue since they have started paying. We also already do this in Spark Stripe.