### PR TITLE
[15.x] Fix anchorBillingCycle for subscription checkout

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -351,7 +351,6 @@ class SubscriptionBuilder
             $trialEnd = null;
         }
 
-        // Can not use billingCycleAnchor with trial period. It is a stripe limitation
         $billingCycleAnchor = $trialEnd === null ? $this->billingCycleAnchor : null;
 
         $payload = array_filter([

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -351,12 +351,17 @@ class SubscriptionBuilder
             $trialEnd = null;
         }
 
+        // Can not use billingCycleAnchor with trial period. It is a stripe limitation
+        $billingCycleAnchor = $trialEnd === null ? $this->billingCycleAnchor : null;
+
         $payload = array_filter([
             'line_items' => Collection::make($this->items)->values()->all(),
             'mode' => 'subscription',
             'subscription_data' => array_filter([
                 'default_tax_rates' => $this->getTaxRatesForPayload(),
                 'trial_end' => $trialEnd ? $trialEnd->getTimestamp() : null,
+                'billing_cycle_anchor' => $billingCycleAnchor,
+                'proration_behavior' => $billingCycleAnchor ? $this->prorateBehavior() : null,
                 'metadata' => array_merge($this->metadata, [
                     'name' => $this->type,
                     'type' => $this->type,


### PR DESCRIPTION
At the moment it is impossible to use newSubsciption builder , add an anchorBillingCycle and create a checkout.

This PR fix this to make this code work : 
```php
$checkoutBuilder = $user
            ->newSubscription('default', ['price_yearly'])
            ->anchorBillingCycleOn(Carbon::tomorrow())
            ->noProrate()
            ->checkout();
```

Before, this code did a checkout but does not add anchorBillingCycle date and proration_behavior to the POST data to stripe as expected here : https://docs.stripe.com/payments/checkout/billing-cycle?ui=stripe-hosted#create-session

It resolves  https://github.com/laravel/cashier-stripe/issues/1658


