### PR TITLE
[16.x] Store subscription renewal date

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -35,6 +35,7 @@ class SubscriptionFactory extends Factory
             'stripe_status' => StripeSubscription::STATUS_ACTIVE,
             'stripe_price' => null,
             'quantity' => null,
+            'renews_at' => null,
             'trial_ends_at' => null,
             'ends_at' => null,
         ];

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('stripe_status');
             $table->string('stripe_price')->nullable();
             $table->integer('quantity')->nullable();
+            $table->timestamp('renews_at')->nullable();
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamp('ends_at')->nullable();
             $table->timestamps();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -86,6 +86,7 @@ class WebhookController extends Controller
                     'stripe_status' => $data['status'],
                     'stripe_price' => $isSinglePrice ? $firstItem['price']['id'] : null,
                     'quantity' => $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null,
+                    'renews_at' => Carbon::createFromTimestamp($data['current_period_end']),
                     'trial_ends_at' => $trialEndsAt,
                     'ends_at' => null,
                 ]);
@@ -163,11 +164,14 @@ class WebhookController extends Controller
                 }
             }
 
+            // Renewal date...
+            $subscription->renews_at = Carbon::createFromTimestamp($data['current_period_end']);
+
             // Cancellation date...
             if ($data['cancel_at_period_end'] ?? false) {
                 $subscription->ends_at = $subscription->onTrial()
                     ? $subscription->trial_ends_at
-                    : Carbon::createFromTimestamp($data['current_period_end']);
+                    : $subscription->renews_at;
             } elseif (isset($data['cancel_at']) || isset($data['canceled_at'])) {
                 $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at'] ?? $data['canceled_at']);
             } else {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -50,9 +50,10 @@ class Subscription extends Model
      * @var array
      */
     protected $casts = [
-        'ends_at' => 'datetime',
         'quantity' => 'integer',
+        'renews_at' => 'datetime',
         'trial_ends_at' => 'datetime',
+        'ends_at' => 'datetime',
     ];
 
     /**
@@ -705,6 +706,7 @@ class Subscription extends Model
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
             'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
+            'renews_at' => Carbon::createFromTimestamp($stripeSubscription->current_period_end),
             'ends_at' => null,
         ])->save();
 
@@ -992,6 +994,8 @@ class Subscription extends Model
 
         $this->stripe_status = $stripeSubscription->status;
 
+        $this->renews_at = null;
+
         // If the user was on trial, we will set the grace period to end when the trial
         // would have ended. Otherwise, we'll retrieve the end of the billing period
         // period and make that the end of the grace period for this current user.
@@ -1026,6 +1030,8 @@ class Subscription extends Model
         ]);
 
         $this->stripe_status = $stripeSubscription->status;
+
+        $this->renews_at = null;
 
         $this->ends_at = Carbon::createFromTimestamp($stripeSubscription->cancel_at);
 
@@ -1078,6 +1084,7 @@ class Subscription extends Model
     {
         $this->fill([
             'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'renews_at' => null,
             'ends_at' => Carbon::now(),
         ])->save();
     }
@@ -1105,6 +1112,7 @@ class Subscription extends Model
         // no longer "canceled". Then we shall save this record in the database.
         $this->fill([
             'stripe_status' => $stripeSubscription->status,
+            'renews_at' => Carbon::createFromTimestamp($stripeSubscription->current_period_end),
             'ends_at' => null,
         ])->save();
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -50,10 +50,10 @@ class Subscription extends Model
      * @var array
      */
     protected $casts = [
+        'ends_at' => 'datetime',
         'quantity' => 'integer',
         'renews_at' => 'datetime',
         'trial_ends_at' => 'datetime',
-        'ends_at' => 'datetime',
     ];
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -309,6 +309,7 @@ class SubscriptionBuilder
             'stripe_status' => $stripeSubscription->status,
             'stripe_price' => $isSinglePrice ? $firstItem->price->id : null,
             'quantity' => $isSinglePrice ? ($firstItem->quantity ?? null) : null,
+            'renews_at' => Carbon::createFromTimestamp($stripeSubscription->current_period_end),
             'trial_ends_at' => ! $this->skipTrial ? $this->trialExpires : null,
             'ends_at' => null,
         ]);

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -49,6 +49,7 @@ class WebhooksTest extends FeatureTestCase
     public function test_subscriptions_are_created()
     {
         $user = $this->createCustomer('subscriptions_are_created', ['stripe_id' => 'cus_foo']);
+        $renewalDate = Carbon::now()->addMonth();
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -57,6 +58,7 @@ class WebhooksTest extends FeatureTestCase
                 'object' => [
                     'id' => 'sub_foo',
                     'customer' => 'cus_foo',
+                    'current_period_end' => $renewalDate->timestamp,
                     'cancel_at_period_end' => false,
                     'quantity' => 10,
                     'items' => [
@@ -77,6 +79,7 @@ class WebhooksTest extends FeatureTestCase
             'stripe_id' => 'sub_foo',
             'stripe_status' => 'active',
             'quantity' => 10,
+            'renews_at' => $renewalDate->format('Y-m-d H:i:s'),
         ]);
 
         $this->assertDatabaseHas('subscription_items', [
@@ -90,6 +93,7 @@ class WebhooksTest extends FeatureTestCase
     public function test_subscriptions_are_updated()
     {
         $user = $this->createCustomer('subscriptions_are_updated', ['stripe_id' => 'cus_foo']);
+        $renewalDate = Carbon::now()->addMonth();
 
         $subscription = $user->subscriptions()->create([
             'type' => 'main',
@@ -112,6 +116,7 @@ class WebhooksTest extends FeatureTestCase
                 'object' => [
                     'id' => $subscription->stripe_id,
                     'customer' => 'cus_foo',
+                    'current_period_end' => $renewalDate->timestamp,
                     'cancel_at_period_end' => false,
                     'items' => [
                         'data' => [[
@@ -129,6 +134,7 @@ class WebhooksTest extends FeatureTestCase
             'user_id' => $user->id,
             'stripe_id' => 'sub_foo',
             'quantity' => 5,
+            'renews_at' => $renewalDate->format('Y-m-d H:i:s'),
         ]);
 
         $this->assertDatabaseHas('subscription_items', [
@@ -147,6 +153,7 @@ class WebhooksTest extends FeatureTestCase
     public function test_subscriptions_on_update_cancel_at_date_is_correct()
     {
         $user = $this->createCustomer('subscriptions_on_update_cancel_at_date_is_correct', ['stripe_id' => 'cus_foo']);
+        $renewalDate = Carbon::now()->addMonth();
         $cancelDate = Carbon::now()->addMonths(6);
 
         $subscription = $user->subscriptions()->create([
@@ -170,6 +177,7 @@ class WebhooksTest extends FeatureTestCase
                 'object' => [
                     'id' => $subscription->stripe_id,
                     'customer' => 'cus_foo',
+                    'current_period_end' => $renewalDate->timestamp,
                     'cancel_at' => $cancelDate->timestamp,
                     'cancel_at_period_end' => false,
                     'items' => [
@@ -188,6 +196,7 @@ class WebhooksTest extends FeatureTestCase
             'user_id' => $user->id,
             'stripe_id' => 'sub_foo',
             'quantity' => 5,
+            'renews_at' => $renewalDate->format('Y-m-d H:i:s'),
             'ends_at' => $cancelDate->format('Y-m-d H:i:s'),
         ]);
 
@@ -218,6 +227,7 @@ class WebhooksTest extends FeatureTestCase
                 'object' => [
                     'id' => $subscription->stripe_id,
                     'customer' => $user->stripe_id,
+                    'current_period_end' => Carbon::now()->addMonth()->timestamp,
                     'cancel_at_period_end' => false,
                     'items' => [
                         'data' => [[


### PR DESCRIPTION
I believe there's a real need from the community to store the subscription renewal date to display it to users or use for cron jobs. See: #361, #515, #874, #1054, #1102, [Stack Overflow](https://stackoverflow.com/questions/41576568/get-next-billing-date-from-laravel-cashier), [Laracasts](https://laracasts.com/discuss/channels/laravel/laravel-cashier-expiry-date), [gist](https://gist.github.com/garygreen/fb4dc0288e2c57f9af015968ff7019bb), etc.

The current workaround requires making an extra API request `$user->subscription()->asStripeSubscription()->current_period_end` that can be avoided if we store the renewal date `$subscription->renews_at` when creating, updating and swapping subscriptions.

Note: I considered using the `ends_at` column instead of creating a new `renews_at` column but they'll have different values when using `$subscription->cancelAt()`.

I understand the need to keep Cashier simple and functional but I think this is a relatively simple change that adds a lot of value.

This PR does not break any existing feature but it does require running this database migration to upgrade:

```php
// php artisan make:migration add_cashier_subscriptions_renews_at_column --table=subscriptions
Schema::table('subscriptions', function (Blueprint $table) {
    $table->timestamp('renews_at')->nullable()->after('quantity');
});
```