### PR TITLE
[15.x] Catch missing payment intents

### DIFF
--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -34,7 +34,7 @@ class PaymentController extends Controller
                 $id, ['expand' => ['payment_method']])
             );
         } catch (StripeInvalidRequestException $exception) {
-            abort(404, 'Payment not found');
+            abort(404, 'Payment not found.');
         }
 
         $paymentIntent = Arr::only($payment->asStripePaymentIntent()->toArray(), [

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -8,7 +8,6 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Http\Middleware\VerifyRedirectUrl;
 use Laravel\Cashier\Payment;
 use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PaymentController extends Controller
 {
@@ -27,8 +26,6 @@ class PaymentController extends Controller
      *
      * @param  string  $id
      * @return \Illuminate\Contracts\View\View
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function show($id)
     {
@@ -37,7 +34,7 @@ class PaymentController extends Controller
                 $id, ['expand' => ['payment_method']])
             );
         } catch (StripeInvalidRequestException $exception) {
-            throw new NotFoundHttpException;
+            abort(404, 'Payment not found');
         }
 
         $paymentIntent = Arr::only($payment->asStripePaymentIntent()->toArray(), [

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Arr;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Http\Middleware\VerifyRedirectUrl;
 use Laravel\Cashier\Payment;
+use Stripe\Exception\InvalidRequestException as StripeInvalidRequestException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PaymentController extends Controller
 {
@@ -25,12 +27,18 @@ class PaymentController extends Controller
      *
      * @param  string  $id
      * @return \Illuminate\Contracts\View\View
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function show($id)
     {
-        $payment = new Payment(Cashier::stripe()->paymentIntents->retrieve(
-            $id, ['expand' => ['payment_method']])
-        );
+        try {
+            $payment = new Payment(Cashier::stripe()->paymentIntents->retrieve(
+                $id, ['expand' => ['payment_method']])
+            );
+        } catch (StripeInvalidRequestException $exception) {
+            throw new NotFoundHttpException;
+        }
 
         $paymentIntent = Arr::only($payment->asStripePaymentIntent()->toArray(), [
             'id', 'status', 'payment_method_types', 'client_secret', 'payment_method',


### PR DESCRIPTION
This gracefully returns a not found exception instead of a 500 error when trying to access a non-existent or invalid payment intent ID in the browser such as from the route `/stripe/payment/xxx`.