### PR TITLE
[16.x] Update `SubscriptionItem` quantity of a Single Price subscription.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -542,6 +542,12 @@ class Subscription extends Model
             'quantity' => $stripeSubscription->quantity,
         ])->save();
 
+        $singleSubscriptionItem = $this->items()->firstOrFail();
+
+        $singleSubscriptionItem->fill([
+            'quantity' => $stripeSubscription->quantity,
+        ])->save();
+
         $this->handlePaymentFailure($this);
 
         return $this;

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -975,4 +975,24 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame('paid', $invoice->status);
         $this->assertSame(2000, $invoice->total);
     }
+
+    public function test_updating_single_price_subscription_quantity_updates_the_quantity_of_the_subscription_item(){
+        $user = $this->createCustomer('invoice_subscription_directly');
+        
+        $subscription = $user->newSubscription('main', static::$priceId)
+            ->create('pm_card_visa');
+
+        $subscription->updateQuantity(2);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'quantity' => 2,
+        ]);
+        
+        $this->assertDatabaseHas('subscription_items', [
+            'subscription_id' => $subscription->id,
+            'stripe_price' => static::$priceId,
+            'quantity' => 2,
+        ]);
+    }
 }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -976,9 +976,10 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame(2000, $invoice->total);
     }
 
-    public function test_updating_single_price_subscription_quantity_updates_the_quantity_of_the_subscription_item(){
+    public function test_updating_single_price_subscription_quantity_updates_the_quantity_of_the_subscription_item()
+    {
         $user = $this->createCustomer('invoice_subscription_directly');
-        
+
         $subscription = $user->newSubscription('main', static::$priceId)
             ->create('pm_card_visa');
 
@@ -988,7 +989,7 @@ class SubscriptionsTest extends FeatureTestCase
             'id' => $subscription->id,
             'quantity' => 2,
         ]);
-        
+
         $this->assertDatabaseHas('subscription_items', [
             'subscription_id' => $subscription->id,
             'stripe_price' => static::$priceId,


### PR DESCRIPTION
When a `Subscription` contains only a single price, updating the subscription’s quantity does not update the corresponding `SubscriptionItem`. This results in inconsistencies between the two models.

This PR ensures that, for single-price subscriptions, the associated `SubscriptionItem` is updated whenever the Subscription’s quantity changes. This allows applications to rely on `SubscriptionItem` consistently, even in environments with a mix of single-price and multi-price subscriptions.