### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/cashier-stripe-development/SKILL.blade.php
+++ b/resources/boost/skills/cashier-stripe-development/SKILL.blade.php
@@ -11,16 +11,6 @@ metadata:
 
 # Cashier Stripe Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Installing or configuring Laravel Cashier Stripe
-- Setting up subscriptions, trials, quantities, or plan swapping
-- Handling webhooks or SCA/3DS payment failures
-- Working with Stripe Checkout, invoices, or charges
-- Testing billing scenarios with Stripe test cards or tokens
-
 ## Documentation
 
 Use `search-docs` for detailed Cashier patterns and documentation covering subscriptions, webhooks, Stripe Checkout, invoices, payment methods, and testing.


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Cashier Stripe skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.