### PR TITLE
Handle duplicate subscription webhooks

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Http\Controllers;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Routing\Controller;
@@ -80,7 +81,7 @@ class WebhookController extends Controller
                 $firstItem = $data['items']['data'][0];
                 $isSinglePrice = count($data['items']['data']) === 1;
 
-                $subscription = $user->subscriptions()->updateOrCreate([
+                $subscription = $this->updateOrCreateSubscription($user, [
                     'stripe_id' => $data['id'],
                 ], [
                     'type' => $data['metadata']['type'] ?? $data['metadata']['name'] ?? $this->newSubscriptionType($payload),
@@ -92,7 +93,7 @@ class WebhookController extends Controller
                 ]);
 
                 foreach ($data['items']['data'] as $item) {
-                    $subscription->items()->updateOrCreate([
+                    $this->updateOrCreateSubscriptionItem($subscription, [
                         'stripe_id' => $item['id'],
                     ], [
                         'stripe_product' => $item['price']['product'],
@@ -121,6 +122,90 @@ class WebhookController extends Controller
     protected function newSubscriptionType(array $payload)
     {
         return 'default';
+    }
+
+    /**
+     * Update or create a subscription while tolerating a concurrent insert.
+     *
+     * @param  \Laravel\Cashier\Billable  $user
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Laravel\Cashier\Subscription
+     */
+    protected function updateOrCreateSubscription($user, array $attributes, array $values)
+    {
+        if ($subscription = $user->subscriptions()->where($attributes)->first()) {
+            $subscription->fill($values)->save();
+
+            return $subscription;
+        }
+
+        try {
+            return $user->subscriptions()->create(array_merge($attributes, $values));
+        } catch (QueryException $e) {
+            if (! $this->causedByUniqueConstraintViolation($e)) {
+                throw $e;
+            }
+
+            $subscription = $user->subscriptions()->where($attributes)->first();
+
+            if (! $subscription) {
+                throw $e;
+            }
+
+            $subscription->fill($values)->save();
+
+            return $subscription;
+        }
+    }
+
+    /**
+     * Update or create a subscription item while tolerating a concurrent insert.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Laravel\Cashier\SubscriptionItem
+     */
+    protected function updateOrCreateSubscriptionItem(Subscription $subscription, array $attributes, array $values)
+    {
+        if ($item = $subscription->items()->where($attributes)->first()) {
+            $item->fill($values)->save();
+
+            return $item;
+        }
+
+        try {
+            return $subscription->items()->create(array_merge($attributes, $values));
+        } catch (QueryException $e) {
+            if (! $this->causedByUniqueConstraintViolation($e)) {
+                throw $e;
+            }
+
+            $item = $subscription->items()->where($attributes)->first();
+
+            if (! $item) {
+                throw $e;
+            }
+
+            $item->fill($values)->save();
+
+            return $item;
+        }
+    }
+
+    /**
+     * Determine if the query exception was caused by a unique constraint violation.
+     *
+     * @param  \Illuminate\Database\QueryException  $exception
+     * @return bool
+     */
+    protected function causedByUniqueConstraintViolation(QueryException $exception)
+    {
+        return is_a($exception, 'Illuminate\Database\UniqueConstraintViolationException')
+            || ($exception->errorInfo[0] ?? null) === '23505'
+            || ($exception->errorInfo[1] ?? null) === 1062
+            || preg_match('#(UNIQUE constraint failed|Integrity constraint violation: 1062|duplicate key value violates unique constraint)#i', $exception->getMessage()) === 1;
     }
 
     /**

--- a/tests/Feature/WebhookConcurrencyTest.php
+++ b/tests/Feature/WebhookConcurrencyTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Cashier\Http\Controllers\WebhookController;
+use Laravel\Cashier\Subscription;
+use Laravel\Cashier\SubscriptionItem;
+use Laravel\Cashier\Tests\TestCase;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Stripe\Subscription as StripeSubscription;
+
+#[WithMigration]
+class WebhookConcurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithLaravelMigrations;
+
+    public function test_subscription_created_webhook_handles_concurrent_subscription_and_item_inserts()
+    {
+        $user = User::forceCreate([
+            'email' => 'concurrent-webhook@cashier-test.com',
+            'name' => 'Taylor Otwell',
+            'password' => 'password',
+            'stripe_id' => 'cus_foo',
+        ]);
+
+        $subscriptionCreated = false;
+        $itemCreated = false;
+
+        Event::listen('eloquent.creating: '.Subscription::class, function (Subscription $subscription) use (&$subscriptionCreated, $user) {
+            if ($subscriptionCreated || $subscription->stripe_id !== 'sub_foo') {
+                return;
+            }
+
+            $subscriptionCreated = true;
+
+            Subscription::withoutEvents(function () use ($user) {
+                $user->subscriptions()->create([
+                    'type' => 'main',
+                    'stripe_id' => 'sub_foo',
+                    'stripe_price' => 'price_bar',
+                    'stripe_status' => StripeSubscription::STATUS_INCOMPLETE,
+                    'quantity' => 1,
+                ]);
+            });
+        });
+
+        Event::listen('eloquent.creating: '.SubscriptionItem::class, function (SubscriptionItem $item) use (&$itemCreated) {
+            if ($itemCreated || $item->stripe_id !== 'bar') {
+                return;
+            }
+
+            $itemCreated = true;
+
+            SubscriptionItem::withoutEvents(function () use ($item) {
+                SubscriptionItem::query()->create([
+                    'subscription_id' => $item->subscription_id,
+                    'stripe_id' => 'bar',
+                    'stripe_product' => 'prod_old',
+                    'stripe_price' => 'price_old',
+                    'quantity' => 1,
+                ]);
+            });
+        });
+
+        $response = (new WebhookConcurrencyController)->handleCustomerSubscriptionCreated([
+            'id' => 'foo',
+            'type' => 'customer.subscription.created',
+            'data' => [
+                'object' => [
+                    'id' => 'sub_foo',
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'quantity' => 10,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
+                            'quantity' => 10,
+                        ]],
+                    ],
+                    'status' => 'active',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $this->assertDatabaseHas('subscriptions', [
+            'type' => 'default',
+            'user_id' => $user->id,
+            'stripe_id' => 'sub_foo',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_foo',
+            'quantity' => 10,
+        ]);
+
+        $this->assertDatabaseHas('subscription_items', [
+            'stripe_id' => 'bar',
+            'stripe_product' => 'prod_bar',
+            'stripe_price' => 'price_foo',
+            'quantity' => 10,
+        ]);
+
+        $this->assertSame(1, $user->subscriptions()->where('stripe_id', 'sub_foo')->count());
+        $this->assertSame(1, SubscriptionItem::query()->where('stripe_id', 'bar')->count());
+    }
+}
+
+class WebhookConcurrencyController extends WebhookController
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handleCustomerSubscriptionCreated(array $payload)
+    {
+        return parent::handleCustomerSubscriptionCreated($payload);
+    }
+}


### PR DESCRIPTION
Fixes #1759.

This makes the `customer.subscription.created` webhook tolerate the known race where the app's subscription creation flow and Stripe's webhook both try to persist the same subscription or subscription item.

The webhook now updates an existing local row when it is present, creates it when it is absent, and retries by reloading/updating the row only when the database error is identifiable as a unique constraint violation. Other query failures are still re-thrown.

I also added an offline regression test that simulates concurrent inserts for both the subscription and its item without requiring Stripe API credentials.

Tests run:

- `php -l src/Http/Controllers/WebhookController.php`
- `php -l tests/Feature/WebhookConcurrencyTest.php`
- `php vendor/bin/phpunit tests/Unit/WebhookControllerTest.php tests/Feature/WebhookConcurrencyTest.php`
- `php vendor/bin/phpstan analyse src/Http/Controllers/WebhookController.php tests/Feature/WebhookConcurrencyTest.php --memory-limit=1G`