### PR TITLE
Fix subscription period lazy loading

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1194,7 +1194,7 @@ class Subscription extends Model
      */
     public function currentPeriodStart(DateTimeZone|string|int|null $timezone = null): ?CarbonInterface
     {
-        $items = $this->items;
+        $items = $this->itemsForCurrentPeriodLookup();
 
         if ($items->isEmpty()) {
             return null;
@@ -1223,7 +1223,7 @@ class Subscription extends Model
      */
     public function currentPeriodEnd(DateTimeZone|string|int|null $timezone = null): ?CarbonInterface
     {
-        $items = $this->items;
+        $items = $this->itemsForCurrentPeriodLookup();
 
         if ($items->isEmpty()) {
             return null;
@@ -1240,6 +1240,28 @@ class Subscription extends Model
         }
 
         return $latestEnd ? ($timezone ? $latestEnd->setTimezone($timezone) : $latestEnd) : null;
+    }
+
+    /**
+     * Get the subscription items prepared for Stripe current period lookups.
+     *
+     * @return \Illuminate\Support\Collection<int, \Laravel\Cashier\SubscriptionItem>
+     */
+    protected function itemsForCurrentPeriodLookup(): Collection
+    {
+        $items = $this->items;
+
+        if ($items->isEmpty()) {
+            return $items;
+        }
+
+        if (! $this->relationLoaded('owner')) {
+            $this->load('owner');
+        }
+
+        return $items->each(function (SubscriptionItem $item) {
+            $item->setRelation('subscription', $this);
+        });
     }
 
     /**

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -2,9 +2,12 @@
 
 namespace Laravel\Cashier\Tests\Unit;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use Laravel\Cashier\Subscription;
+use Laravel\Cashier\SubscriptionItem;
 use PHPUnit\Framework\TestCase;
 use Stripe\Subscription as StripeSubscription;
 
@@ -170,5 +173,50 @@ class SubscriptionTest extends TestCase
 
         $this->assertTrue($subscription->hasMultiplePrices());
         $this->assertFalse($subscription->hasSinglePrice());
+    }
+
+    public function test_current_period_dates_do_not_lazy_load_subscription_item_relations()
+    {
+        Model::preventLazyLoading();
+
+        try {
+            $subscription = new Subscription;
+            $subscription->exists = true;
+            $subscription->setRelation('owner', new class
+            {
+                public function stripe()
+                {
+                    return new class
+                    {
+                        public $subscriptionItems;
+
+                        public function __construct()
+                        {
+                            $this->subscriptionItems = new class
+                            {
+                                public function retrieve($id, array $params = [])
+                                {
+                                    return (object) [
+                                        'current_period_start' => 1700000000,
+                                        'current_period_end' => 1700086400,
+                                    ];
+                                }
+                            };
+                        }
+                    };
+                }
+            });
+
+            $item = new SubscriptionItem(['stripe_id' => 'si_test']);
+            $item->exists = true;
+            $item->preventsLazyLoading = true;
+
+            $subscription->setRelation('items', new Collection([$item]));
+
+            $this->assertSame(1700000000, $subscription->currentPeriodStart()->getTimestamp());
+            $this->assertSame(1700086400, $subscription->currentPeriodEnd()->getTimestamp());
+        } finally {
+            Model::preventLazyLoading(false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1844.

This prepares subscription items before `currentPeriodStart()` and `currentPeriodEnd()` ask each item for its Stripe period data. The subscription owner is explicitly loaded when needed, and each loaded item receives the current subscription relation so Eloquent lazy-loading prevention does not raise while resolving `$item->subscription->owner`.

Tests:
- `vendor\bin\phpunit.bat tests\Unit\SubscriptionTest.php --filter current_period_dates_do_not_lazy_load_subscription_item_relations`
- `vendor\bin\phpunit.bat tests\Unit`
- `vendor\bin\phpunit.bat` (Stripe feature tests skipped locally because `STRIPE_SECRET` is not set)