### PR TITLE
Remove ray() function call

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -515,8 +515,6 @@ class SubscriptionBuilder
     protected function getPriceTaxRatesForPayload(string|array $price): ?array
     {
         if ($taxRates = $this->owner->priceTaxRates()) {
-            ray($price, $taxRates);
-
             return $taxRates[$price] ?? null;
         }
 


### PR DESCRIPTION
I am in a process of updating a project to Cashier v16. The `ray()` function call fails for me with the error message:

    "Call to undefined function Laravel\Cashier\ray()",

Because [ray ](https://myray.app/) is a paid debugging tool, I assume this is a forgotten statement and it works for people who have ray installed.

If my assumption is wrong, this PR can be closed.