### PR TITLE
Update Symfony deps versions to support v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "moneyphp/money": "^4.0",
         "nesbot/carbon": "^2.0|^3.0",
         "stripe/stripe-php": "^17.3.0",
-        "symfony/console": "^6.0|^7.0",
-        "symfony/http-kernel": "^6.0|^7.0",
+        "symfony/console": "^6.0|^7.0|^8.0",
+        "symfony/http-kernel": "^6.0|^7.0|^8.0",
         "symfony/polyfill-intl-icu": "^1.22.1",
         "symfony/polyfill-php84": "^1.32"
     },


### PR DESCRIPTION
Updates Symfony versions to allow v8. without this , the installation fails on laravel 13 projects.

Fixes #1831 