### PR TITLE
Allow for multiple coupons on subscription

### DIFF
--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -31,6 +31,27 @@ trait AllowsCoupons
     public bool $allowPromotionCodes = false;
 
     /**
+     * The coupon IDs being applied.
+     *
+     * @var array|null
+     */
+    public ?array $coupons = null;
+
+    /**
+     * The promotion code IDs being applied.
+     *
+     * @var array|null
+     */
+    public ?array $promotionCodes = null;
+
+    /**
+     * Does the object allow multiple coupons
+     *
+     * @var bool
+     */
+    public bool $allowsMultipleCoupons = false;
+
+    /**
      * The coupon ID to be applied.
      *
      * @param  string  $couponId
@@ -39,6 +60,9 @@ trait AllowsCoupons
     public function withCoupon(string $couponId)
     {
         $this->couponId = $couponId;
+        if ( $this->allowsMultipleCoupons ) {
+            $this->coupons[] = $couponId;
+        }
 
         return $this;
     }
@@ -52,6 +76,9 @@ trait AllowsCoupons
     public function withPromotionCode(string $promotionCodeId)
     {
         $this->promotionCodeId = $promotionCodeId;
+        if ( $this->allowsMultipleCoupons ) {
+            $this->promotionCodes[] = $promotionCodeId;
+        }
 
         return $this;
     }

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -45,7 +45,7 @@ trait AllowsCoupons
     public ?array $promotionCodes = null;
 
     /**
-     * Does the object allow multiple coupons
+     * Does the object allow multiple coupons.
      *
      * @var bool
      */
@@ -60,7 +60,7 @@ trait AllowsCoupons
     public function withCoupon(string $couponId)
     {
         $this->couponId = $couponId;
-        if ( $this->allowsMultipleCoupons ) {
+        if ($this->allowsMultipleCoupons) {
             $this->coupons[] = $couponId;
         }
 
@@ -76,7 +76,7 @@ trait AllowsCoupons
     public function withPromotionCode(string $promotionCodeId)
     {
         $this->promotionCodeId = $promotionCodeId;
-        if ( $this->allowsMultipleCoupons ) {
+        if ($this->allowsMultipleCoupons) {
             $this->promotionCodes[] = $promotionCodeId;
         }
 

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -280,7 +280,7 @@ trait ManagesCustomer
      *
      * @return \Laravel\Cashier\Discount|null
      */
-    public function discount(): ?Discount
+    public function discount(int $index = 0): ?Discount
     {
         // Customer-level discounts are no longer supported, check any active subscription...
         // Try default subscription first, then any active subscription...
@@ -294,8 +294,8 @@ trait ManagesCustomer
         // Use the same expansion logic as the subscription's discount method...
         $stripeSubscription = $subscription->asStripeSubscription(['discounts.promotion_code']);
 
-        if (isset($stripeSubscription->discounts) && ! empty($stripeSubscription->discounts)) {
-            return new Discount($stripeSubscription->discounts[0]);
+        if (isset($stripeSubscription->discounts) && ! empty($stripeSubscription->discounts) && isset($stripeSubscription->discounts[$index])) {
+            return new Discount($stripeSubscription->discounts[$index]);
         }
 
         return null;

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1424,7 +1424,6 @@ class Subscription extends Model
      * The discount that applies to the subscription, if applicable.
      *
      * @param  int  $index
-     *
      * @return \Laravel\Cashier\Discount|null
      */
     public function discount(int $index = 0): ?Discount

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1423,14 +1423,16 @@ class Subscription extends Model
     /**
      * The discount that applies to the subscription, if applicable.
      *
+     * @param  int  $index
+     *
      * @return \Laravel\Cashier\Discount|null
      */
-    public function discount(): ?Discount
+    public function discount(int $index = 0): ?Discount
     {
         $subscription = $this->asStripeSubscription(['discounts.promotion_code']);
 
-        if (isset($subscription->discounts) && ! empty($subscription->discounts)) {
-            return new Discount($subscription->discounts[0]);
+        if (isset($subscription->discounts) && ! empty($subscription->discounts) && isset($subscription->discounts[$index])) {
+            return new Discount($subscription->discounts[$index]);
         }
 
         return null;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -97,6 +97,7 @@ class SubscriptionBuilder
     {
         $this->type = $type;
         $this->owner = $owner;
+        $this->allowsMultipleCoupons = true;
 
         foreach ((array) $prices as $price) {
             $this->price($price);
@@ -450,18 +451,26 @@ class SubscriptionBuilder
         ]);
 
         // Apply discounts using new discounts array (supports multiple discounts)...
-        if ($this->couponId || $this->promotionCodeId) {
+        if ($this->coupons || $this->promotionCodes) {
             $discounts = [];
 
-            if ($this->couponId) {
-                // Validate the coupon before applying...
-                $this->validateCouponForSubscriptionApplication($this->couponId);
+            if ( isset($this->coupons) ) {
+                foreach ($this->coupons as $couponId) {
+                    if ($couponId) {
+                        // Validate the coupon before applying...
+                        $this->validateCouponForSubscriptionApplication($couponId);
 
-                $discounts[] = ['coupon' => $this->couponId];
+                        $discounts[] = ['coupon' => $couponId];
+                    }
+                }
             }
 
-            if ($this->promotionCodeId) {
-                $discounts[] = ['promotion_code' => $this->promotionCodeId];
+            if ( isset($this->promotionCodes) ) {
+                foreach ($this->promotionCodes as $promotionCodeId) {
+                    if ($promotionCodeId) {
+                        $discounts[] = ['promotion_code' => $promotionCodeId];
+                    }
+                }
             }
 
             $payload['discounts'] = $discounts;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -454,7 +454,7 @@ class SubscriptionBuilder
         if ($this->coupons || $this->promotionCodes) {
             $discounts = [];
 
-            if ( isset($this->coupons) ) {
+            if (isset($this->coupons)) {
                 foreach ($this->coupons as $couponId) {
                     if ($couponId) {
                         // Validate the coupon before applying...
@@ -465,7 +465,7 @@ class SubscriptionBuilder
                 }
             }
 
-            if ( isset($this->promotionCodes) ) {
+            if (isset($this->promotionCodes)) {
                 foreach ($this->promotionCodes as $promotionCodeId) {
                     if ($promotionCodeId) {
                         $discounts[] = ['promotion_code' => $promotionCodeId];

--- a/tests/Feature/DiscountTest.php
+++ b/tests/Feature/DiscountTest.php
@@ -29,6 +29,11 @@ class DiscountTest extends FeatureTestCase
     /**
      * @var string
      */
+    protected static $thirdCouponId;
+
+    /**
+     * @var string
+     */
     protected static $promotionCodeId;
 
     /**
@@ -76,6 +81,13 @@ class DiscountTest extends FeatureTestCase
         static::$promotionCodeId = self::stripe()->promotionCodes->create([
             'coupon' => static::$secondCouponId,
             'code' => static::$promotionCodeCode = Str::random(16),
+        ])->id;
+
+        static::$thirdCouponId = self::stripe()->coupons->create([
+            'duration' => 'repeating',
+            'amount_off' => 200,
+            'duration_in_months' => 3,
+            'currency' => 'USD',
         ])->id;
     }
 
@@ -167,6 +179,21 @@ class DiscountTest extends FeatureTestCase
         $this->assertEquals(static::$promotionCodeId, $subscription->discount()->promotionCode()->id);
         $this->assertEquals(static::$secondCouponId, $subscription->discount()->promotionCode()->coupon()->id);
         $this->assertEquals(static::$promotionCodeCode, $subscription->discount()->promotionCode()->code);
+    }
+
+    public function test_applying_multiple_discounts_directly_to_subscriptions()
+    {
+        $user = $this->createCustomer('applying_coupons_to_subscription_directly');
+        $subscriptionBuilder = $user->newSubscription('main', static::$priceId)
+            ->withCoupon(static::$couponId)
+            ->withCoupon(static::$thirdCouponId);
+
+        // Create subscription
+        $subscription = $subscriptionBuilder->create('pm_card_visa');
+
+        $this->assertEquals(2, $subscription->discounts()->count());
+        $this->assertEquals(static::$couponId, $subscription->discount()->coupon()->id);
+        $this->assertEquals(static::$thirdCouponId, $subscription->discount(1)->coupon()->id);
     }
 
     public function test_customers_can_retrieve_a_promotion_code()


### PR DESCRIPTION
Currently you can only attach one coupon when creating a new subscription, even though the Stripe API allows for multiple coupons. 

Currently you would have to do something like this:
```
$subscriptionOptions = [
    'discounts'    => [
        ['coupon' => 'coupon1'],
        ['coupon' => 'coupon2'],
    ]
];

$subscription = $subscriptionBuilder->create('pm_card_visa', [], $subscriptionOptions);
```
instead of using the fluent `withCoupon()` method.

This update allows multiple calls to the `withCoupon()` method and sends all coupons to the subscription builder upon creation. Like so:

```
$user->newSubscription('main', static::$priceId)
    ->withCoupon('coupon1')
    ->withCoupon('coupon2')
    ->create('pm_card_visa');
```

It gracefully handles `Checkout` which still only allows for the single coupon.