### PR TITLE
[15.x] Add stripe invoice mixin to invoice

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -15,6 +15,9 @@ use Stripe\Customer as StripeCustomer;
 use Stripe\Invoice as StripeInvoice;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @mixin \Stripe\Invoice
+ */
 class Invoice implements Arrayable, Jsonable, JsonSerializable
 {
     /**


### PR DESCRIPTION
When using the Invoice class, phpstan and IDE's won't be able to access any of the Stripe props, as the class is missing a mixin annotation.