### PR TITLE
Fix JS error in payment view when intent has unsupported payment method types

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -247,12 +247,23 @@
                         this.paymentMethod = this.paymentMethods.filter(
                             paymentMethod => paymentMethod.type === type
                         )[0];
+
+                        // Fallback to the first available payment method if the resolved type
+                        // is not in the supported list (e.g. "link", "amazon_pay")...
+                        if (! this.paymentMethod) {
+                            this.paymentMethod = this.paymentMethods[0] ?? null;
+                        }
                     }
                 },
 
                 configureStripeElements: function () {
                     // Stripe Elements are only needed when a payment method is required.
                     if (this.paymentIntent.status !== 'requires_payment_method') {
+                        return;
+                    }
+
+                    // If no supported payment method is available, skip element creation...
+                    if (! this.paymentMethod) {
                         return;
                     }
 
@@ -278,6 +289,11 @@
                 },
 
                 confirmPaymentMethod: function () {
+                    if (! this.paymentMethod) {
+                        this.errorMessage = 'No supported payment method available. Please try a different payment method.';
+                        return;
+                    }
+
                     this.isPaymentProcessing = true;
                     this.errorMessage = '';
 


### PR DESCRIPTION
## Summary

Fixes a JavaScript `TypeError: Cannot read properties of undefined` crash on the payment confirmation page when a PaymentIntent includes payment method types not present in the view's hardcoded supported list.

## Problem

The `payment.blade.php` view maintains a hardcoded list of 8 supported payment method types (`card`, `alipay`, `au_becs_debit`, `bancontact`, `eps`, `giropay`, `ideal`, `sepa_debit`).

When a PaymentIntent has an attached payment method with a type outside this list (e.g. `link`, `amazon_pay`, `cashapp`), the `configurePayment` method resolves that type and filters the supported list, which returns an empty array. `this.paymentMethod` is then set to `undefined`.

This causes two JS errors:

1. `TypeError: Cannot read properties of undefined (reading 'element')` in `configureStripeElements` (line 260)
2. `TypeError: Cannot read properties of undefined (reading 'remember')` in `confirmPaymentMethod` (line 286)

This is increasingly common as Stripe automatically enables newer payment methods (Link, Amazon Pay, etc.) on accounts via Stripe's "automatic payment methods" feature.

Related: #1665 (closed as needs more info)

## Fix

1. After filtering the supported payment methods list, fall back to the first available supported method (typically `card`) if no match is found
2. Add a guard in `configureStripeElements` to skip element creation if no payment method is available
3. Add a guard in `confirmPaymentMethod` to show a user-friendly error instead of crashing

## Reproduction

1. Create a subscription with a Stripe account that has Link or Amazon Pay enabled
2. Trigger an incomplete payment (e.g. using a 3D Secure test card that requires authentication)
3. Visit the Cashier payment confirmation page
4. Observe the JS errors in the console and broken UI