### PR TITLE
Fix: Add support for Stripe Source in fillSourceDetails

### DIFF
--- a/src/Concerns/ManagesPaymentMethods.php
+++ b/src/Concerns/ManagesPaymentMethods.php
@@ -8,6 +8,7 @@ use Laravel\Cashier\PaymentMethod;
 use Stripe\BankAccount as StripeBankAccount;
 use Stripe\Card as StripeCard;
 use Stripe\PaymentMethod as StripePaymentMethod;
+use Stripe\Source as StripeSource;
 
 trait ManagesPaymentMethods
 {
@@ -247,13 +248,13 @@ trait ManagesPaymentMethods
     /**
      * Fills the model's properties with the source from Stripe.
      *
-     * @param  \Stripe\Card|\Stripe\BankAccount|null  $source
+     * @param  \Stripe\Card|\Stripe\BankAccount|\Stripe\Source|null  $source
      * @return $this
      *
      * @deprecated Will be removed in a future Cashier update. You should use the new payment methods API instead.
      */
     #[\Deprecated('Will be removed in a future Cashier update. You should use the new payment methods API instead')]
-    protected function fillSourceDetails(StripeCard|StripeBankAccount|null $source)
+    protected function fillSourceDetails(StripeCard|StripeBankAccount|StripeSource|null $source)
     {
         if ($source instanceof StripeCard) {
             $this->pm_type = $source->brand;
@@ -261,6 +262,9 @@ trait ManagesPaymentMethods
         } elseif ($source instanceof StripeBankAccount) {
             $this->pm_type = 'Bank Account';
             $this->pm_last_four = $source->last4;
+        } elseif ($source instanceof StripeSource) {
+            $this->pm_type = $source->card->brand ?? $source->type ?? null;
+            $this->pm_last_four = $source->card->last4 ?? null;
         }
 
         return $this;


### PR DESCRIPTION
defaultPaymentMethod() already returns legacy Source objects (line 159), but fillSourceDetails() only accepts Card|BankAccount, causing a TypeError when updateDefaultPaymentMethodFromStripe() is called for customers with legacy Source payment methods (e.g. created before Stripe's PaymentMethod API migration).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
