### PR TITLE
Add `remote_enabled` option to enable external font downloads

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -106,6 +106,8 @@ return [
         'options' => [
             // Supported: 'letter', 'legal', 'A4'
             'paper' => env('CASHIER_PAPER', 'letter'),
+            // Supported: true, false
+            'remote_enabled' => env('CASHIER_REMOTE_ENABLED', false),
         ],
     ],
 

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -106,7 +106,7 @@ return [
         'options' => [
             // Supported: 'letter', 'legal', 'A4'
             'paper' => env('CASHIER_PAPER', 'letter'),
-            // Supported: true, false
+
             'remote_enabled' => env('CASHIER_REMOTE_ENABLED', false),
         ],
     ],

--- a/src/Invoices/DompdfInvoiceRenderer.php
+++ b/src/Invoices/DompdfInvoiceRenderer.php
@@ -19,6 +19,7 @@ class DompdfInvoiceRenderer implements InvoiceRenderer
         }
 
         $dompdfOptions = new Options;
+        $dompdfOptions->setIsRemoteEnabled($options['remote_enabled'] ?? false);
         $dompdfOptions->setChroot(base_path());
 
         $dompdf = new Dompdf($dompdfOptions);


### PR DESCRIPTION
This setting allows us to publish the `invoice.blade.php` view and use custom fonts with additional glyphs in.

I'm not immediately aware of an alternate, safer solution than this, other than packaging a font file with Cashier?

However, enabling the `remote_enabled` setting comes with this warning in Dompdf:

```
Enable remote file access

If this setting is set to true, DOMPDF will access remote sites for
images and CSS files as required.

==== IMPORTANT ====
This can be a security risk, in particular in combination with isPhpEnabled and
allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
This allows anonymous users to download legally doubtful internet content which on
tracing back appears to being downloaded by your server, or allows malicious php code
in remote html pages to be executed by your server with your account privileges.

This setting may increase the risk of system exploit. Do not change
this settings without understanding the consequences. Additional
documentation is available on the dompdf wiki at:
https://github.com/dompdf/dompdf/wiki
```