### PR TITLE
Store pm_type and pm_last_four when invoice is paid.

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -376,11 +376,18 @@ class WebhookController extends Controller
                 $payment->payment_method
             ));
 
-            $user->pm_type = $paymentMethod->type;
-
+            
             if ($paymentMethod->type === 'card') {
+                $card = $paymentMethod->card;
+
+                $pm_type = ucwords($card->brand) . ' '
+                    . ($card->funding === 'unknown' ? 'Credit' : ucwords($card->funding))
+                    . " exp. {$card->exp_year}-{$card->exp_month}";
+
+                $user->pm_type = $pm_type;
                 $user->pm_last_four = $paymentMethod->card->last4;
             } else {
+                $user->pm_type = $paymentMethod->type;
                 $user->pm_last_four = null;
             }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -12,6 +12,7 @@ use Laravel\Cashier\Events\WebhookHandled;
 use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
+use Laravel\Cashier\PaymentMethod;
 use Laravel\Cashier\Subscription;
 use Stripe\Stripe;
 use Stripe\Subscription as StripeSubscription;
@@ -354,5 +355,38 @@ class WebhookController extends Controller
     protected function setMaxNetworkRetries($retries = 3)
     {
         Stripe::setMaxNetworkRetries($retries);
+    }
+
+    /**
+     * Handle invoice payment succeeded.
+     *
+     * @param  array  $payload
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function handleInvoicePaymentSucceeded(array $payload)
+    {
+        $user = $this->getUserByStripeId($payload['data']['object']['customer']);
+
+        if ($user) {
+            $payment = new Payment($user->stripe()->paymentIntents->retrieve(
+                $payload['data']['object']['payment_intent']
+            ));
+
+            $paymentMethod = new PaymentMethod($user, $user->stripe()->paymentMethods->retrieve(
+                $payment->payment_method
+            ));
+
+            $user->pm_type = $paymentMethod->type;
+
+            if ($paymentMethod->type === 'card') {
+                $user->pm_last_four = $paymentMethod->card->last4;
+            } else {
+                $user->pm_last_four = null;
+            }
+
+            $user->save();
+        }
+
+        return $this->successMethod();
     }
 }


### PR DESCRIPTION
Currently `pm_type` and `pm_last_four` remains empty when we use Stripe hosted checkout pages (even for subscriptions) as no "default payment method" is set in such cases.

I see Stripe hosted pages are becoming more and more used lately. And even for cases where I set up the payment details from my application, I consider knowing the "last (actual) payment method used" by a customer to be very relevant (more than knowing what is set as default for future payments which may never happen) for both business management reasons and customer support billing related cases, so this PR adds a new webhook handler for `invoice.payment_succeeded` event which is already listen by the webhook created with `php artisan cashier:webhook` but no handler existed yet.

For card payments, it saves card brand (with funding type) and exp. date to `pm_type` (e.g.: `Visa Credit exp. 2034-12`) + the last 4 digits to `pm_last_four`.

Note: the initial commit saves only "card" (literal) & last 4, if you prefer.