### PR TITLE
Fix WebhookController failing to clear trial_ends_at when trial_end is null (fixes laravel/cashier-stripe#1824)

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -71,7 +71,7 @@ class WebhookController extends Controller
             $data = $payload['data']['object'];
 
             if (! $user->subscriptions->contains('stripe_id', $data['id'])) {
-                if (isset($data['trial_end'])) {
+                if (array_key_exists('trial_end', $data) && ! is_null($data['trial_end'])) {
                     $trialEndsAt = Carbon::createFromTimestamp($data['trial_end']);
                 } else {
                     $trialEndsAt = null;
@@ -158,11 +158,15 @@ class WebhookController extends Controller
             $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
 
             // Trial ending date...
-            if (isset($data['trial_end'])) {
-                $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
+            if (array_key_exists('trial_end', $data)) {
+                if (is_null($data['trial_end'])) {
+                    $subscription->trial_ends_at = null;
+                } else {
+                    $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
 
-                if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
-                    $subscription->trial_ends_at = $trialEnd;
+                    if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
+                        $subscription->trial_ends_at = $trialEnd;
+                    }
                 }
             }
 

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -87,6 +87,85 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
+    public function test_subscription_created_with_null_trial_end_sets_null_trial()
+    {
+        $user = $this->createCustomer('subscription_created_null_trial', ['stripe_id' => 'cus_foo']);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.created',
+            'data' => [
+                'object' => [
+                    'id' => 'sub_foo',
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'quantity' => 1,
+                    'trial_end' => null,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
+                            'quantity' => 1,
+                        ]],
+                    ],
+                    'status' => 'active',
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'user_id' => $user->id,
+            'stripe_id' => 'sub_foo',
+            'trial_ends_at' => null,
+        ]);
+    }
+
+    public function test_subscription_updated_with_null_trial_end_clears_trial()
+    {
+        $user = $this->createCustomer('subscription_updated_null_trial', ['stripe_id' => 'cus_foo']);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_price' => 'price_foo',
+            'stripe_status' => StripeSubscription::STATUS_ACTIVE,
+            'trial_ends_at' => Carbon::now()->addDays(14),
+        ]);
+
+        $subscription->items()->create([
+            'stripe_id' => 'it_'.Str::random(10),
+            'stripe_product' => 'prod_bar',
+            'stripe_price' => 'price_foo',
+            'quantity' => 1,
+        ]);
+
+        // Simulate a webhook where Stripe sends trial_end as null (trial removed)
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.updated',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'trial_end' => null,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
+                            'quantity' => 1,
+                        ]],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $subscription->refresh();
+
+        $this->assertNull($subscription->trial_ends_at, 'trial_ends_at should be cleared when Stripe sends trial_end as null.');
+        $this->assertFalse($subscription->onTrial(), 'Subscription should no longer be on trial.');
+    }
+
     public function test_subscriptions_are_updated()
     {
         $user = $this->createCustomer('subscriptions_are_updated', ['stripe_id' => 'cus_foo']);


### PR DESCRIPTION
## Summary

Fixes laravel/cashier-stripe#1824 — `WebhookController` fails to clear `trial_ends_at` when Stripe sends `trial_end: null` in webhook payloads, causing stale trial data and downstream failures.

## Steps to Reproduce

1. Create a subscription with a trial period
2. Wait for the trial to end (or advance a Stripe Test Clock)
3. Stripe sends `customer.subscription.updated` with `"status": "active"` and `"trial_end": null`
4. Check the `subscriptions` table — `trial_ends_at` still contains the old timestamp
5. `$subscription->onTrial()` returns `true` erroneously
6. `$subscription->resume()` fails with a 400 from Stripe (sends stale trial_end date)

## Before (Bug)

The webhook handler uses `isset($data['trial_end'])` to check if `trial_ends_at` should be updated. In PHP, `isset(null)` returns `false`. When Stripe sends `trial_end: null` (trial ended), the update block is skipped entirely, leaving stale trial data in the local database.

## After (Fix)

Replaced `isset()` with `array_key_exists()` in both `handleCustomerSubscriptionCreated` and `handleCustomerSubscriptionUpdated`. When `trial_end` is `null`, `trial_ends_at` is explicitly set to `null` in the database.

## Root Cause

PHP's `isset()` returns `false` for `null` values, even when the key exists in the array. The webhook handler relied on `isset()` to detect the presence of `trial_end`, but this fails for the `null` case that Stripe sends when a trial ends.

## The Fix

- Changed `isset($data['trial_end'])` to `array_key_exists('trial_end', $data)` in both webhook handlers
- Added explicit null handling: when `trial_end` is `null`, set `trial_ends_at` to `null`
- In `handleCustomerSubscriptionCreated`: added `&& !is_null()` guard for timestamp creation

## Breaking Changes

None.

## Files Changed

- `src/Http/Controllers/WebhookController.php` — Replaced `isset()` with `array_key_exists()` and added null handling (+8/-3)
- `tests/Feature/WebhooksTest.php` — 2 regression tests for null trial_end handling (+79 lines)

## Test Results

- `test_subscription_created_with_null_trial_end_sets_null_trial` — passes
- `test_subscription_updated_with_null_trial_end_clears_trial` — passes
- All existing webhook tests continue to pass