### PR TITLE
Avoids Stripe error removing metered price from flex sub

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1023,7 +1023,7 @@ class Subscription extends Model
         $stripeItem = $this->findItemOrFail($price)->asStripeSubscriptionItem();
 
         $stripeItem->delete(array_filter([
-            'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' && !$this->usesFlexibleBilling() ? true : null,
+            'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' && ! $this->usesFlexibleBilling() ? true : null,
             'proration_behavior' => $this->prorateBehavior(),
         ]));
 
@@ -1585,15 +1585,14 @@ class Subscription extends Model
     }
 
     /**
-     * Ascertain if the subscription uses the new flexible billing mode
+     * Ascertain if the subscription uses the new flexible billing mode.
      *
-     * @param StripeSubscription|null $subscription
-     *
+     * @param  StripeSubscription|null  $subscription
      * @return bool
      */
     public function usesFlexibleBilling(?StripeSubscription $subscription = null): bool
     {
-        if (!$subscription) {
+        if (! $subscription) {
             $subscription = $this->asStripeSubscription();
         }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -831,6 +831,7 @@ class Subscription extends Model
     protected function mergeItemsThatShouldBeDeletedDuringSwap(Collection $items): Collection
     {
         $stripeSubscription = $this->asStripeSubscription();
+
         /** @var \Stripe\SubscriptionItem $stripeSubscriptionItem */
         foreach ($stripeSubscription->items->data as $stripeSubscriptionItem) {
             $price = $stripeSubscriptionItem->price;
@@ -1575,16 +1576,6 @@ class Subscription extends Model
     }
 
     /**
-     * Create a new factory instance for the model.
-     *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
-     */
-    protected static function newFactory()
-    {
-        return SubscriptionFactory::new();
-    }
-
-    /**
      * Ascertain if the subscription uses the new flexible billing mode.
      *
      * @param  StripeSubscription|null  $subscription
@@ -1597,5 +1588,15 @@ class Subscription extends Model
         }
 
         return $subscription->billing_mode->type == 'flexible';
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    protected static function newFactory()
+    {
+        return SubscriptionFactory::new();
     }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -830,14 +830,15 @@ class Subscription extends Model
      */
     protected function mergeItemsThatShouldBeDeletedDuringSwap(Collection $items): Collection
     {
+        $stripeSubscription = $this->asStripeSubscription();
         /** @var \Stripe\SubscriptionItem $stripeSubscriptionItem */
-        foreach ($this->asStripeSubscription()->items->data as $stripeSubscriptionItem) {
+        foreach ($stripeSubscription->items->data as $stripeSubscriptionItem) {
             $price = $stripeSubscriptionItem->price;
 
             if (! $item = $items->get($price->id, [])) {
                 $item['deleted'] = true;
 
-                if ($price->recurring->usage_type == 'metered') {
+                if ($price->recurring->usage_type == 'metered' && $this->usesFlexibleBilling($stripeSubscription)) {
                     $item['clear_usage'] = true;
                 }
             }
@@ -1022,7 +1023,7 @@ class Subscription extends Model
         $stripeItem = $this->findItemOrFail($price)->asStripeSubscriptionItem();
 
         $stripeItem->delete(array_filter([
-            'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' ? true : null,
+            'clear_usage' => $stripeItem->price->recurring->usage_type === 'metered' && !$this->usesFlexibleBilling() ? true : null,
             'proration_behavior' => $this->prorateBehavior(),
         ]));
 
@@ -1581,5 +1582,21 @@ class Subscription extends Model
     protected static function newFactory()
     {
         return SubscriptionFactory::new();
+    }
+
+    /**
+     * Ascertain if the subscription uses the new flexible billing mode
+     *
+     * @param StripeSubscription|null $subscription
+     *
+     * @return bool
+     */
+    public function usesFlexibleBilling(?StripeSubscription $subscription = null): bool
+    {
+        if (!$subscription) {
+            $subscription = $this->asStripeSubscription();
+        }
+
+        return $subscription->billing_mode->type == 'flexible';
     }
 }


### PR DESCRIPTION
This addresses the issue raised in Issue #1819 and referenced in PR #1772 [comment here](https://github.com/laravel/cashier-stripe/pull/1772#issuecomment-3488337549) until PR is merged or alternative support for flexible billing is provided.
