### PR TITLE
Correct API version

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,7 +19,7 @@ The Stripe SDK version is now fixed at v13.x.
 
 PR: https://github.com/laravel/cashier-stripe/pull/1615
 
-The default Stripe API version for Cashier 15 is `2023-10-16`. If this is the latest Stripe API version when you upgrade to this Cashier version, then we recommend you also upgrade your Stripe API version settings [in your Stripe dashboard](https://dashboard.stripe.com/developers) to this version after deploying the Cashier upgrade. If this is no longer the latest Stripe API version, we recommend you do not modify your Stripe API version settings.
+The default Stripe API version for Cashier 15 is `2023-08-16`. If this is the latest Stripe API version when you upgrade to this Cashier version, then we recommend you also upgrade your Stripe API version settings [in your Stripe dashboard](https://dashboard.stripe.com/developers) to this version after deploying the Cashier upgrade. If this is no longer the latest Stripe API version, we recommend you do not modify your Stripe API version settings.
 
 If you use the Stripe PHP SDK directly, make sure to properly test your integration after updating.
 


### PR DESCRIPTION
From what I can see in Stripe dev tools, the available version is `2023-08-16`. This corrects the date to align with the available versions

Assuming that's what Cashier should use, [this version](https://github.com/laravel/cashier-stripe/blob/80601df40f331c2130d519b9a54203a2b7c67f76/src/Cashier.php#L29) should be updated as well.

<img width="714" alt="Screenshot 2024-11-17 at 1 22 43 PM" src="https://github.com/user-attachments/assets/f3e3d544-548d-41f5-b379-09747f6e5eed">


