### PR TITLE
Allow setting the proration_date

### DIFF
--- a/src/Concerns/ProratesDate.php
+++ b/src/Concerns/ProratesDate.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+trait ProratesDate
+{
+    /**
+     * Indicates when the price change should be prorated.
+     */
+    protected ?int $prorationDate = null;
+
+    /**
+     * Indicate that date for proration.
+     */
+    public function prorateDate(\DateTimeInterface|int $date = null): static
+    {
+        $this->prorationDate = $date instanceof \DateTimeInterface ? $date->getTimestamp() : $date;
+
+        return $this;
+    }
+}

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Concerns\HandlesPaymentFailures;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
+use Laravel\Cashier\Concerns\ProratesDate;
 use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
 
 /**
@@ -20,6 +21,7 @@ class SubscriptionItem extends Model
     use HasFactory;
     use InteractsWithPaymentBehavior;
     use Prorates;
+    use ProratesDate;
 
     /**
      * The attributes that are not mass assignable.
@@ -109,11 +111,12 @@ class SubscriptionItem extends Model
     {
         $this->subscription->guardAgainstIncomplete();
 
-        $stripeSubscriptionItem = $this->updateStripeSubscriptionItem([
+        $stripeSubscriptionItem = $this->updateStripeSubscriptionItem(array_filter([
             'payment_behavior' => $this->paymentBehavior(),
             'proration_behavior' => $this->prorateBehavior(),
+            'proration_date' => $this->prorationDate,
             'quantity' => $quantity,
-        ]);
+        ]));
 
         $this->fill([
             'quantity' => $stripeSubscriptionItem->quantity,
@@ -155,6 +158,7 @@ class SubscriptionItem extends Model
                 'quantity' => $this->quantity,
                 'payment_behavior' => $this->paymentBehavior(),
                 'proration_behavior' => $this->prorateBehavior(),
+                'proration_date' => $this->prorationDate,
                 'tax_rates' => $this->subscription->getPriceTaxRatesForPayload($price),
             ], function ($value) {
                 return ! is_null($value);


### PR DESCRIPTION
This is a different solution for #1637 that doesn't change method signatures.

This makes it easy to prorate monthly on a yearly price or any number of other splits you would like to make.
