### PR TITLE
Bump stripe/stripe-php to v16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/view": "^10.0|^11.0",
         "moneyphp/money": "^4.0",
         "nesbot/carbon": "^2.0|^3.0",
-        "stripe/stripe-php": "^13.0",
+        "stripe/stripe-php": "^16.2",
         "symfony/console": "^6.0|^7.0",
         "symfony/http-kernel": "^6.0|^7.0",
         "symfony/polyfill-intl-icu": "^1.22.1"


### PR DESCRIPTION
Bump stripe/stripe-php to latest version (16.2). Some Stripe features like invoice preview were not available prior to 15.x.