### PR TITLE
Feature/subscription subscribed any support

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -139,11 +139,11 @@ trait ManagesSubscriptions
     {
         if (! $any) {
             $subscription = $this->subscription($type);
-    
+
             if (! $subscription || ! $subscription->valid()) {
                 return false;
             }
-    
+
             return ! $price || $subscription->hasPrice($price);
         }
 

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -135,15 +135,25 @@ trait ManagesSubscriptions
      * @param  string|null  $price
      * @return bool
      */
-    public function subscribed(string $type = 'default', ?string $price = null): bool
+    public function subscribed(string $type = 'default', ?string $price = null, $any = false): bool
     {
-        $subscription = $this->subscription($type);
-
-        if (! $subscription || ! $subscription->valid()) {
-            return false;
+        if (! $any) {
+            $subscription = $this->subscription($type);
+    
+            if (! $subscription || ! $subscription->valid()) {
+                return false;
+            }
+    
+            return ! $price || $subscription->hasPrice($price);
         }
 
-        return ! $price || $subscription->hasPrice($price);
+        return (bool) $this->subscriptions->where('type', $type)->first(function (Subscription $subscription) use ($price) {
+            if (! $subscription->valid()) {
+                return false;
+            }
+
+            return ! $price || $subscription->hasPrice($price);
+        });
     }
 
     /**

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -996,4 +996,39 @@ class SubscriptionsTest extends FeatureTestCase
             'quantity' => 2,
         ]);
     }
+
+    public function test_subscribed_check_with_multiple_subscriptions()
+    {
+        $user = $this->createCustomer('test_subscribed_check_with_multiple_subscriptions');
+
+        // Case 1 & 2: Newest Active, Oldest Inactive
+        $subscriptionOld = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+        $subscriptionOld->cancelNow();
+
+        $subscriptionNew = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $user->refresh();
+
+        // 1. Two subscriptions do not use any, newest active, oldest inactive, should result in true
+        $this->assertTrue($user->subscribed('main'));
+
+        // 2. Two subscriptions do use any, newest active, oldest inactive, should result in true
+        $this->assertTrue($user->subscribed('main', null, true));
+
+        // Case 3 & 4: Newest Inactive, Oldest Active
+        $user = $this->createCustomer('test_subscribed_check_with_multiple_subscriptions_2');
+
+        $subscriptionOld = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $subscriptionNew = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+        $subscriptionNew->cancelNow();
+
+        $user->refresh();
+
+        // 3. Two subscriptions do not use any, Newest is inactive, oldest is active, should result in false
+        $this->assertFalse($user->subscribed('main'));
+
+        // 4. Tow subscriptions does use any, Newest is inactive, oldest is active, should result in true
+        $this->assertTrue($user->subscribed('main', null, true));
+    }
 }


### PR DESCRIPTION
This pull request is related to the issue I have opened here: https://github.com/laravel/cashier-stripe/issues/1805

To summarise I found out that when working with multiple subscription of the same type the `subscribed` functions within the train `ManagesSubscriptions` does not work as intended. It might be that I am the only one or the  one of a small group of people using it like this so I have created an extra parameter to solve this. The default behaviour should stay the same while also solving the issue for users experiencing the same challenge.

I think this issue only plays for platforms that allow for a user entity to have multiple of the same subscriptions for instance when an organisation has multiple subscriptions where there are scales of a subscription allows 10 devices to be connected and the more expensive 50. If the user requires only 20 devices it might be that two basic subscriptions are taken.