### PR TITLE
Fix: Ensure trial_ends_at is properly parsed before checking if it's …

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -72,7 +72,7 @@ trait ManagesSubscriptions
      */
     public function onGenericTrial()
     {
-        return $this->trial_ends_at && $this->trial_ends_at->isFuture();
+        return $this->trial_ends_at && Carbon::parse($this->trial_ends_at)->isFuture();
     }
 
     /**


### PR DESCRIPTION
This update fixes an issue where calling isFuture() on trial_ends_at could cause an error if the value was stored as a string. Now, trial_ends_at is explicitly parsed with Carbon::parse() before checking if it’s in the future, ensuring proper type handling and preventing potential crashes.
