### PR TITLE
fix: correctly calculate unit amount excluding tax based on tax behavior

### DIFF
--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -44,7 +44,17 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
      */
     public function unitAmountExcludingTax(): string
     {
-        return $this->formatAmount($this->taxes()->sum('taxable_amount') ?? 0);
+        // taxable_amount is the pre-tax total when tax is inclusive.
+        $inclusiveTax = $this->taxes()
+            ->first(fn (object $tax) => ($tax->tax_behavior ?? null) === 'inclusive');
+
+        if ($inclusiveTax !== null) {
+            $quantity = (int) ($this->item->quantity ?? 1);
+
+            return $this->formatAmount((int) round($inclusiveTax->taxable_amount / $quantity));
+        }
+
+        return $this->formatAmount($this->unitAmount() ?? 0);
     }
 
     /**

--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -44,7 +44,7 @@ class InvoiceLineItem implements Arrayable, Jsonable, JsonSerializable
      */
     public function unitAmountExcludingTax(): string
     {
-        // taxable_amount is the pre-tax total when tax is inclusive.
+        // taxable_amount is the pre-tax total when tax is inclusive...
         $inclusiveTax = $this->taxes()
             ->first(fn (object $tax) => ($tax->tax_behavior ?? null) === 'inclusive');
 

--- a/tests/Unit/InvoiceLineItemTest.php
+++ b/tests/Unit/InvoiceLineItemTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Unit;
 
 use App\Models\User;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Invoice;
 use Laravel\Cashier\InvoiceLineItem;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Stripe\Customer as StripeCustomer;
 use Stripe\Invoice as StripeInvoice;
 use Stripe\InvoiceLineItem as StripeInvoiceLineItem;
@@ -15,6 +17,21 @@ use Stripe\TaxRate as StripeTaxRate;
 
 class InvoiceLineItemTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cashier::formatCurrencyUsing(fn ($amount) => '$'.number_format($amount / 100, 2));
+    }
+
+    protected function tearDown(): void
+    {
+        $property = new ReflectionProperty(Cashier::class, 'formatCurrencyUsing');
+        $property->setValue(null, null);
+
+        parent::tearDown();
+    }
+
     public function test_we_can_calculate_the_inclusive_tax_percentage()
     {
         $customer = new User();
@@ -63,6 +80,122 @@ class InvoiceLineItemTest extends TestCase
         $result = $item->exclusiveTaxPercentage();
 
         $this->assertSame(37.13, $result);
+    }
+
+    public function test_unit_amount_excluding_tax_with_no_taxes()
+    {
+        $customer = new User();
+        $customer->stripe_id = 'foo';
+
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+
+        $invoice = new Invoice($customer, $stripeInvoice);
+
+        $stripeInvoiceLineItem = StripeInvoiceLineItem::constructFrom([
+            'currency' => 'usd',
+            'quantity' => 1,
+            'taxes' => [],
+            'pricing' => [
+                'type' => 'price_details',
+                'unit_amount_decimal' => '1000',
+            ],
+        ]);
+
+        $item = new InvoiceLineItem($invoice, $stripeInvoiceLineItem);
+
+        $this->assertSame('$10.00', $item->unitAmountExcludingTax());
+    }
+
+    public function test_unit_amount_excluding_tax_with_inclusive_tax()
+    {
+        $customer = new User();
+        $customer->stripe_id = 'foo';
+
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+
+        $invoice = new Invoice($customer, $stripeInvoice);
+
+        $stripeInvoiceLineItem = StripeInvoiceLineItem::constructFrom([
+            'currency' => 'usd',
+            'quantity' => 1,
+            'taxes' => [
+                [
+                    'type' => 'tax_rate_details',
+                    'amount' => 9,
+                    'tax_behavior' => 'inclusive',
+                    'taxable_amount' => 91,
+                    'tax_rate_details' => ['tax_rate' => 'txr_test'],
+                ],
+            ],
+        ]);
+
+        $item = new InvoiceLineItem($invoice, $stripeInvoiceLineItem);
+
+        $this->assertSame('$0.91', $item->unitAmountExcludingTax());
+    }
+
+    public function test_unit_amount_excluding_tax_with_exclusive_tax()
+    {
+        $customer = new User();
+        $customer->stripe_id = 'foo';
+
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+
+        $invoice = new Invoice($customer, $stripeInvoice);
+
+        $stripeInvoiceLineItem = StripeInvoiceLineItem::constructFrom([
+            'currency' => 'usd',
+            'quantity' => 1,
+            'taxes' => [
+                [
+                    'type' => 'tax_rate_details',
+                    'amount' => 200,
+                    'tax_behavior' => 'exclusive',
+                    'taxable_amount' => 1000,
+                    'tax_rate_details' => ['tax_rate' => 'txr_test'],
+                ],
+            ],
+            'pricing' => [
+                'type' => 'price_details',
+                'unit_amount_decimal' => '1000',
+            ],
+        ]);
+
+        $item = new InvoiceLineItem($invoice, $stripeInvoiceLineItem);
+
+        $this->assertSame('$10.00', $item->unitAmountExcludingTax());
+    }
+
+    public function test_unit_amount_excluding_tax_divides_by_quantity_for_inclusive_tax()
+    {
+        $customer = new User();
+        $customer->stripe_id = 'foo';
+
+        $stripeInvoice = new StripeInvoice();
+        $stripeInvoice->customer = 'foo';
+
+        $invoice = new Invoice($customer, $stripeInvoice);
+
+        $stripeInvoiceLineItem = StripeInvoiceLineItem::constructFrom([
+            'currency' => 'usd',
+            'quantity' => 2,
+            'taxes' => [
+                [
+                    'type' => 'tax_rate_details',
+                    'amount' => 18,
+                    'tax_behavior' => 'inclusive',
+                    'taxable_amount' => 182,
+                    'tax_rate_details' => ['tax_rate' => 'txr_test'],
+                ],
+            ],
+        ]);
+
+        $item = new InvoiceLineItem($invoice, $stripeInvoiceLineItem);
+
+        $this->assertSame('$0.91', $item->unitAmountExcludingTax());
     }
 
     public function test_price_uses_expanded_object_when_available()


### PR DESCRIPTION
## Summary

`InvoiceLineItem::unitAmountExcludingTax()` returned `$0.00` on any line item with no taxes applied because it summed `taxable_amount` from an empty taxes collection.

The correct approach depends on tax behavior:

- **Inclusive tax** — use `taxable_amount / quantity` from the first inclusive tax entry, which is the pre-tax portion of the line total
- **Exclusive tax / no tax** — use `unitAmount()` from the pricing structure, which is already the pre-tax unit price

## Changes

- `src/InvoiceLineItem.php`: Rewrite `unitAmountExcludingTax()` to branch on tax behavior rather than summing from the taxes collection
- `tests/Unit/InvoiceLineItemTest.php`: Add unit tests covering no tax, inclusive tax, exclusive tax, and multi-quantity inclusive tax cases