### PR TITLE
[16.x] Return PaymentMethod when updating default payment method, if payment method already exist.

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -178,7 +178,6 @@ trait ManagesPaymentMethods
         // If the customer already has the payment method as their default, we can bail out
         // of the call now. We don't need to keep adding the same payment method to this
         // model's account every single time we go through this specific process call.
-        // We will return current PaymentMethod set in invoice settings
         if ($stripePaymentMethod->id === $customer->invoice_settings->default_payment_method) {
             return new PaymentMethod($this, $stripePaymentMethod);
         }

--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -171,13 +171,16 @@ trait ManagesPaymentMethods
 
         $customer = $this->asStripeCustomer();
 
-        $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
+        $stripePaymentMethod = $paymentMethod instanceof StripePaymentMethod
+            ? $paymentMethod
+            : $this->resolveStripePaymentMethod($paymentMethod);
 
         // If the customer already has the payment method as their default, we can bail out
         // of the call now. We don't need to keep adding the same payment method to this
         // model's account every single time we go through this specific process call.
+        // We will return current PaymentMethod set in invoice settings
         if ($stripePaymentMethod->id === $customer->invoice_settings->default_payment_method) {
-            return null;
+            return new PaymentMethod($this, $stripePaymentMethod);
         }
 
         $paymentMethod = $this->addPaymentMethod($stripePaymentMethod);

--- a/tests/Feature/PaymentMethodsTest.php
+++ b/tests/Feature/PaymentMethodsTest.php
@@ -118,6 +118,13 @@ class PaymentMethodsTest extends FeatureTestCase
         $this->assertEquals('4242', $paymentMethod->card->last4);
         $this->assertTrue($user->hasDefaultPaymentMethod());
 
+        $paymentMethod = $user->updateDefaultPaymentMethod($paymentMethod->asStripePaymentMethod());
+
+        $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
+        $this->assertEquals('visa', $paymentMethod->card->brand);
+        $this->assertEquals('4242', $paymentMethod->card->last4);
+        $this->assertTrue($user->hasDefaultPaymentMethod());
+
         $paymentMethod = $user->defaultPaymentMethod();
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);


### PR DESCRIPTION
### Summary

This PR fixes two related issues in `ManagesPaymentMethods::updateDefaultPaymentMethod`:

1. The method declared a return type of `PaymentMethod` but previously returned `null` when the passed payment method was already the customer's default. Returning `null` violated the signature and caused test failures.
2. The method always resolved the passed value via the Stripe API, even when a `Stripe\PaymentMethod` instance was passed — resulting in an unnecessary API call.

### Changes

- If the supplied payment method is already set as the customer's default, we now return a `Laravel\Cashier\PaymentMethod` instance instead of `null`.
- If the caller passes a `Stripe\PaymentMethod` instance, we avoid calling the Stripe API and use the instance directly.
- Updated `test_we_can_set_a_default_payment_method` to assert the "already default" path correctly by calling `updateDefaultPaymentMethod` a second time with the already-attached payment method.
```php
public function updateDefaultPaymentMethod(StripePaymentMethod|string $paymentMethod): PaymentMethod
  {
      {...}
      $stripePaymentMethod = $paymentMethod instanceof StripePaymentMethod
          ? $paymentMethod
          : $this->resolveStripePaymentMethod($paymentMethod);

      // If the customer already has the payment method as their default, we can bail out
      // of the call now. We don't need to keep adding the same payment method to this
      // model's account every single time we go through this specific process call.
      // We will return current PaymentMethod set in invoice settings
      if ($stripePaymentMethod->id === $customer->invoice_settings->default_payment_method) {
          return new PaymentMethod($this, $stripePaymentMethod);
      }

      $paymentMethod = $this->addPaymentMethod($stripePaymentMethod);

      $this->updateStripeCustomer([
          'invoice_settings' => ['default_payment_method' => $paymentMethod->id],
      ]);
      
      {...}
}
```

### Why

- Fixes a type inconsistency and aligns behavior with the method's declared return type.
- Avoids an unnecessary Stripe API retrieval when the caller already has a `Stripe\PaymentMethod` instance.

### Tests

- Updated `tests/Feature/PaymentMethodsTest.php::test_we_can_set_a_default_payment_method` to exercise the newly fixed behavior.
- Run the test suite locally: `vendor/bin/phpunit`.
```php
// tests/Feature/PaymentMethodsTest.php
public function test_we_can_set_a_default_payment_method()
{
     {...}
    $paymentMethod = $user->updateDefaultPaymentMethod($paymentMethod->asStripePaymentMethod());

    $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
    $this->assertEquals('visa', $paymentMethod->card->brand);
    $this->assertEquals('4242', $paymentMethod->card->last4);
    $this->assertTrue($user->hasDefaultPaymentMethod());
    {...}
}
```

### Backwards compatibility

No breaking changes to public API — just fixes behavior and reduces a redundant API call.

