### PR TITLE
Add support for `ui_mode: custom` in Stripe Checkout Sessions

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -85,8 +85,8 @@ class Checkout implements Arrayable, Jsonable, JsonSerializable, Responsable
             $data['subscription_data']['metadata']['is_on_session_checkout'] = true;
         }
 
-        // Remove success and cancel URLs if "ui_mode" is "embedded"...
-        if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
+        // Remove success and cancel URLs if "ui_mode" is "embedded" or "custom"...
+        if (isset($data['ui_mode']) && in_array($data['ui_mode'], ['embedded', 'custom'])) {
             $data['return_url'] = $sessionOptions['return_url'] ?? route('home');
 
             // Remove return URL for embedded UI mode when no redirection is desired on completion...

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -200,6 +200,28 @@ class CheckoutTest extends FeatureTestCase
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
 
+    public function test_customers_can_start_a_custom_product_checkout_session()
+    {
+        $user = $this->createCustomer('customers_can_start_a_custom_product_checkout_session');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $items = [$shirtPrice->id => 5];
+
+        $checkout = $user->checkout($items, [
+            'ui_mode' => 'custom',
+            'return_url' => 'http://example.com',
+        ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
+
     public function test_checkout_prevents_address_lock_when_tax_collection_enabled()
     {
         // Enable tax calculation globally

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -207,7 +207,7 @@ class CheckoutTest extends FeatureTestCase
         $shirtPrice = self::stripe()->prices->create([
             'currency' => 'USD',
             'product_data' => [
-                'name' => 'T-shirt',
+                'name' => 'T-Shirt',
             ],
             'unit_amount' => 1500,
         ]);


### PR DESCRIPTION
Currently, Cashier treats `ui_mode: custom` the same as hosted mode, causing it to incorrectly require `success_url`/`cancel_url`, and generate errors such as:

- `Route [home] not defined.`
- `The following parameters are not supported with 'ui_mode: custom': cancel_url, success_url.`
- See https://github.com/laravel/cashier-stripe/issues/1780

This PR ensures `custom` sessions are handled the same way as `embedded` sessions and return the Stripe session object as expected:

```diff
- if (isset($data['ui_mode']) && $data['ui_mode'] === 'embedded') {
+ if (isset($data['ui_mode']) && in_array($data['ui_mode'], ['embedded', 'custom'])) {
    $data['return_url'] = $sessionOptions['return_url'] ?? route('home');

    // Remove return URL for embedded UI mode when no redirection is desired on completion...
    if (isset($data['redirect_on_completion']) && $data['redirect_on_completion'] === 'never') {
        unset($data['return_url']);
    }
} else {
    $data['success_url'] = $sessionOptions['success_url'] ?? route('home').'?checkout=success';
    $data['cancel_url'] = $sessionOptions['cancel_url'] ?? route('home').'?checkout=cancelled';
}
```