### PR TITLE
[15.x] Fix payment behavior not being passed

### DIFF
--- a/src/Concerns/InteractsWithPaymentBehavior.php
+++ b/src/Concerns/InteractsWithPaymentBehavior.php
@@ -70,4 +70,17 @@ trait InteractsWithPaymentBehavior
     {
         return $this->paymentBehavior;
     }
+
+    /**
+     * Set the payment behavior for any subscription updates.
+     *
+     * @param  string  $paymentBehavior
+     * @return $this
+     */
+    public function setPaymentBehavior($paymentBehavior)
+    {
+        $this->paymentBehavior = $paymentBehavior;
+
+        return $this;
+    }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -435,7 +435,10 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($price) {
-            $this->findItemOrFail($price)->setProrationBehavior($this->prorationBehavior)->incrementQuantity($count);
+            $this->findItemOrFail($price)
+                ->setPaymentBehavior($this->paymentBehavior)
+                ->setProrationBehavior($this->prorationBehavior)
+                ->incrementQuantity($count);
 
             return $this->refresh();
         }
@@ -478,7 +481,10 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($price) {
-            $this->findItemOrFail($price)->setProrationBehavior($this->prorationBehavior)->decrementQuantity($count);
+            $this->findItemOrFail($price)
+                ->setPaymentBehavior($this->paymentBehavior)
+                ->setProrationBehavior($this->prorationBehavior)
+                ->decrementQuantity($count);
 
             return $this->refresh();
         }
@@ -502,7 +508,10 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($price) {
-            $this->findItemOrFail($price)->setProrationBehavior($this->prorationBehavior)->updateQuantity($quantity);
+            $this->findItemOrFail($price)
+                ->setPaymentBehavior($this->paymentBehavior)
+                ->setProrationBehavior($this->prorationBehavior)
+                ->updateQuantity($quantity);
 
             return $this->refresh();
         }


### PR DESCRIPTION
This fix makes sure that the requested payment_behavior is passed from Subscription to SubscriptionItem if the update is passed.

This is a fix for #1646