### PR TITLE
Fix invoice() exception handling

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -152,7 +152,7 @@ trait ManagesInvoices
             return $invoice->chargesAutomatically() ? $invoice->pay($payOptions) : $invoice->send();
         } catch (StripeCardException $exception) {
             // Get the latest payment from the invoice payments...
-            $stripeInvoice = $invoice->asStripeInvoice()->refresh(['expand' => ['payments']]);
+            $stripeInvoice = $invoice->refresh(['payments']);
 
             $invoicePayments = $stripeInvoice->payments->data;
 

--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -152,7 +152,7 @@ trait ManagesInvoices
             return $invoice->chargesAutomatically() ? $invoice->pay($payOptions) : $invoice->send();
         } catch (StripeCardException $exception) {
             // Get the latest payment from the invoice payments...
-            $stripeInvoice = $invoice->refresh(['payments']);
+            $stripeInvoice = $invoice->refresh(['payments'])->asStripeInvoice();
 
             $invoicePayments = $stripeInvoice->payments->data;
 


### PR DESCRIPTION
Currently, failed `invoice()` payments result in this exception:

```
ErrorException: Attempt to read property "data" on null
```

This is because the `refresh()` method from the Stripe SDK does not accept any parameters and therefore `payments` is not expanded.
The PR fixes this by using the Cashier `refresh()` method.