### PR TITLE
[15.x] Fix nullable invoice settings

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -151,7 +151,7 @@ trait ManagesPaymentMethods
         /** @var \Stripe\Customer */
         $customer = $this->asStripeCustomer(['default_source', 'invoice_settings.default_payment_method']);
 
-        if ($customer->invoice_settings->default_payment_method) {
+        if ($customer->invoice_settings?->default_payment_method) {
             return new PaymentMethod($this, $customer->invoice_settings->default_payment_method);
         }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/cashier-stripe/issues/1729

This should actually never happen because `invoice_settings` is always an associative array according to the Stripe API docs: https://docs.stripe.com/api/customers/object#customer_object-invoice_settings

Regardless, we should protect against it so it doesn't fails over in Cashier.