### PR TITLE
cancel() return true only in the right circumptance

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -176,7 +176,7 @@ class Subscription extends Model
      */
     public function valid(): bool
     {
-        return $this->active() || $this->onTrial() || $this->onGracePeriod();
+        return !$this->canceled() && ($this->active() || $this->onTrial() || $this->onGracePeriod());
     }
 
     /**
@@ -302,7 +302,7 @@ class Subscription extends Model
      */
     public function canceled(): bool
     {
-        return ! is_null($this->ends_at);
+        return ($this->stripe_status == StripeSubscription::STATUS_CANCELED) || (!is_null($this->ends_at) && !$this->ends_at->isFuture())
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -302,7 +302,7 @@ class Subscription extends Model
      */
     public function canceled(): bool
     {
-        return ($this->stripe_status == StripeSubscription::STATUS_CANCELED) || (!is_null($this->ends_at) && !$this->ends_at->isFuture())
+        return ($this->stripe_status == StripeSubscription::STATUSLED) || (!is_null($this->ends_at) && !$this->ends_at->isFuture());
     }
 
     /**


### PR DESCRIPTION
Also changed valid() to make the canceled status a priority over active() OnGracePeriod() & onTrial()

https://github.com/laravel/cashier-stripe/issues/1791
