### PR TITLE
[16.x] Subscribe to invoice.paid event instead of invoice.payment_succeeded.

### DIFF
--- a/src/Console/WebhookCommand.php
+++ b/src/Console/WebhookCommand.php
@@ -17,7 +17,7 @@ class WebhookCommand extends Command
         'customer.deleted',
         'payment_method.automatically_updated',
         'invoice.payment_action_required',
-        'invoice.payment_succeeded',
+        'invoice.paid',
     ];
 
     /**


### PR DESCRIPTION
Essentially, invoice.paid is a superset of invoice.payment_succeeded.  
[From the Stripe docs](https://docs.stripe.com/invoicing/integration#handle-payment-events):
> Successful invoice payments trigger both an [invoice.paid](https://docs.stripe.com/api/events/types?event_types-invoice.paid) and [invoice.payment_succeeded](https://docs.stripe.com/api/events/types?event_types-invoice.payment_succeeded) event. Both event types contain the same invoice data, so it’s only necessary to listen to one of them to be notified of successful invoice payments. The difference is that invoice.payment_succeeded events are sent for successful invoice payments, but aren’t sent when you mark an invoice as [paid_out_of_band](https://docs.stripe.com/api/invoices/pay#pay_invoice-paid_out_of_band). invoice.paid events, on the other hand, are triggered for both successful payments and out of band payments. Because invoice.paid covers both scenarios, we typically recommend listening to invoice.paid rather than invoice.payment_succeeded.

Nothing in Cashier actually relies on either of these events (hence no tests), but if we're subscribing to one of them automatically, it should be the recommended option.