### PR TITLE
[15.x] Fix unset 'return_url' for embedded UI without redirection

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -99,7 +99,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
 
             // Remove return URL for embedded UI mode when no redirection is desired on completion...
-            if(isset($data['redirect_on_completion']) && $data['redirect_on_completion'] === 'never') {
+            if (isset($data['redirect_on_completion']) && $data['redirect_on_completion'] === 'never') {
                 unset($data['return_url']);
             }
         } else {

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -97,6 +97,11 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
         // Remove success and cancel URLs if "ui_mode" is "embedded"...
         if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
+
+            // Remove return URL for embedded UI mode when no redirection is desired on completion...
+            if(isset($data['redirect_on_completion']) && $data['redirect_on_completion'] === 'never') {
+                unset($data['return_url']);
+            }
         } else {
             $data['success_url'] = $sessionOptions['success_url'] ?? route('home').'?checkout=success';
             $data['cancel_url'] = $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled';

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -169,4 +169,26 @@ class CheckoutTest extends FeatureTestCase
 
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
+
+    public function test_customers_can_start_an_embedded_product_checkout_session_without_a_redirect()
+    {
+        $user = $this->createCustomer('customers_can_start_an_embedded_product_checkout_session');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $items = [$shirtPrice->id => 5];
+
+        $checkout = $user->checkout($items, [
+            'ui_mode' => 'embedded',
+            'redirect_on_completion' => 'never',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
 }


### PR DESCRIPTION
Adjusts the checkout logic to unset 'return_url' when the UI is in 'embedded' mode and the 'redirect_on_completion' option is set to 'never'. This change addresses API constraints and prevents errors associated with empty 'return_url' values in no-redirect scenarios.

Fixes #1629 


