### PR TITLE
[16.x] Fix taxes with stripe sdk 17

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DateTimeZone;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Model;
@@ -431,11 +432,11 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
             return $taxRateDetails->tax_rate;
         }
 
-        // If tax_rate is just an ID string, fetch it from Stripe
+        // If tax_rate is just an ID string, fetch it from Stripe...
         if (isset($taxRateDetails->tax_rate) && is_string($taxRateDetails->tax_rate)) {
             try {
                 return $this->owner->stripe()->taxRates->retrieve($taxRateDetails->tax_rate);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 return null;
             }
         }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -426,7 +426,21 @@ class Invoice implements Arrayable, Jsonable, JsonSerializable
      */
     protected function getTaxRate($taxRateDetails): ?StripeTaxRate
     {
-        return $taxRateDetails->tax_rate instanceof StripeTaxRate ? $taxRateDetails->tax_rate : null;
+        // If tax_rate is already expanded as an object, return it...
+        if ($taxRateDetails->tax_rate instanceof StripeTaxRate) {
+            return $taxRateDetails->tax_rate;
+        }
+
+        // If tax_rate is just an ID string, fetch it from Stripe
+        if (isset($taxRateDetails->tax_rate) && is_string($taxRateDetails->tax_rate)) {
+            try {
+                return $this->owner->stripe()->taxRates->retrieve($taxRateDetails->tax_rate);
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
@@ -235,11 +236,11 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
             return $taxRateDetails->tax_rate;
         }
 
-        // If tax_rate is just an ID string, fetch it from Stripe
+        // If tax_rate is just an ID string, fetch it from Stripe...
         if (isset($taxRateDetails->tax_rate) && is_string($taxRateDetails->tax_rate)) {
             try {
                 return $this->invoice->owner()->stripe()->taxRates->retrieve($taxRateDetails->tax_rate);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 return null;
             }
         }

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -43,7 +43,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
      */
     public function unitAmountExcludingTax(): string
     {
-        return $this->formatAmount($this->item->unit_amount_excluding_tax ?? 0);
+        return $this->formatAmount($this->taxes()->sum('taxable_amount') ?? 0);
     }
 
     /**
@@ -233,6 +233,15 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
         // If tax_rate is already expanded as an object, return it...
         if (isset($taxRateDetails->tax_rate->id) && is_object($taxRateDetails->tax_rate)) {
             return $taxRateDetails->tax_rate;
+        }
+
+        // If tax_rate is just an ID string, fetch it from Stripe
+        if (isset($taxRateDetails->tax_rate) && is_string($taxRateDetails->tax_rate)) {
+            try {
+                return $this->invoice->owner()->stripe()->taxRates->retrieve($taxRateDetails->tax_rate);
+            } catch (\Exception $e) {
+                return null;
+            }
         }
 
         return null;

--- a/src/Tax.php
+++ b/src/Tax.php
@@ -93,7 +93,7 @@ class Tax
      */
     public function __get(string $key)
     {
-        return $this->taxRate instanceof StripeTaxRate && property_exists($this->TaxRate, $key)
+        return $this->taxRate instanceof StripeTaxRate && in_array($key, $this->taxRate->keys())
             ? $this->taxRate->{$key}
             : null;
     }


### PR DESCRIPTION
I see that on 16.x, there is no more taxes on invoices... We are in EU and taxes are important unfortunately...

I think that [#1783](https://github.com/laravel/cashier-stripe/pull/1762) break things because we don't call [refreshWithExpandedData](https://github.com/laravel/cashier-stripe/blob/16.x/src/Invoice.php#L593C24-L593C47) and not work with :

- 'lines.data.taxes.tax_rate_details.tax_rate',
- 'total_taxes.tax_rate_details.tax_rate',

So, I think we need to load stripe rate from API but maybe there is a better method to make that.