### PR TITLE
Allow configuring names for the `stripe_id` column on Cashier models.

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -31,7 +31,7 @@ class SubscriptionFactory extends Factory
         return [
             (new $model)->getForeignKey() => ($model)::factory(),
             'type' => 'default',
-            'stripe_id' => 'sub_'.Str::random(40),
+            $this->model::$stripeIdColumn => 'sub_'.Str::random(40),
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,
             'quantity' => null,

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -31,7 +31,7 @@ class SubscriptionFactory extends Factory
         return [
             (new $model)->getForeignKey() => ($model)::factory(),
             'type' => 'default',
-            $this->model::$stripeIdColumn => 'sub_'.Str::random(40),
+            $this->model::stripeIdColumn() => 'sub_'.Str::random(40),
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,
             'quantity' => null,

--- a/database/factories/SubscriptionItemFactory.php
+++ b/database/factories/SubscriptionItemFactory.php
@@ -25,7 +25,7 @@ class SubscriptionItemFactory extends Factory
     {
         return [
             'subscription_id' => Subscription::factory(),
-            $this->model::$stripeIdColumn => 'si_'.Str::random(40),
+            $this->model::stripeIdColumn() => 'si_'.Str::random(40),
             'stripe_product' => 'prod_'.Str::random(40),
             'stripe_price' => 'price_'.Str::random(40),
             'quantity' => null,

--- a/database/factories/SubscriptionItemFactory.php
+++ b/database/factories/SubscriptionItemFactory.php
@@ -25,7 +25,7 @@ class SubscriptionItemFactory extends Factory
     {
         return [
             'subscription_id' => Subscription::factory(),
-            'stripe_id' => 'si_'.Str::random(40),
+            $this->model::$stripeIdColumn => 'si_'.Str::random(40),
             'stripe_product' => 'prod_'.Str::random(40),
             'stripe_price' => 'price_'.Str::random(40),
             'quantity' => null,

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier;
 
 use Laravel\Cashier\Concerns\HandlesTaxes;
+use Laravel\Cashier\Concerns\HasStripeId;
 use Laravel\Cashier\Concerns\ManagesCustomer;
 use Laravel\Cashier\Concerns\ManagesInvoices;
 use Laravel\Cashier\Concerns\ManagesPaymentMethods;
@@ -12,6 +13,7 @@ use Laravel\Cashier\Concerns\PerformsCharges;
 trait Billable
 {
     use HandlesTaxes;
+    use HasStripeId;
     use ManagesCustomer;
     use ManagesInvoices;
     use ManagesPaymentMethods;

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -107,7 +107,7 @@ class Cashier
             ? $model::withTrashed()
             : new $model;
 
-        return $stripeId ? $builder->where($model::$stripeIdColumn, $stripeId)->first() : null;
+        return $stripeId ? $builder->where($model::stripeIdColumn(), $stripeId)->first() : null;
     }
 
     /**

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -107,7 +107,7 @@ class Cashier
             ? $model::withTrashed()
             : new $model;
 
-        return $stripeId ? $builder->where('stripe_id', $stripeId)->first() : null;
+        return $stripeId ? $builder->where($model::$stripeIdColumn, $stripeId)->first() : null;
     }
 
     /**

--- a/src/Concerns/HasStripeId.php
+++ b/src/Concerns/HasStripeId.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+trait HasStripeId
+{
+
+    /**
+     * The name of the model's "stripe_id" column.
+     *
+     * @var string
+     */
+    public static string $stripeIdColumn = 'stripe_id';
+
+    /**
+     * Get the Stripe ID for the model.
+     *
+     * @return null|string
+     */
+    public function stripeId()
+    {
+        return $this->{static::$stripeIdColumn};
+    }
+
+}

--- a/src/Concerns/HasStripeId.php
+++ b/src/Concerns/HasStripeId.php
@@ -5,11 +5,14 @@ namespace Laravel\Cashier\Concerns;
 trait HasStripeId
 {
     /**
-     * The name of the model's "stripe_id" column.
+     * Get the name of the model's "stripe_id" column.
      *
-     * @var string
+     * @return  string
      */
-    public static string $stripeIdColumn = 'stripe_id';
+    public static function stripeIdColumn()
+    {
+        return 'stripe_id';
+    }
 
     /**
      * Get the Stripe ID for the model.
@@ -18,6 +21,6 @@ trait HasStripeId
      */
     public function stripeId()
     {
-        return $this->{static::$stripeIdColumn};
+        return $this->{static::stripeIdColumn()};
     }
 }

--- a/src/Concerns/HasStripeId.php
+++ b/src/Concerns/HasStripeId.php
@@ -7,7 +7,7 @@ trait HasStripeId
     /**
      * Get the name of the model's "stripe_id" column.
      *
-     * @return  string
+     * @return string
      */
     public static function stripeIdColumn()
     {

--- a/src/Concerns/HasStripeId.php
+++ b/src/Concerns/HasStripeId.php
@@ -4,7 +4,6 @@ namespace Laravel\Cashier\Concerns;
 
 trait HasStripeId
 {
-
     /**
      * The name of the model's "stripe_id" column.
      *
@@ -21,5 +20,4 @@ trait HasStripeId
     {
         return $this->{static::$stripeIdColumn};
     }
-
 }

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -82,7 +82,7 @@ trait ManagesCustomer
         // and allow us to retrieve users from Stripe later when we need to work.
         $customer = static::stripe()->customers->create($options);
 
-        $this->{$this::$stripeIdColumn} = $customer->id;
+        $this->{$this::stripeIdColumn()} = $customer->id;
 
         $this->save();
 

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -35,7 +35,7 @@ trait ManagesInvoices
         $this->assertCustomerExists();
 
         $options = array_merge([
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
             'currency' => $this->preferredCurrency(),
             'description' => $description,
         ], $options);
@@ -85,7 +85,7 @@ trait ManagesInvoices
         $this->assertCustomerExists();
 
         $options = array_merge([
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
             'price' => $price,
             'quantity' => $quantity,
         ], $options);
@@ -164,7 +164,7 @@ trait ManagesInvoices
 
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
             'currency' => $stripeCustomer->currency ?? config('cashier.currency'),
         ], $options);
 
@@ -195,7 +195,7 @@ trait ManagesInvoices
 
         $parameters = array_merge([
             'automatic_tax' => $this->automaticTaxPayload(),
-            'customer' => $this->stripe_id,
+            'customer' => $this->stripeId(),
         ], $options);
 
         try {
@@ -283,7 +283,7 @@ trait ManagesInvoices
         $parameters = array_merge(['limit' => 24], $parameters);
 
         $stripeInvoices = static::stripe()->invoices->all(
-            ['customer' => $this->stripe_id] + $parameters
+            ['customer' => $this->stripeId()] + $parameters
         );
 
         // Here we will loop through the Stripe invoices and create our own custom Invoice

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -20,7 +20,7 @@ trait ManagesPaymentMethods
     public function createSetupIntent(array $options = [])
     {
         if ($this->hasStripeId()) {
-            $options['customer'] = $this->stripe_id;
+            $options['customer'] = $this->stripeId();
         }
 
         return static::stripe()->setupIntents->create($options);
@@ -77,7 +77,7 @@ trait ManagesPaymentMethods
 
         // "type" is temporarily required by Stripe...
         $paymentMethods = static::stripe()->paymentMethods->all(
-            array_filter(['customer' => $this->stripe_id, 'type' => $type]) + $parameters
+            array_filter(['customer' => $this->stripeId(), 'type' => $type]) + $parameters
         );
 
         return Collection::make($paymentMethods->data)->map(function ($paymentMethod) {
@@ -97,9 +97,9 @@ trait ManagesPaymentMethods
 
         $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
 
-        if ($stripePaymentMethod->customer !== $this->stripe_id) {
+        if ($stripePaymentMethod->customer !== $this->stripeId()) {
             $stripePaymentMethod = $stripePaymentMethod->attach(
-                ['customer' => $this->stripe_id]
+                ['customer' => $this->stripeId()]
             );
         }
 
@@ -118,7 +118,7 @@ trait ManagesPaymentMethods
 
         $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
 
-        if ($stripePaymentMethod->customer !== $this->stripe_id) {
+        if ($stripePaymentMethod->customer !== $this->stripeId()) {
             return;
         }
 

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -86,7 +86,7 @@ trait PerformsCharges
         $options['amount'] = $amount;
 
         if ($this->hasStripeId()) {
-            $options['customer'] = $this->stripe_id;
+            $options['customer'] = $this->stripeId();
         }
 
         return new Payment(

--- a/src/CustomerBalanceTransaction.php
+++ b/src/CustomerBalanceTransaction.php
@@ -32,7 +32,7 @@ class CustomerBalanceTransaction
      */
     public function __construct($owner, StripeCustomerBalanceTransaction $transaction)
     {
-        if ($owner->stripe_id !== $transaction->customer) {
+        if ($owner->stripeId() !== $transaction->customer) {
             throw InvalidCustomerBalanceTransaction::invalidOwner($transaction, $owner);
         }
 

--- a/src/Exceptions/CustomerAlreadyCreated.php
+++ b/src/Exceptions/CustomerAlreadyCreated.php
@@ -14,6 +14,6 @@ class CustomerAlreadyCreated extends Exception
      */
     public static function exists($owner)
     {
-        return new static(class_basename($owner)." is already a Stripe customer with ID {$owner->stripe_id}.");
+        return new static(class_basename($owner)." is already a Stripe customer with ID {$owner->stripeId()}.");
     }
 }

--- a/src/Exceptions/InvalidCustomerBalanceTransaction.php
+++ b/src/Exceptions/InvalidCustomerBalanceTransaction.php
@@ -16,6 +16,6 @@ class InvalidCustomerBalanceTransaction extends Exception
      */
     public static function invalidOwner(StripeCustomerBalanceTransaction $transaction, $owner)
     {
-        return new static("The transaction `{$transaction->id}` does not belong to customer `$owner->stripe_id`.");
+        return new static("The transaction `{$transaction->id}` does not belong to customer `{$owner->stripeId()}`.");
     }
 }

--- a/src/Exceptions/InvalidInvoice.php
+++ b/src/Exceptions/InvalidInvoice.php
@@ -16,6 +16,6 @@ class InvalidInvoice extends Exception
      */
     public static function invalidOwner(StripeInvoice $invoice, $owner)
     {
-        return new static("The invoice `{$invoice->id}` does not belong to this customer `$owner->stripe_id`.");
+        return new static("The invoice `{$invoice->id}` does not belong to this customer `{$owner->stripeId()}`.");
     }
 }

--- a/src/Exceptions/InvalidPaymentMethod.php
+++ b/src/Exceptions/InvalidPaymentMethod.php
@@ -17,7 +17,7 @@ class InvalidPaymentMethod extends Exception
     public static function invalidOwner(StripePaymentMethod $paymentMethod, $owner)
     {
         return new static(
-            "The payment method `{$paymentMethod->id}`'s customer `{$paymentMethod->customer}` does not belong to this customer `$owner->stripe_id`."
+            "The payment method `{$paymentMethod->id}`'s customer `{$paymentMethod->customer}` does not belong to this customer `{$owner->stripeId()}`."
         );
     }
 }

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -16,7 +16,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function incompleteSubscription(Subscription $subscription)
     {
         return new static(
-            "The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete."
+            "The subscription \"{$subscription->stripeId()}\" cannot be updated because its payment is incomplete."
         );
     }
 
@@ -30,7 +30,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function duplicatePrice(Subscription $subscription, $price)
     {
         return new static(
-            "The price \"$price\" is already attached to subscription \"{$subscription->stripe_id}\"."
+            "The price \"$price\" is already attached to subscription \"{$subscription->stripeId()}\"."
         );
     }
 
@@ -43,7 +43,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function cannotDeleteLastPrice(Subscription $subscription)
     {
         return new static(
-            "The price on subscription \"{$subscription->stripe_id}\" cannot be removed because it is the last one."
+            "The price on subscription \"{$subscription->stripeId()}\" cannot be removed because it is the last one."
         );
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -70,7 +70,7 @@ class WebhookController extends Controller
         if ($user) {
             $data = $payload['data']['object'];
 
-            if (! $user->subscriptions->contains(Cashier::$subscriptionModel::$stripeIdColumn, $data['id'])) {
+            if (! $user->subscriptions->contains(Cashier::$subscriptionModel::stripeIdColumn(), $data['id'])) {
                 if (isset($data['trial_end'])) {
                     $trialEndsAt = Carbon::createFromTimestamp($data['trial_end']);
                 } else {
@@ -82,7 +82,7 @@ class WebhookController extends Controller
 
                 $subscription = $user->subscriptions()->create([
                     'type' => $data['metadata']['type'] ?? $data['metadata']['name'] ?? $this->newSubscriptionType($payload),
-                    Cashier::$subscriptionModel::$stripeIdColumn => $data['id'],
+                    Cashier::$subscriptionModel::stripeIdColumn() => $data['id'],
                     'stripe_status' => $data['status'],
                     'stripe_price' => $isSinglePrice ? $firstItem['price']['id'] : null,
                     'quantity' => $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null,
@@ -92,7 +92,7 @@ class WebhookController extends Controller
 
                 foreach ($data['items']['data'] as $item) {
                     $subscription->items()->create([
-                        Cashier::$subscriptionItemModel::$stripeIdColumn => $item['id'],
+                        Cashier::$subscriptionItemModel::stripeIdColumn() => $item['id'],
                         'stripe_product' => $item['price']['product'],
                         'stripe_price' => $item['price']['id'],
                         'quantity' => $item['quantity'] ?? null,
@@ -131,7 +131,7 @@ class WebhookController extends Controller
         if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
             $data = $payload['data']['object'];
 
-            $subscription = $user->subscriptions()->firstOrNew([Cashier::$subscriptionModel::$stripeIdColumn => $data['id']]);
+            $subscription = $user->subscriptions()->firstOrNew([Cashier::$subscriptionModel::stripeIdColumn() => $data['id']]);
 
             if (
                 isset($data['status']) &&
@@ -189,7 +189,7 @@ class WebhookController extends Controller
                     $subscriptionItemIds[] = $item['id'];
 
                     $subscription->items()->updateOrCreate([
-                        Cashier::$subscriptionItemModel::$stripeIdColumn => $item['id'],
+                        Cashier::$subscriptionItemModel::stripeIdColumn() => $item['id'],
                     ], [
                         'stripe_product' => $item['price']['product'],
                         'stripe_price' => $item['price']['id'],
@@ -198,7 +198,7 @@ class WebhookController extends Controller
                 }
 
                 // Delete items that aren't attached to the subscription anymore...
-                $subscription->items()->whereNotIn(Cashier::$subscriptionItemModel::$stripeIdColumn, $subscriptionItemIds)->delete();
+                $subscription->items()->whereNotIn(Cashier::$subscriptionItemModel::stripeIdColumn(), $subscriptionItemIds)->delete();
             }
         }
 
@@ -253,7 +253,7 @@ class WebhookController extends Controller
             });
 
             $user->forceFill([
-                $user::$stripeIdColumn => null,
+                $user::stripeIdColumn() => null,
                 'trial_ends_at' => null,
                 'pm_type' => null,
                 'pm_last_four' => null,

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -78,7 +78,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     public function __construct($owner, StripeInvoice $invoice, array $refreshData = [])
     {
-        if ($owner->stripe_id !== $invoice->customer) {
+        if ($owner->stripeId() !== $invoice->customer) {
             throw InvalidInvoice::invalidOwner($invoice, $owner);
         }
 
@@ -590,7 +590,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
         } else {
             // If no invoice ID is present then assume this is the customer's upcoming invoice...
             $this->invoice = $this->owner->stripe()->invoices->upcoming(array_merge($this->refreshData, [
-                'customer' => $this->owner->stripe_id,
+                'customer' => $this->owner->stripeId(),
                 'expand' => $expand,
             ]));
         }

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -40,7 +40,7 @@ class PaymentMethod implements Arrayable, Jsonable, JsonSerializable
             throw new LogicException('The payment method is not attached to a customer.');
         }
 
-        if ($owner->stripe_id !== $paymentMethod->customer) {
+        if ($owner->stripeId() !== $paymentMethod->customer) {
             throw InvalidPaymentMethod::invalidOwner($paymentMethod, $owner);
         }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -716,7 +716,7 @@ class Subscription extends Model
             $subscriptionItemIds[] = $item->id;
 
             $this->items()->updateOrCreate([
-                Cashier::$subscriptionItemModel::$stripeIdColumn => $item->id,
+                Cashier::$subscriptionItemModel::stripeIdColumn() => $item->id,
             ], [
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
@@ -725,7 +725,7 @@ class Subscription extends Model
         }
 
         // Delete items that aren't attached to the subscription anymore...
-        $this->items()->whereNotIn(Cashier::$subscriptionItemModel::$stripeIdColumn, $subscriptionItemIds)->delete();
+        $this->items()->whereNotIn(Cashier::$subscriptionItemModel::stripeIdColumn(), $subscriptionItemIds)->delete();
 
         $this->unsetRelation('items');
 
@@ -871,7 +871,7 @@ class Subscription extends Model
             ], $options)));
 
         $this->items()->create([
-            Cashier::$subscriptionItemModel::$stripeIdColumn => $stripeSubscriptionItem->id,
+            Cashier::$subscriptionItemModel::stripeIdColumn() => $stripeSubscriptionItem->id,
             'stripe_product' => $stripeSubscriptionItem->price->product,
             'stripe_price' => $stripeSubscriptionItem->price->id,
             'quantity' => $stripeSubscriptionItem->quantity ?? null,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -294,7 +294,7 @@ class SubscriptionBuilder
      */
     protected function createSubscription(StripeSubscription $stripeSubscription)
     {
-        if ($subscription = $this->owner->subscriptions()->where(Cashier::$subscriptionModel::$stripeIdColumn, $stripeSubscription->id)->first()) {
+        if ($subscription = $this->owner->subscriptions()->where(Cashier::$subscriptionModel::stripeIdColumn(), $stripeSubscription->id)->first()) {
             return $subscription;
         }
 
@@ -305,7 +305,7 @@ class SubscriptionBuilder
         /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $this->owner->subscriptions()->create([
             'type' => $this->type,
-            Cashier::$subscriptionModel::$stripeIdColumn => $stripeSubscription->id,
+            Cashier::$subscriptionModel::stripeIdColumn() => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
             'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
@@ -316,7 +316,7 @@ class SubscriptionBuilder
         /** @var \Stripe\SubscriptionItem $item */
         foreach ($stripeSubscription->items as $item) {
             $subscription->items()->create([
-                Cashier::$subscriptionItemModel::$stripeIdColumn => $item->id,
+                Cashier::$subscriptionItemModel::stripeIdColumn() => $item->id,
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity ?? null,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -294,7 +294,7 @@ class SubscriptionBuilder
      */
     protected function createSubscription(StripeSubscription $stripeSubscription)
     {
-        if ($subscription = $this->owner->subscriptions()->where('stripe_id', $stripeSubscription->id)->first()) {
+        if ($subscription = $this->owner->subscriptions()->where(Cashier::$subscriptionModel::$stripeIdColumn, $stripeSubscription->id)->first()) {
             return $subscription;
         }
 
@@ -305,7 +305,7 @@ class SubscriptionBuilder
         /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $this->owner->subscriptions()->create([
             'type' => $this->type,
-            'stripe_id' => $stripeSubscription->id,
+            Cashier::$subscriptionModel::$stripeIdColumn => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
             'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
@@ -316,7 +316,7 @@ class SubscriptionBuilder
         /** @var \Stripe\SubscriptionItem $item */
         foreach ($stripeSubscription->items as $item) {
             $subscription->items()->create([
-                'stripe_id' => $item->id,
+                Cashier::$subscriptionItemModel::$stripeIdColumn => $item->id,
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity ?? null,

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Laravel\Cashier\Concerns\HandlesPaymentFailures;
+use Laravel\Cashier\Concerns\HasStripeId;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionItemFactory;
@@ -18,6 +19,7 @@ class SubscriptionItem extends Model
 {
     use HandlesPaymentFailures;
     use HasFactory;
+    use HasStripeId;
     use InteractsWithPaymentBehavior;
     use Prorates;
 
@@ -213,7 +215,7 @@ class SubscriptionItem extends Model
     {
         $timestamp = $timestamp instanceof DateTimeInterface ? $timestamp->getTimestamp() : $timestamp;
 
-        return $this->subscription->owner->stripe()->subscriptionItems->createUsageRecord($this->stripe_id, [
+        return $this->subscription->owner->stripe()->subscriptionItems->createUsageRecord($this->stripeId(), [
             'quantity' => $quantity,
             'action' => $timestamp ? 'set' : 'increment',
             'timestamp' => $timestamp ?? time(),
@@ -229,7 +231,7 @@ class SubscriptionItem extends Model
     public function usageRecords($options = [])
     {
         return new Collection($this->subscription->owner->stripe()->subscriptionItems->allUsageRecordSummaries(
-            $this->stripe_id, $options
+            $this->stripeId(), $options
         )->data);
     }
 
@@ -242,7 +244,7 @@ class SubscriptionItem extends Model
     public function updateStripeSubscriptionItem(array $options = [])
     {
         return $this->subscription->owner->stripe()->subscriptionItems->update(
-            $this->stripe_id, $options
+            $this->stripeId(), $options
         );
     }
 
@@ -255,7 +257,7 @@ class SubscriptionItem extends Model
     public function asStripeSubscriptionItem(array $expand = [])
     {
         return $this->subscription->owner->stripe()->subscriptionItems->retrieve(
-            $this->stripe_id, ['expand' => $expand]
+            $this->stripeId(), ['expand' => $expand]
         );
     }
 

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -18,7 +18,7 @@ class ChargesTest extends FeatureTestCase
 
         $this->assertInstanceOf(Payment::class, $response);
         $this->assertEquals(1000, $response->rawAmount());
-        $this->assertEquals($user->stripe_id, $response->customer);
+        $this->assertEquals($user->stripeId(), $response->customer);
     }
 
     public function test_non_stripe_customer_can_be_charged()
@@ -43,7 +43,7 @@ class ChargesTest extends FeatureTestCase
 
         $this->assertInstanceOf(Payment::class, $response);
         $this->assertEquals(1000, $response->rawAmount());
-        $this->assertEquals($user->stripe_id, $response->customer);
+        $this->assertEquals($user->stripeId(), $response->customer);
         $this->assertTrue($response->requiresPaymentMethod());
         $this->assertTrue($response->automatic_payment_methods->enabled);
 

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -113,7 +113,7 @@ class InvoicesTest extends FeatureTestCase
 
         $this->expectException(InvalidInvoice::class);
         $this->expectExceptionMessage(
-            "The invoice `{$invoice->id}` does not belong to this customer `$otherUser->stripe_id`."
+            "The invoice `{$invoice->id}` does not belong to this customer `{$otherUser->stripeId()}`."
         );
 
         $otherUser->findInvoice($invoice->id);

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -117,7 +117,7 @@ class SubscriptionsTest extends FeatureTestCase
             ->create('pm_card_visa');
 
         $this->assertEquals(1, count($user->subscriptions));
-        $this->assertNotNull(($subscription = $user->subscription('main'))->stripe_id);
+        $this->assertNotNull(($subscription = $user->subscription('main'))->stripeId());
         $this->assertSame($metadata, $subscription->asStripeSubscription()->metadata->toArray());
 
         $this->assertTrue($user->subscribed('main'));

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -110,7 +110,7 @@ class WebhooksTest extends FeatureTestCase
             'type' => 'customer.subscription.updated',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripe_id,
+                    'id' => $subscription->stripeId(),
                     'customer' => 'cus_foo',
                     'cancel_at_period_end' => false,
                     'items' => [
@@ -168,7 +168,7 @@ class WebhooksTest extends FeatureTestCase
             'type' => 'customer.subscription.updated',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripe_id,
+                    'id' => $subscription->stripeId(),
                     'customer' => 'cus_foo',
                     'cancel_at' => $cancelDate->timestamp,
                     'cancel_at_period_end' => false,
@@ -216,12 +216,12 @@ class WebhooksTest extends FeatureTestCase
             'type' => 'customer.subscription.updated',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripe_id,
-                    'customer' => $user->stripe_id,
+                    'id' => $subscription->stripeId(),
+                    'customer' => $user->stripeId(),
                     'cancel_at_period_end' => false,
                     'items' => [
                         'data' => [[
-                            'id' => $subscription->items()->first()->stripe_id,
+                            'id' => $subscription->items()->first()->stripeId(),
                             'price' => ['id' => static::$priceId, 'product' => static::$productId],
                             'quantity' => 1,
                         ]],
@@ -245,8 +245,8 @@ class WebhooksTest extends FeatureTestCase
             'type' => 'customer.subscription.deleted',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripe_id,
-                    'customer' => $user->stripe_id,
+                    'id' => $subscription->stripeId(),
+                    'customer' => $user->stripeId(),
                     'quantity' => 1,
                 ],
             ],
@@ -267,8 +267,8 @@ class WebhooksTest extends FeatureTestCase
             'type' => 'customer.subscription.updated',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripe_id,
-                    'customer' => $user->stripe_id,
+                    'id' => $subscription->stripeId(),
+                    'customer' => $user->stripeId(),
                     'status' => StripeSubscription::STATUS_INCOMPLETE_EXPIRED,
                     'quantity' => 1,
                 ],
@@ -295,7 +295,7 @@ class WebhooksTest extends FeatureTestCase
                 'data' => [
                     'object' => [
                         'id' => 'foo',
-                        'customer' => $user->stripe_id,
+                        'customer' => $user->stripeId(),
                         'payment_intent' => $exception->payment->id,
                     ],
                 ],

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -67,7 +67,7 @@ class CustomerTest extends TestCase
     public function test_stripe_customer_cannot_be_created_when_stripe_id_is_already_set()
     {
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $this->expectException(CustomerAlreadyCreated::class);
 

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -67,7 +67,7 @@ class CustomerTest extends TestCase
     public function test_stripe_customer_cannot_be_created_when_stripe_id_is_already_set()
     {
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $this->expectException(CustomerAlreadyCreated::class);
 

--- a/tests/Unit/InvoiceLineItemTest.php
+++ b/tests/Unit/InvoiceLineItemTest.php
@@ -18,7 +18,7 @@ class InvoiceLineItemTest extends TestCase
     public function test_we_can_calculate_the_inclusive_tax_percentage()
     {
         $customer = new User();
-        $customer->stripe_id = 'foo';
+        $customer->{$customer::$stripeIdColumn} = 'foo';
 
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_NONE;
@@ -43,7 +43,7 @@ class InvoiceLineItemTest extends TestCase
     public function test_we_can_calculate_the_exclusive_tax_percentage()
     {
         $customer = new User();
-        $customer->stripe_id = 'foo';
+        $customer->{$customer::$stripeIdColumn} = 'foo';
 
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_NONE;

--- a/tests/Unit/InvoiceLineItemTest.php
+++ b/tests/Unit/InvoiceLineItemTest.php
@@ -18,7 +18,7 @@ class InvoiceLineItemTest extends TestCase
     public function test_we_can_calculate_the_inclusive_tax_percentage()
     {
         $customer = new User();
-        $customer->{$customer::$stripeIdColumn} = 'foo';
+        $customer->{$customer::stripeIdColumn()} = 'foo';
 
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_NONE;
@@ -43,7 +43,7 @@ class InvoiceLineItemTest extends TestCase
     public function test_we_can_calculate_the_exclusive_tax_percentage()
     {
         $customer = new User();
-        $customer->{$customer::$stripeIdColumn} = 'foo';
+        $customer->{$customer::stripeIdColumn()} = 'foo';
 
         $stripeInvoice = new StripeInvoice();
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_NONE;

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -30,7 +30,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->created = 1560541724;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -47,7 +47,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->created = 1560541724;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -65,7 +65,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -82,7 +82,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -100,7 +100,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = -450;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -117,7 +117,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -133,7 +133,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = -450;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -147,7 +147,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = 0;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -162,7 +162,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -178,7 +178,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -195,7 +195,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -213,7 +213,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -238,7 +238,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->discounts = [$discount, $otherDiscount];
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -256,7 +256,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -271,7 +271,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -287,7 +287,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_EXEMPT;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -301,7 +301,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_REVERSE;
 
         $user = new User();
-        $user->{$user::$stripeIdColumn} = 'foo';
+        $user->{$user::stripeIdColumn()} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -30,7 +30,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->created = 1560541724;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -47,7 +47,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->created = 1560541724;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -65,7 +65,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -82,7 +82,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -100,7 +100,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = -450;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -117,7 +117,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -133,7 +133,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = -450;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -147,7 +147,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->starting_balance = 0;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -162,7 +162,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -178,7 +178,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -195,7 +195,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -213,7 +213,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -238,7 +238,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->discounts = [$discount, $otherDiscount];
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -256,7 +256,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -271,7 +271,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->currency = 'USD';
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -287,7 +287,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_EXEMPT;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 
@@ -301,7 +301,7 @@ class InvoiceTest extends TestCase
         $stripeInvoice->customer_tax_exempt = StripeCustomer::TAX_EXEMPT_REVERSE;
 
         $user = new User();
-        $user->stripe_id = 'foo';
+        $user->{$user::$stripeIdColumn} = 'foo';
 
         $invoice = new Invoice($user, $stripeInvoice);
 


### PR DESCRIPTION
This PR allows for using a column other than `stripe_id` on the various Cashier models.

It replaces all uses of `->stripe_id` with `->stripeId()` which can be found in the new [HasStripeId](src/Concerns/HasStripeId.php) trait. This trait is included alongside the other traits in the `Billable` trait, and in the `Subscription` and `SubscriptionItem` models. 

To make use of it, you would simply define the model's `public static function stripeIdColumn()` method to return whatever column name your model uses (including custom `Subscription` and `SubscriptionItem` models that extend their Cashier counterparts).

The purpose of this PR was so that in a project of mine I could use my custom models that mirror their actual Stripe counterparts 1:1 in my database. This allows me to both match the Stripe object schema and also more closely follow the Laravel/Eloquent schema pattern (in this case using `id` instead of `stripe_id` for the `User` [`Customer`], `Subscription`, and `SubscriptionItem` models).