### PR TITLE
feat(Checkout):  Add request option parameters

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -70,7 +70,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      * @param  \Illuminate\Database\Eloquent\Model|null  $owner
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
+     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions  $opts
      * @return \Laravel\Cashier\Checkout
      */
     public static function create($owner, array $sessionOptions = [], array $customerOptions = [], $opts = null)

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -11,6 +11,7 @@ use Stripe\Checkout\Session;
 
 /**
  * @phpstan-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ *
  * @psalm-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
  */
 class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -71,7 +71,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      * @param  \Illuminate\Database\Eloquent\Model|null  $owner
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions  $opts
+     * @param RequestOptionsArray|\Stripe\Util\RequestOptions|null  $opts
      * @return \Laravel\Cashier\Checkout
      */
     public static function create($owner, array $sessionOptions = [], array $customerOptions = [], $opts = null)

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -70,7 +70,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      * @param  \Illuminate\Database\Eloquent\Model|null  $owner
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
+     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
      * @return \Laravel\Cashier\Checkout
      */
     public static function create($owner, array $sessionOptions = [], array $customerOptions = [], $opts = null)

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Facades\Redirect;
 use JsonSerializable;
 use Stripe\Checkout\Session;
 
+/**
+ * @phpstan-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ * @psalm-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ */
 class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
 {
     /**
@@ -66,9 +70,10 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
      * @param  \Illuminate\Database\Eloquent\Model|null  $owner
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
+     * @param null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
      * @return \Laravel\Cashier\Checkout
      */
-    public static function create($owner, array $sessionOptions = [], array $customerOptions = [])
+    public static function create($owner, array $sessionOptions = [], array $customerOptions = [], $opts = null)
     {
         $data = array_merge([
             'mode' => Session::MODE_PAYMENT,
@@ -107,7 +112,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['cancel_url'] = $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled';
         }
 
-        $session = $stripe->checkout->sessions->create($data);
+        $session = $stripe->checkout->sessions->create($data, $opts);
 
         return new static($owner, $session);
     }

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -8,6 +8,7 @@ use Laravel\Cashier\Concerns\HandlesTaxes;
 
 /**
  * @phpstan-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ *
  * @psalm-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
  */
 class CheckoutBuilder

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Concerns\AllowsCoupons;
 use Laravel\Cashier\Concerns\HandlesTaxes;
 
+/**
+ * @phpstan-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ * @psalm-import-type RequestOptionsArray from \Stripe\Util\RequestOptions
+ */
 class CheckoutBuilder
 {
     use AllowsCoupons;
@@ -60,9 +64,10 @@ class CheckoutBuilder
      * @param  array|string  $items
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
+     * @param null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
      * @return \Laravel\Cashier\Checkout
      */
-    public function create($items, array $sessionOptions = [], array $customerOptions = [])
+    public function create($items, array $sessionOptions = [], array $customerOptions = [], $opts = null)
     {
         $payload = array_filter([
             'allow_promotion_codes' => $this->allowPromotionCodes,

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -64,7 +64,7 @@ class CheckoutBuilder
      * @param  array|string  $items
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
+     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions  $opts
      * @return \Laravel\Cashier\Checkout
      */
     public function create($items, array $sessionOptions = [], array $customerOptions = [], $opts = null)

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -65,7 +65,7 @@ class CheckoutBuilder
      * @param  array|string  $items
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions  $opts
+     * @param  RequestOptionsArray|\Stripe\Util\RequestOptions|null  $opts
      * @return \Laravel\Cashier\Checkout
      */
     public function create($items, array $sessionOptions = [], array $customerOptions = [], $opts = null)

--- a/src/CheckoutBuilder.php
+++ b/src/CheckoutBuilder.php
@@ -64,7 +64,7 @@ class CheckoutBuilder
      * @param  array|string  $items
      * @param  array  $sessionOptions
      * @param  array  $customerOptions
-     * @param null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
+     * @param  null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
      * @return \Laravel\Cashier\Checkout
      */
     public function create($items, array $sessionOptions = [], array $customerOptions = [], $opts = null)


### PR DESCRIPTION
feat(Checkout):  Add request option parameters
- Add $opts parameter to Checkout and CheckoutBuilder classes 
- Allow custom request options to be passed when creating Checkouts 
- Add type import comments for PHPStan and Psalm
