### PR TITLE
fix(checkout): Unset 'return_url' for embedded UI without redirection

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -97,6 +97,11 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
         // Remove success and cancel URLs if "ui_mode" is "embedded"...
         if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
+
+            // Remove return URL for embedded UI mode when no redirection is desired on completion...
+            if(isset($data['redirect_on_completion']) && $data['redirect_on_completion'] === 'never') {
+                unset($data['return_url']);
+            }
         } else {
             $data['success_url'] = $sessionOptions['success_url'] ?? route('home').'?checkout=success';
             $data['cancel_url'] = $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled';

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -169,4 +169,27 @@ class CheckoutTest extends FeatureTestCase
 
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
+
+
+    public function test_customers_can_start_an_embedded_product_checkout_session_without_a_redirect()
+    {
+        $user = $this->createCustomer('customers_can_start_an_embedded_product_checkout_session');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $items = [$shirtPrice->id => 5];
+
+        $checkout = $user->checkout($items, [
+            'ui_mode' => 'embedded',
+            'redirect_on_completion' => 'never',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
 }


### PR DESCRIPTION
This commit resolves an issue with the handling of 'return_url' in the checkout process. When the UI mode is 'embedded' and 'redirect_on_completion' is set to 'never', 'return_url' is now consistently unset. This change prevents errors related to passing an empty 'return_url' and ensures compatibility with scenarios where no redirection is intended upon completion.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
