### PR TITLE
Only use clear_usage when billing mode is not flexible

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -839,7 +839,7 @@ class Subscription extends Model
             if (! $item = $items->get($price->id, [])) {
                 $item['deleted'] = true;
 
-                if ($price->recurring->usage_type == 'metered' && $this->usesFlexibleBilling($stripeSubscription)) {
+                if ($price->recurring->usage_type == 'metered' && ! $this->usesFlexibleBilling($stripeSubscription)) {
                     $item['clear_usage'] = true;
                 }
             }


### PR DESCRIPTION
The current condition is the reverse of what is expected. What’s expected is that when the billing mode is flexible, clear_usage should not be used. Hence, operations like swapAndInvoice would still fail when removing a metered price in a flexible subscription.

This PR negates the `usesFlexibleBilling` so that it would be `true` when the billing mode is not flexible.