### PR TITLE
[15.x] improve type hints for collection return types

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -364,7 +364,7 @@ trait ManagesCustomer
      *
      * @param  int  $limit
      * @param  array  $options
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, CustomerBalanceTransaction>
      */
     public function balanceTransactions($limit = 10, array $options = [])
     {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -570,7 +570,7 @@ class Subscription extends Model
      *
      * @param  array  $options
      * @param  string|null  $price
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Stripe\UsageRecordSummary>
      */
     public function usageRecords(array $options = [], $price = null)
     {
@@ -586,7 +586,7 @@ class Subscription extends Model
      *
      * @param  string  $price
      * @param  array  $options
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Stripe\UsageRecordSummary>
      */
     public function usageRecordsFor($price, array $options = [])
     {

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -224,7 +224,7 @@ class SubscriptionItem extends Model
      * Get the usage records for a metered product.
      *
      * @param  array  $options
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, \Stripe\UsageRecordSummary>
      */
     public function usageRecords($options = [])
     {


### PR DESCRIPTION
Add specific type parameters to Illuminate\Support\Collection return types to clarify contained objects