### PR TITLE
Fix retrieving subscription()

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -152,7 +152,7 @@ trait ManagesSubscriptions
      */
     public function subscription($type = 'default')
     {
-        return $this->subscriptions->where('type', $type)->first();
+        return $this->subscriptions()->where('type', $type)->first();
     }
 
     /**


### PR DESCRIPTION
Function always returns null in error because it's not calling the function subscriptions() but a field called subscriptions.