### PR TITLE
Resolve soft deleted subscription owners

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\AllowsCoupons;
@@ -93,7 +94,11 @@ class Subscription extends Model
     {
         $model = Cashier::$customerModel;
 
-        return $this->belongsTo($model, (new $model)->getForeignKey());
+        $relation = $this->belongsTo($model, (new $model)->getForeignKey());
+
+        return in_array(SoftDeletes::class, class_uses_recursive($model))
+            ? $relation->withTrashed()
+            : $relation;
     }
 
     /**

--- a/tests/Feature/SubscriptionOwnerTest.php
+++ b/tests/Feature/SubscriptionOwnerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\SubscriptionItem;
+use Laravel\Cashier\Tests\TestCase;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+
+#[WithMigration]
+class SubscriptionOwnerTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithLaravelMigrations;
+
+    protected function tearDown(): void
+    {
+        Cashier::useCustomerModel(User::class);
+
+        parent::tearDown();
+    }
+
+    public function test_subscription_owner_can_resolve_soft_deleted_billables()
+    {
+        Schema::table('users', function ($table) {
+            $table->softDeletes();
+        });
+
+        Cashier::useCustomerModel(SoftDeletingUser::class);
+
+        $user = SoftDeletingUser::forceCreate([
+            'email' => 'soft-deleted-owner@cashier-test.com',
+            'name' => 'Taylor Otwell',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'stripe_id' => 'cus_foo',
+        ]);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_price' => 'price_foo',
+            'stripe_status' => 'active',
+        ]);
+
+        $item = $subscription->items()->create([
+            'stripe_id' => 'si_foo',
+            'stripe_product' => 'prod_foo',
+            'stripe_price' => 'price_foo',
+            'quantity' => 1,
+        ]);
+
+        $user->delete();
+
+        $item = SubscriptionItem::query()->find($item->id);
+
+        $this->assertTrue($item->subscription->owner->is($user));
+    }
+}
+
+class SoftDeletingUser extends User
+{
+    use SoftDeletes;
+
+    protected $table = 'users';
+
+    public function getForeignKey()
+    {
+        return 'user_id';
+    }
+}


### PR DESCRIPTION
Fixes #1800.

Cashier already uses `withTrashed()` when locating a billable by Stripe ID for webhook handling, but the subscription's `owner()` relation always used a plain `belongsTo()` relation. That means a subscription item can resolve its subscription but fail to resolve the soft-deleted billable owner when paths such as `currentPeriodEnd()` call back into `asStripeSubscriptionItem()`.

This updates `Subscription::owner()` to include trashed owners only when the configured Cashier customer model uses `SoftDeletes`, preserving the existing relation for non-soft-deleting billables.

Tests run:

- `php -l src/Subscription.php`
- `php -l tests/Feature/SubscriptionOwnerTest.php`
- `php vendor/bin/phpunit tests/Unit/SubscriptionTest.php tests/Feature/SubscriptionOwnerTest.php`
- `php vendor/bin/phpstan analyse src/Subscription.php tests/Feature/SubscriptionOwnerTest.php --memory-limit=1G`