### PR TITLE
Prevent address lock in Checkout (#1764)

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -84,7 +84,11 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
 
         // Make sure to collect address and name when Tax ID collection is enabled...
         if (isset($data['customer']) && ($data['tax_id_collection']['enabled'] ?? false)) {
-            $data['customer_update']['address'] = 'auto';
+            // Use billing_address_collection instead of customer_update.address = 'auto' to
+            // prevent address lock in checkout after payment cancellation while allowing overrides
+            if (!isset($data['billing_address_collection'])) {
+                $data['billing_address_collection'] = 'required';
+            }
             $data['customer_update']['name'] = 'auto';
         }
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -84,11 +84,10 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
 
         // Make sure to collect address and name when Tax ID collection is enabled...
         if (isset($data['customer']) && ($data['tax_id_collection']['enabled'] ?? false)) {
-            // Use billing_address_collection instead of customer_update.address = 'auto' to
-            // prevent address lock in checkout after payment cancellation while allowing overrides
             if (! isset($data['billing_address_collection'])) {
                 $data['billing_address_collection'] = 'required';
             }
+
             $data['customer_update']['name'] = 'auto';
         }
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -86,7 +86,7 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
         if (isset($data['customer']) && ($data['tax_id_collection']['enabled'] ?? false)) {
             // Use billing_address_collection instead of customer_update.address = 'auto' to
             // prevent address lock in checkout after payment cancellation while allowing overrides
-            if (!isset($data['billing_address_collection'])) {
+            if (! isset($data['billing_address_collection'])) {
                 $data['billing_address_collection'] = 'required';
             }
             $data['customer_update']['name'] = 'auto';

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -199,4 +199,58 @@ class CheckoutTest extends FeatureTestCase
 
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
+
+    public function test_checkout_prevents_address_lock_when_tax_collection_enabled()
+    {
+        // Enable tax calculation globally
+        \Laravel\Cashier\Cashier::calculateTaxes();
+
+        try {
+            $user = $this->createCustomer('address_lock_fix');
+
+            $price = self::stripe()->prices->create([
+                'currency' => 'USD',
+                'product_data' => ['name' => 'Test Product'],
+                'unit_amount' => 1000,
+            ]);
+
+            $checkout = $user->checkout($price->id, [
+                'success_url' => 'http://example.com',
+                'cancel_url' => 'http://example.com',
+            ]);
+
+            $session = $checkout->asStripeCheckoutSession();
+
+            // Verify that address lock is prevented
+            $this->assertTrue($session->tax_id_collection['enabled']);
+            $this->assertEquals('required', $session->billing_address_collection);
+            $this->assertNotEquals('auto', $session->customer_update['address'] ?? null);
+        } finally {
+            \Laravel\Cashier\Cashier::$calculatesTaxes = false;
+        }
+    }
+
+    public function test_checkout_respects_user_overrides_when_tax_collection_enabled()
+    {
+        $user = $this->createCustomer('user_overrides_tax_collection');
+
+        $price = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => ['name' => 'Test Product'],
+            'unit_amount' => 1000,
+        ]);
+
+        // User explicitly overrides billing_address_collection
+        $checkout = $user->checkout($price->id, [
+            'success_url' => 'http://example.com',
+            'cancel_url' => 'http://example.com',
+            'tax_id_collection' => ['enabled' => true],
+            'billing_address_collection' => 'auto',  // User override
+        ]);
+
+        $session = $checkout->asStripeCheckoutSession();
+
+        // User override should be respected
+        $this->assertEquals('auto', $session->billing_address_collection);
+    }
 }


### PR DESCRIPTION
- Replace customer_update.address = 'auto' with billing_address_collection = 'required' to prevent address lock
- Prevents address fields from being locked after payment cancellation
- Maintains tax collection functionality while allowing user overrides

Fixes issue #1764 


**Problem:**
When `calculateTaxes()` is enabled, checkout sessions automatically set `customer_update.address = 'auto'` which causes address fields to become grayed out and uneditable after payment cancellation, in particular with PayPal, which prevents users from completing their purchase.

**Solution:**
Following Stripe's recommendation, we now use `billing_address_collection = 'required'` instead of `customer_update.address = 'auto'` to collect address information without causing the address lock behavior.

**Benefits:**
- Fixes the cancellation address lock issue
- Maintains all existing tax collection functionality  
- Allows overriding of settings when needed

**Testing:**
Added tests to verify the fix works and user overrides are respected.
