### PR TITLE
[15.x] Fix failing payment confirm tests

### DIFF
--- a/src/Concerns/HandlesPaymentFailures.php
+++ b/src/Concerns/HandlesPaymentFailures.php
@@ -68,7 +68,7 @@ trait HandlesPaymentFailures
                     ])->save();
 
                     if ($subscription->hasIncompletePayment()) {
-                        (new Payment($paymentIntent))->validate();
+                        (new Payment($paymentIntent))->refresh(['invoice.subscription'])->validate();
                     }
                 } else {
                     throw $e;

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -210,6 +210,19 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Refresh the PaymentIntent instance from the Stripe API.
+     *
+     * @param  array  $expand
+     * @return $this
+     */
+    public function refresh(array $expand = [])
+    {
+        $this->paymentIntent = $this->asStripePaymentIntent($expand);
+
+        return $this;
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array


### PR DESCRIPTION
This should fix the failing payment confirm tests by making sure we get the most recent state of the payment intent by re-fetching it from the Stripe API.