### PR TITLE
Exclude canceled subscriptions from active status

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -230,6 +230,7 @@ class Subscription extends Model
     {
         return ! $this->ended() &&
             (! Cashier::$deactivateIncomplete || $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE) &&
+            $this->stripe_status !== StripeSubscription::STATUS_CANCELED &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE_EXPIRED &&
             (! Cashier::$deactivatePastDue || $this->stripe_status !== StripeSubscription::STATUS_PAST_DUE) &&
             $this->stripe_status !== StripeSubscription::STATUS_UNPAID;
@@ -248,7 +249,8 @@ class Subscription extends Model
                 ->orWhere(function ($query) {
                     $query->onGracePeriod();
                 });
-        })->where('stripe_status', '!=', StripeSubscription::STATUS_INCOMPLETE_EXPIRED)
+        })->where('stripe_status', '!=', StripeSubscription::STATUS_CANCELED)
+            ->where('stripe_status', '!=', StripeSubscription::STATUS_INCOMPLETE_EXPIRED)
             ->where('stripe_status', '!=', StripeSubscription::STATUS_UNPAID);
 
         if (Cashier::$deactivatePastDue) {

--- a/tests/Feature/SubscriptionStatusTest.php
+++ b/tests/Feature/SubscriptionStatusTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Tests\TestCase;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Stripe\Subscription as StripeSubscription;
+
+class SubscriptionStatusTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithLaravelMigrations;
+
+    public function test_canceled_status_subscriptions_are_not_active()
+    {
+        $user = User::forceCreate([
+            'email' => 'canceled_status_subscriptions_are_not_active@cashier-test.com',
+            'name' => 'Taylor Otwell',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+        ]);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'yearly',
+            'stripe_id' => 'sub_canceled',
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+            'stripe_price' => 'stripe-yearly',
+            'quantity' => 1,
+            'trial_ends_at' => null,
+            'ends_at' => null,
+        ]);
+
+        $this->assertFalse($subscription->active());
+        $this->assertFalse($subscription->valid());
+        $this->assertFalse($user->subscriptions()->active()->exists());
+    }
+}

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -70,6 +70,16 @@ class SubscriptionTest extends TestCase
         $this->assertTrue($subscription->valid());
     }
 
+    public function test_a_canceled_subscription_is_not_active_or_valid()
+    {
+        $subscription = new Subscription([
+            'stripe_status' => StripeSubscription::STATUS_CANCELED,
+        ]);
+
+        $this->assertFalse($subscription->active());
+        $this->assertFalse($subscription->valid());
+    }
+
     public function test_payment_is_incomplete_when_status_is_incomplete()
     {
         $subscription = new Subscription([


### PR DESCRIPTION
Fixes #1791.

When Stripe sends a subscription update with status `canceled` but without cancel timestamps, Cashier stores `stripe_status = canceled` with `ends_at = null`. Since `active()` only checked `ends_at` and other inactive statuses, those subscriptions were still treated as active and valid.

This keeps the existing `canceled()` and grace-period semantics based on `ends_at`, but excludes Stripe's canceled status from `active()` and the active query scope.

Tests:
- `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64\php.exe vendor\bin\phpunit tests\Unit\SubscriptionTest.php tests\Feature\SubscriptionStatusTest.php`
- `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64\php.exe vendor\bin\phpstan analyse src\Subscription.php tests\Unit\SubscriptionTest.php tests\Feature\SubscriptionStatusTest.php --memory-limit=1G`
- `git diff --cached --check`