### PR TITLE
Fix handling of customer.subscription.updated webhook to prevent 500 error and correctly set ends_at

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -170,7 +170,7 @@ class WebhookController extends Controller
             if ($data['cancel_at_period_end'] ?? false) {
                 $subscription->ends_at = $subscription->onTrial()
                     ? $subscription->trial_ends_at
-                    : Carbon::createFromTimestamp($data['items']['data'][0]['current_period_end']);
+                    : Carbon::createFromTimestamp($data['current_period_end'] ?? $data['items']['data'][0]['current_period_end']);
             } elseif (isset($data['cancel_at']) || isset($data['canceled_at'])) {
                 $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at'] ?? $data['canceled_at']);
             } else {

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -170,7 +170,7 @@ class WebhookController extends Controller
             if ($data['cancel_at_period_end'] ?? false) {
                 $subscription->ends_at = $subscription->onTrial()
                     ? $subscription->trial_ends_at
-                    : Carbon::createFromTimestamp($data['current_period_end']);
+                    : Carbon::createFromTimestamp($data['items']['data'][0]['current_period_end']);
             } elseif (isset($data['cancel_at']) || isset($data['canceled_at'])) {
                 $subscription->ends_at = Carbon::createFromTimestamp($data['cancel_at'] ?? $data['canceled_at']);
             } else {


### PR DESCRIPTION
This pull request fixes an issue in the `WebhookController` where the application would throw a 500 error during the `customer.subscription.updated` event when a subscription was canceled via the Stripe Billing Portal.

The error occurred because the code attempted to access the top-level `current_period_end` key, which is not consistently present in the payload. According to Stripe’s official documentation, the correct value should be taken from the subscription item in `data['items']['data'][0]['current_period_end']`.

**Changes:**

* Updated `handleCustomerSubscriptionUpdated` to safely retrieve `current_period_end` from the first subscription item instead of the top-level object.
* Ensured the `ends_at` field is set correctly when a subscription is not on trial.
* Prevented unexpected 500 errors caused by missing array keys.

**Steps to Reproduce:**

1. Subscribe a user through Stripe.
2. Redirect the user to the Stripe Billing Portal.
3. Cancel the subscription from the Billing Portal.
4. Observe the webhook call to `/stripe/webhook` fails with a 500 error.

**Expected Behavior After Fix:**

* The webhook processes successfully without errors.
* The subscription’s `ends_at` is updated using the correct timestamp from Stripe’s payload.

**Reference:**

* [[Stripe Subscription Object Documentation](https://docs.stripe.com/api/subscriptions/object#:~:text=%3A%201679609768%2C-,%22current_period_end%22%3A%201682288167%2C,-%22current_period_start%22)](https://docs.stripe.com/api/subscriptions/object#:~:text=%3A%201679609768%2C-,%22current_period_end%22%3A%201682288167%2C,-%22current_period_start%22)