### PR TITLE
[15.x] Check if the default payment method is valid.

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -50,6 +50,20 @@ trait ManagesPaymentMethods
     }
 
     /**
+     * Determines if the customer currently has a valid default payment method.
+     *
+     * @return bool
+     */
+    public function hasValidDefaultPaymentMethod()
+    {
+        return !(($this->defaultPaymentMethod() === null) ||
+            (
+                ($this->defaultPaymentMethod()->id !== null) &&
+                ($this->resolveStripePaymentMethod($this->defaultPaymentMethod()->id)=== null)
+            ));
+    }
+
+    /**
      * Determines if the customer currently has at least one payment method of an optional type.
      *
      * @param  string|null  $type

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -95,6 +95,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertCount(1, $user->paymentMethods());
         $this->assertTrue($user->hasPaymentMethod());
         $this->assertTrue($user->hasDefaultPaymentMethod());
+        $this->assertTrue($user->hasValidDefaultPaymentMethod());
 
         $user->deletePaymentMethod($paymentMethod->asStripePaymentMethod());
 
@@ -104,6 +105,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertNull($user->pm_last_four);
         $this->assertFalse($user->hasPaymentMethod());
         $this->assertFalse($user->hasDefaultPaymentMethod());
+        $this->assertFalse($user->hasValidDefaultPaymentMethod());
     }
 
     public function test_we_can_set_a_default_payment_method()
@@ -117,6 +119,7 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertEquals('visa', $paymentMethod->card->brand);
         $this->assertEquals('4242', $paymentMethod->card->last4);
         $this->assertTrue($user->hasDefaultPaymentMethod());
+        $this->assertTrue($user->hasValidDefaultPaymentMethod());
 
         $paymentMethod = $user->defaultPaymentMethod();
 

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -42,10 +42,12 @@ class CustomerTest extends TestCase
         $user->pm_type = 'visa';
 
         $this->assertTrue($user->hasDefaultPaymentMethod());
+        $this->assertTrue($user->hasValidDefaultPaymentMethod());
 
         $user = new User;
 
         $this->assertFalse($user->hasDefaultPaymentMethod());
+        $this->assertFalse($user->hasValidDefaultPaymentMethod());
     }
 
     public function test_default_payment_method_returns_null_when_the_user_is_not_a_customer_yet()


### PR DESCRIPTION
This PR adds a method **hasValidDefaultPaymentMethod** which checks whether the user has a valid default payment method stored on Stripe.

Currently in cashier, we can check whether a user has a default payment method through:


* hasDefaultPaymentMethod only checks for payment type. 
* defaultPaymentMethod  -- only gives the default payment method details.