### PR TITLE
Fix upcomingInvoice method type declaration violation

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -237,7 +237,7 @@ trait ManagesInvoices
 
             return new Invoice($this, $stripeInvoice, $parameters);
         } catch (StripeInvalidRequestException $exception) {
-            //
+            return null;
         }
     }
 

--- a/tests/Feature/InvoicesTest.php
+++ b/tests/Feature/InvoicesTest.php
@@ -158,4 +158,14 @@ class InvoicesTest extends FeatureTestCase
         $this->assertEquals('1000', $response->pricing->unit_amount_decimal);
         $this->assertEquals(2, $response->quantity);
     }
+
+    public function test_upcoming_invoice_returns_null_when_stripe_api_fails()
+    {
+        $user = $this->createCustomer('upcoming_invoice_api_failure');
+        $user->createAsStripeCustomer();
+
+        $result = $user->upcomingInvoice();
+
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
### Problem
The `upcomingInvoice()` method in v16.0.1 has a return type declaration of `?Invoice` but contains an empty catch block that doesn't return `null` when `StripeInvalidRequestException` is thrown, causing a TypeError.

### Solution
Added explicit `return null;` in the catch block.

### Changes
- `src/Concerns/ManagesInvoices.php`: Fixed empty catch block
- `tests/Feature/InvoicesTest.php`: Added test coverage for API failure scenario

### Impact
This is a minimal fix that resolves a critical type declaration issue.
