### PR TITLE
[15.x] Create stripe customer if not exists or update/sync

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -128,6 +128,36 @@ trait ManagesCustomer
     }
 
     /**
+     * Update the Stripe customer information for the current user or create one.
+     *
+     * @param  array  $options
+     * @return \Stripe\Customer
+     */
+    public function createOrUpdateStripeCustomer(array $options = [])
+    {
+        if ($this->hasStripeId()) {
+            return $this->updateStripeCustomer($options);
+        }
+
+        return $this->createAsStripeCustomer($options);
+    }
+
+    /**
+     * Sync the customer's information to Stripe for the current user or create one.
+     *
+     * @param  array  $options
+     * @return \Stripe\Customer
+     */
+    public function createOrSyncStripeCustomer(array $options = [])
+    {
+        if ($this->hasStripeId()) {
+            return $this->syncStripeCustomerDetails();
+        }
+
+        return $this->createAsStripeCustomer($options);
+    }
+
+    /**
      * Get the Stripe customer for the model.
      *
      * @param  array  $expand

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -133,7 +133,7 @@ trait ManagesCustomer
      * @param  array  $options
      * @return \Stripe\Customer
      */
-    public function createOrUpdateStripeCustomer(array $options = [])
+    public function updateOrCreateStripeCustomer(array $options = [])
     {
         if ($this->hasStripeId()) {
             return $this->updateStripeCustomer($options);
@@ -148,7 +148,7 @@ trait ManagesCustomer
      * @param  array  $options
      * @return \Stripe\Customer
      */
-    public function createOrSyncStripeCustomer(array $options = [])
+    public function syncOrCreateStripeCustomer(array $options = [])
     {
         if ($this->hasStripeId()) {
             return $this->syncStripeCustomerDetails();

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -28,7 +28,7 @@ class CustomerTest extends FeatureTestCase
     {
         $user = $this->createCustomer('customers_in_stripe_can_be_created_or_updated');
 
-        $customer = $user->createOrUpdateStripeCustomer(['description' => 'Hello World']);
+        $customer = $user->updateOrCreateStripeCustomer(['description' => 'Hello World']);
 
         // Created
         $this->assertEquals('Main Str. 1', $customer->address->line1);
@@ -36,7 +36,7 @@ class CustomerTest extends FeatureTestCase
         $this->assertEquals('72201', $customer->address->postal_code);
         $this->assertEquals('Hello World', $customer->description);
 
-        $customer = $user->createOrUpdateStripeCustomer(['description' => 'Random details']);
+        $customer = $user->updateOrCreateStripeCustomer(['description' => 'Random details']);
 
         // Updated
         $this->assertEquals('Random details', $customer->description);
@@ -65,7 +65,7 @@ class CustomerTest extends FeatureTestCase
     {
         $user = $this->createCustomer('customer_details_can_be_synced_or_created_with_stripe');
 
-        $customer = $user->createOrSyncStripeCustomer(['description' => 'Hello World']);
+        $customer = $user->syncOrCreateStripeCustomer(['description' => 'Hello World']);
 
         // Created
         $this->assertEquals('Main Str. 1', $customer->address->line1);
@@ -77,7 +77,7 @@ class CustomerTest extends FeatureTestCase
         $user->email = 'john@example.com';
         $user->phone = '+32 499 00 00 00';
 
-        $customer = $user->createOrSyncStripeCustomer();
+        $customer = $user->syncOrCreateStripeCustomer();
 
         // Synced
         $this->assertEquals('John Doe', $customer->name);

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -24,6 +24,24 @@ class CustomerTest extends FeatureTestCase
         $this->assertEquals('Mohamed Said', $customer->description);
     }
 
+    public function test_customers_in_stripe_can_be_created_or_updated()
+    {
+        $user = $this->createCustomer('customers_in_stripe_can_be_created_or_updated');
+
+        $customer = $user->createOrUpdateStripeCustomer(['description' => 'Hello World']);
+
+        // Created
+        $this->assertEquals('Main Str. 1', $customer->address->line1);
+        $this->assertEquals('Little Rock', $customer->address->city);
+        $this->assertEquals('72201', $customer->address->postal_code);
+        $this->assertEquals('Hello World', $customer->description);
+
+        $customer = $user->createOrUpdateStripeCustomer(['description' => 'Random details']);
+
+        // Updated
+        $this->assertEquals('Random details', $customer->description);
+    }
+
     public function test_customer_details_can_be_synced_with_stripe()
     {
         $user = $this->createCustomer('customer_details_can_be_synced_with_stripe');
@@ -37,6 +55,33 @@ class CustomerTest extends FeatureTestCase
 
         $this->assertEquals('Mohamed Said', $customer->name);
         $this->assertEquals('mohamed@example.com', $customer->email);
+        $this->assertEquals('+32 499 00 00 00', $customer->phone);
+        $this->assertEquals('Main Str. 1', $customer->address->line1);
+        $this->assertEquals('Little Rock', $customer->address->city);
+        $this->assertEquals('72201', $customer->address->postal_code);
+    }
+
+    public function test_customer_details_can_be_synced_or_created_with_stripe()
+    {
+        $user = $this->createCustomer('customer_details_can_be_synced_or_created_with_stripe');
+
+        $customer = $user->createOrSyncStripeCustomer(['description' => 'Hello World']);
+
+        // Created
+        $this->assertEquals('Main Str. 1', $customer->address->line1);
+        $this->assertEquals('Little Rock', $customer->address->city);
+        $this->assertEquals('72201', $customer->address->postal_code);
+        $this->assertEquals('Hello World', $customer->description);
+
+        $user->name = 'John Doe';
+        $user->email = 'john@example.com';
+        $user->phone = '+32 499 00 00 00';
+
+        $customer = $user->createOrSyncStripeCustomer();
+
+        // Synced
+        $this->assertEquals('John Doe', $customer->name);
+        $this->assertEquals('john@example.com', $customer->email);
         $this->assertEquals('+32 499 00 00 00', $customer->phone);
         $this->assertEquals('Main Str. 1', $customer->address->line1);
         $this->assertEquals('Little Rock', $customer->address->city);


### PR DESCRIPTION
Assume, we have a route for redirecting to billing (stripe customer portal). Before that, the customer's stripe account should be created. We may use the `createOrGetStripeCustomer` method, but if we intend to update the stripe customer's details with his latest profile data or any metadata, then `createOrSyncStripeCustomer` and `createOrUpdateStripeCustomer` will be helpful.

- [x] It will not break any existing feature.
