### PR TITLE
Use `Stripe` predefined constants for balance type

### DIFF
--- a/src/CustomerBalanceTransaction.php
+++ b/src/CustomerBalanceTransaction.php
@@ -90,7 +90,7 @@ class CustomerBalanceTransaction
      */
     public function isCheckoutSessionSubscriptionPayment(): bool
     {
-        return $this->transaction->balance_type === 'checkout_session_subscription_payment';
+        return $this->transaction->balance_type === StripeCustomerBalanceTransaction::TYPE_CHECKOUT_SESSION_SUBSCRIPTION_PAYMENT;
     }
 
     /**
@@ -100,7 +100,7 @@ class CustomerBalanceTransaction
      */
     public function isCheckoutSessionSubscriptionPaymentCanceled(): bool
     {
-        return $this->transaction->balance_type === 'checkout_session_subscription_payment_canceled';
+        return $this->transaction->balance_type === StripeCustomerBalanceTransaction::TYPE_CHECKOUT_SESSION_SUBSCRIPTION_PAYMENT_CANCELED;
     }
 
     /**

--- a/tests/Unit/CustomerBalanceTransactionTest.php
+++ b/tests/Unit/CustomerBalanceTransactionTest.php
@@ -13,7 +13,7 @@ class CustomerBalanceTransactionTest extends TestCase
         $stripeTransaction = StripeCustomerBalanceTransaction::constructFrom([
             'id' => 'cbtxn_test_123',
             'object' => 'customer_balance_transaction',
-            'balance_type' => 'checkout_session_subscription_payment',
+            'balance_type' => StripeCustomerBalanceTransaction::TYPE_CHECKOUT_SESSION_SUBSCRIPTION_PAYMENT,
             'checkout_session' => 'cs_test_123',
             'amount' => 1000,
             'currency' => 'usd',
@@ -28,7 +28,7 @@ class CustomerBalanceTransactionTest extends TestCase
 
         $transaction = new CustomerBalanceTransaction($owner, $stripeTransaction);
 
-        $this->assertSame('checkout_session_subscription_payment', $transaction->balanceType());
+        $this->assertSame(StripeCustomerBalanceTransaction::TYPE_CHECKOUT_SESSION_SUBSCRIPTION_PAYMENT, $transaction->balanceType());
         $this->assertSame('cs_test_123', $transaction->checkoutSession());
         $this->assertTrue($transaction->isCheckoutSessionSubscriptionPayment());
         $this->assertFalse($transaction->isCheckoutSessionSubscriptionPaymentCanceled());


### PR DESCRIPTION
This PR refactors balance type checks to use `StripeCustomerBalanceTransaction` predefined constants instead of hardcoded strings for better maintainability and readability.