### PR TITLE
[16.x] Fix: trial_ends_at not cleared when trial_end is null in subscription webhook

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -158,12 +158,14 @@ class WebhookController extends Controller
             $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
 
             // Trial ending date...
-            if (isset($data['trial_end'])) {
+            if (array_key_exists('trial_end', $data) && !is_null($data['trial_end'])) {
                 $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
 
                 if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
                     $subscription->trial_ends_at = $trialEnd;
                 }
+            } else {
+                $subscription->trial_ends_at = null;
             }
 
             // Cancellation date...

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -158,7 +158,7 @@ class WebhookController extends Controller
             $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
 
             // Trial ending date...
-            if (array_key_exists('trial_end', $data) && !is_null($data['trial_end'])) {
+            if (array_key_exists('trial_end', $data) && ! is_null($data['trial_end'])) {
                 $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
 
                 if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -343,4 +343,55 @@ class WebhooksTest extends FeatureTestCase
             });
         }
     }
+
+    public function test_trial_ends_at_is_cleared_when_trial_end_is_null()
+    {
+        $user = $this->createCustomer('trial_ends_at_cleared', ['stripe_id' => 'cus_foo']);
+
+        $trialEndsAt = Carbon::now()->addDays(7);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_price' => 'price_foo',
+            'stripe_status' => StripeSubscription::STATUS_ACTIVE,
+            'trial_ends_at' => $trialEndsAt,
+        ]);
+
+        $subscription->items()->create([
+            'stripe_id' => 'it_'.Str::random(10),
+            'stripe_product' => 'prod_bar',
+            'stripe_price' => 'price_foo',
+            'quantity' => 1,
+        ]);
+
+        $this->assertTrue($subscription->onTrial());
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.updated',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'trial_end' => null,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
+                            'quantity' => 1,
+                        ]],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'trial_ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->fresh()->onTrial());
+    }
 }


### PR DESCRIPTION
When a subscription's trial ends, Stripe sends a webhook with trial_end: null. The WebhookController was using isset(), which returns false for null values, so the local trial_ends_at column never got cleared.

This left stale future timestamps in the database, causing onTrial() to return true incorrectly.

Fixed by changing the check to array_key_exists() with explicit null handling.

Thanks to @xjavun for discovering and suggesting the fix.

Fixes [#1824](https://github.com/laravel/cashier-stripe/issues/1824)