### PR TITLE
Adds explicit nullable to avoid php 8.4 deprecation warnings

### DIFF
--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -69,7 +69,7 @@ class SubscriptionFactory extends Factory
      *
      * @return $this
      */
-    public function trialing(DateTimeInterface $trialEndsAt = null): static
+    public function trialing(?DateTimeInterface $trialEndsAt = null): static
     {
         return $this->state([
             'stripe_status' => StripeSubscription::STATUS_TRIALING,

--- a/src/Exceptions/IncompletePayment.php
+++ b/src/Exceptions/IncompletePayment.php
@@ -24,7 +24,7 @@ class IncompletePayment extends Exception
      * @param  \Throwable|null  $previous
      * @return void
      */
-    public function __construct(Payment $payment, $message = '', $code = 0, Throwable $previous = null)
+    public function __construct(Payment $payment, $message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 


### PR DESCRIPTION
Fixing deprecation warnings for php 8.4

Closes #1741 
