### PR TITLE
[16.x] refactor: allow null coupon and promotion code IDs

### DIFF
--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -33,10 +33,9 @@ trait AllowsCoupons
     /**
      * The coupon ID to be applied.
      *
-     * @param  string  $couponId
      * @return $this
      */
-    public function withCoupon(string $couponId)
+    public function withCoupon(string|null $couponId)
     {
         $this->couponId = $couponId;
 
@@ -46,10 +45,9 @@ trait AllowsCoupons
     /**
      * The promotion code ID to apply.
      *
-     * @param  string  $promotionCodeId
      * @return $this
      */
-    public function withPromotionCode(string $promotionCodeId)
+    public function withPromotionCode(string|null $promotionCodeId)
     {
         $this->promotionCodeId = $promotionCodeId;
 

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -11,15 +11,11 @@ trait AllowsCoupons
 
     /**
      * The coupon ID being applied.
-     *
-     * @var string|null
      */
     public ?string $couponId = null;
 
     /**
      * The promotion code ID being applied.
-     *
-     * @var string|null
      */
     public ?string $promotionCodeId = null;
 
@@ -35,7 +31,7 @@ trait AllowsCoupons
      *
      * @return $this
      */
-    public function withCoupon(string|null $couponId)
+    public function withCoupon(?string $couponId)
     {
         $this->couponId = $couponId;
 
@@ -47,7 +43,7 @@ trait AllowsCoupons
      *
      * @return $this
      */
-    public function withPromotionCode(string|null $promotionCodeId)
+    public function withPromotionCode(?string $promotionCodeId)
     {
         $this->promotionCodeId = $promotionCodeId;
 

--- a/tests/Feature/VerifyWebhookSignatureTest.php
+++ b/tests/Feature/VerifyWebhookSignatureTest.php
@@ -65,8 +65,7 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('Timestamp outside the tolerance zone');
 
         $response = (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {
-            });
+            ->handle($this->request, function ($request) {});
     }
 
     public function test_app_aborts_when_timestamp_is_invalid()
@@ -78,8 +77,7 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('Unable to extract timestamp and signatures from header');
 
         $response = (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {
-            });
+            ->handle($this->request, function ($request) {});
     }
 
     public function test_app_aborts_when_secret_does_not_match()
@@ -91,8 +89,7 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
         (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {
-            });
+            ->handle($this->request, function ($request) {});
     }
 
     public function test_app_aborts_when_no_secret_was_provided()
@@ -104,8 +101,7 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
         (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {
-            });
+            ->handle($this->request, function ($request) {});
     }
 
     public function withTimestamp($timestamp)

--- a/tests/Feature/VerifyWebhookSignatureTest.php
+++ b/tests/Feature/VerifyWebhookSignatureTest.php
@@ -65,7 +65,8 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('Timestamp outside the tolerance zone');
 
         $response = (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {});
+            ->handle($this->request, function ($request) {
+            });
     }
 
     public function test_app_aborts_when_timestamp_is_invalid()
@@ -77,7 +78,8 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('Unable to extract timestamp and signatures from header');
 
         $response = (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {});
+            ->handle($this->request, function ($request) {
+            });
     }
 
     public function test_app_aborts_when_secret_does_not_match()
@@ -89,7 +91,8 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
         (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {});
+            ->handle($this->request, function ($request) {
+            });
     }
 
     public function test_app_aborts_when_no_secret_was_provided()
@@ -101,7 +104,8 @@ class VerifyWebhookSignatureTest extends TestCase
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
         (new VerifyWebhookSignature())
-            ->handle($this->request, function ($request) {});
+            ->handle($this->request, function ($request) {
+            });
     }
 
     public function withTimestamp($timestamp)


### PR DESCRIPTION
Update method signatures to accept null values for couponId and promotionCodeId parameters to handle cases where these values might be unset

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
