### PR TITLE
[16.x] Taxes on invoice need to be null

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -34,7 +34,7 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      *
      * @var \Laravel\Cashier\Tax[]|null
      */
-    protected array $taxes = null;
+    protected ?array $taxes = null;
 
     /**
      * The payments associated with the invoice.

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -32,9 +32,9 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
     /**
      * The taxes applied to the invoice.
      *
-     * @var \Laravel\Cashier\Tax[]
+     * @var \Laravel\Cashier\Tax[]|null
      */
-    protected array $taxes = [];
+    protected array $taxes = null;
 
     /**
      * The payments associated with the invoice.


### PR DESCRIPTION
We can retrieve taxes on invoice but currently impossible. Invoice check if property is null (so not hydrated) but property is initialized to empty array.
