### PR TITLE
Refactor Subscription model to properly handle canceled status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -229,6 +229,7 @@ class Subscription extends Model
     public function active(): bool
     {
         return ! $this->ended() &&
+            $this->stripe_status !== StripeSubscription::STATUS_CANCELED &&
             (! Cashier::$deactivateIncomplete || $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE) &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE_EXPIRED &&
             (! Cashier::$deactivatePastDue || $this->stripe_status !== StripeSubscription::STATUS_PAST_DUE) &&
@@ -248,7 +249,8 @@ class Subscription extends Model
                 ->orWhere(function ($query) {
                     $query->onGracePeriod();
                 });
-        })->where('stripe_status', '!=', StripeSubscription::STATUS_INCOMPLETE_EXPIRED)
+        })->where('stripe_status', '!=', StripeSubscription::STATUS_CANCELED)
+            ->where('stripe_status', '!=', StripeSubscription::STATUS_INCOMPLETE_EXPIRED)
             ->where('stripe_status', '!=', StripeSubscription::STATUS_UNPAID);
 
         if (Cashier::$deactivatePastDue) {
@@ -302,7 +304,7 @@ class Subscription extends Model
      */
     public function canceled(): bool
     {
-        return ! is_null($this->ends_at);
+        return $this->stripe_status === StripeSubscription::STATUS_CANCELED || ! is_null($this->ends_at);
     }
 
     /**
@@ -313,7 +315,10 @@ class Subscription extends Model
      */
     public function scopeCanceled(Builder $query): void
     {
-        $query->whereNotNull('ends_at');
+        $query->where(function ($query) {
+            $query->where('stripe_status', StripeSubscription::STATUS_CANCELED)
+                  ->orWhereNotNull('ends_at');
+        });
     }
 
     /**
@@ -324,7 +329,10 @@ class Subscription extends Model
      */
     public function scopeNotCanceled(Builder $query): void
     {
-        $query->whereNull('ends_at');
+        $query->where(function ($query) {
+            $query->whereNull('ends_at')
+                  ->where('stripe_status', '!=', StripeSubscription::STATUS_CANCELED);
+        });
     }
 
     /**
@@ -355,7 +363,19 @@ class Subscription extends Model
      */
     public function onTrial(): bool
     {
-        return $this->trial_ends_at && $this->trial_ends_at->isFuture();
+        if (! $this->trial_ends_at || ! $this->trial_ends_at->isFuture()) {
+            return false;
+        }
+
+        if ($this->stripe_status === StripeSubscription::STATUS_CANCELED) {
+            return false;
+        }
+
+        if ($this->ends_at && $this->ends_at->isPast()) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -366,7 +386,13 @@ class Subscription extends Model
      */
     public function scopeOnTrial(Builder $query): void
     {
-        $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '>', Carbon::now());
+        $query->whereNotNull('trial_ends_at')
+              ->where('trial_ends_at', '>', Carbon::now())
+              ->where('stripe_status', '!=', StripeSubscription::STATUS_CANCELED)
+              ->where(function ($query) {
+                  $query->whereNull('ends_at')
+                        ->orWhere('ends_at', '>', Carbon::now());
+              });
     }
 
     /**
@@ -408,7 +434,11 @@ class Subscription extends Model
      */
     public function onGracePeriod(): bool
     {
-        return $this->ends_at && $this->ends_at->isFuture();
+        if (! $this->ends_at || ! $this->ends_at->isFuture()) {
+            return false;
+        }
+
+        return $this->stripe_status !== StripeSubscription::STATUS_CANCELED;
     }
 
     /**
@@ -419,7 +449,9 @@ class Subscription extends Model
      */
     public function scopeOnGracePeriod(Builder $query): void
     {
-        $query->whereNotNull('ends_at')->where('ends_at', '>', Carbon::now());
+        $query->whereNotNull('ends_at')
+              ->where('ends_at', '>', Carbon::now())
+              ->where('stripe_status', '!=', StripeSubscription::STATUS_CANCELED);
     }
 
     /**

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -171,4 +171,196 @@ class SubscriptionTest extends TestCase
         $this->assertTrue($subscription->hasMultiplePrices());
         $this->assertFalse($subscription->hasSinglePrice());
     }
+
+    public function test_canceled_returns_true_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => null,
+        ]);
+
+        $this->assertTrue($subscription->canceled());
+    }
+
+    public function test_canceled_returns_true_when_ends_at_is_set()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_ACTIVE;
+        $subscription->ends_at = now()->addDay();
+
+        $this->assertTrue($subscription->canceled());
+    }
+
+    public function test_canceled_returns_true_when_both_status_and_ends_at_are_set()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->ends_at = now()->addDay();
+
+        $this->assertTrue($subscription->canceled());
+    }
+
+    public function test_active_returns_false_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->active());
+    }
+
+    public function test_active_returns_false_when_stripe_status_is_canceled_with_ends_at()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->active());
+    }
+
+    public function test_on_trial_returns_false_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->trial_ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->onTrial());
+    }
+
+    public function test_on_trial_returns_false_when_stripe_status_is_canceled_even_without_trial()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'trial_ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->onTrial());
+    }
+
+    public function test_on_grace_period_returns_false_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->onGracePeriod());
+    }
+
+    public function test_on_grace_period_returns_false_when_stripe_status_is_canceled_even_without_ends_at()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->onGracePeriod());
+    }
+
+    public function test_on_grace_period_returns_true_when_ends_at_is_future_and_status_is_active()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_ACTIVE;
+        $subscription->ends_at = now()->addDay();
+
+        // Should be on grace period when ends_at is in future and not STATUS_CANCELED
+        $this->assertTrue($subscription->onGracePeriod());
+        $this->assertTrue($subscription->canceled()); // Scheduled for cancellation
+        $this->assertTrue($subscription->valid()); // But still valid due to grace period
+    }
+
+    public function test_on_trial_returns_false_when_subscription_is_canceled_with_past_ends_at()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_ACTIVE;
+        $subscription->trial_ends_at = now()->addDay();
+        $subscription->ends_at = now()->subDay(); // Canceled in the past
+
+        // Should not be on trial if canceled (ends_at in past)
+        $this->assertFalse($subscription->onTrial());
+        $this->assertTrue($subscription->canceled());
+        $this->assertFalse($subscription->valid());
+    }
+
+    public function test_on_trial_returns_false_when_canceled_now_with_trial()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->trial_ends_at = now()->addDay();
+        $subscription->ends_at = now(); // Canceled now (current time)
+
+        // Should not be on trial if canceled immediately
+        $this->assertFalse($subscription->onTrial());
+        $this->assertTrue($subscription->canceled());
+        $this->assertFalse($subscription->valid());
+    }
+
+    public function test_valid_returns_false_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->valid());
+    }
+
+    public function test_valid_returns_false_when_stripe_status_is_canceled_with_ends_at()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->valid());
+    }
+
+    public function test_valid_returns_false_when_stripe_status_is_canceled_with_trial()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->trial_ends_at = now()->addDay();
+
+        $this->assertFalse($subscription->valid());
+    }
+
+    public function test_ended_returns_true_when_stripe_status_is_canceled()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'ends_at' => null,
+        ]);
+
+        $this->assertTrue($subscription->ended());
+    }
+
+    public function test_ended_returns_true_when_stripe_status_is_canceled_with_past_ends_at()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_CANCELED;
+        $subscription->ends_at = now()->subDay();
+
+        $this->assertTrue($subscription->ended());
+    }
+
+    public function test_ended_returns_false_when_canceled_via_ends_at_but_still_on_grace_period()
+    {
+        $subscription = new Subscription();
+        $subscription->setDateFormat('Y-m-d H:i:s');
+        $subscription->stripe_status = StripeSubscription::STATUS_ACTIVE;
+        $subscription->ends_at = now()->addDay();
+
+        // Should not be ended because it's on grace period (canceled via ends_at, not STATUS_CANCELED)
+        $this->assertFalse($subscription->ended());
+    }
 }


### PR DESCRIPTION
## Summary
This pull request refines the subscription status logic to ensure that the `stripe_status` field is treated as the source of truth when determining whether a subscription is active, canceled, or within a grace or trial period.

Currently, subscriptions canceled directly via Stripe (for example, when a test clock is canceled or when a subscription is immediately canceled during a trial) may still appear as valid within the application. This happens because the `stripe_status` field isn't consistently considered in status validation methods.

## Changes
- `canceled()` — Now checks `stripe_status` before other attributes (`ends_at`) for clearer intent and correctness.
- `onTrial()` / `onGracePeriod()` — Refactored to use early returns for readability and to align with Laravel’s style conventions.
- Scope Methods — Updated to mirror the instance methods for consistent behavior between query and model contexts.
- Tests — Added dedicated tests covering:
  - Subscriptions canceled via Stripe’s API or test clocks.
  - Immediate cancellations during trial periods.
  - Edge cases around `ends_at` and `trial_ends_at`.

This change ensures that:
- The subscription status reflects the true state in Stripe.
- Users no longer retain access after cancellation.
- Trial and grace periods behave consistently even when canceled early.
- Code readability and maintainability are improved with clearer control flow.

All existing behavior for active and scheduled-cancellation subscriptions remains unchanged.

## Related Issues
#1550 #1791