### PR TITLE
Improvement: End the generic trial instead of clearing it when a subs…

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -100,9 +100,9 @@ class WebhookController extends Controller
                 }
             }
 
-            // Terminate the billable's generic trial if it exists...
-            if (! is_null($user->trial_ends_at)) {
-                $user->update(['trial_ends_at' => null]);
+            // End the billable's generic trial if it exists...
+            if ($user->onGenericTrial()) {
+                $user->update(['trial_ends_at' => now()]);
             }
         }
 


### PR DESCRIPTION
This will end the generic trial instead of clearing it, which enables you to still know if a user had a generic trial or not (and when it ended)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
