### PR TITLE
Remove full stop from command description

### DIFF
--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -35,7 +35,7 @@ class WebhookCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Create the Stripe webhook to interact with Cashier.';
+    protected $description = 'Create the Stripe webhook to interact with Cashier';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
Laravel's default command descriptions omit the trailing full stop, spotted that Cashier had one and just proposing to make it consistent.
