### PR TITLE
Add workbench to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /.github export-ignore
 /art export-ignore
 /tests export-ignore
+/workbench export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
This pull request makes a small update to the `.gitattributes` file, adding the `/workbench` directory to the list of paths that should be ignored when installing from composer:

<img width="320" height="533" alt="Screenshot 2025-10-23 at 12 04 10 AM" src="https://github.com/user-attachments/assets/ba77acc7-3905-435c-ba40-43ed8897de07" />
