### PR TITLE
Clear on-session checkout flag after the initial payment

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -293,11 +293,7 @@ class WebhookController extends Controller
             return $this->successMethod();
         }
 
-        if ($payload['data']['object']['metadata']['is_on_session_checkout'] ?? false) {
-            return $this->successMethod();
-        }
-
-        if ($payload['data']['object']['subscription_details']['metadata']['is_on_session_checkout'] ?? false) {
+        if ($this->invoiceIsOnSessionCheckout($payload)) {
             return $this->successMethod();
         }
 
@@ -319,6 +315,31 @@ class WebhookController extends Controller
     }
 
     /**
+     * Handle invoice payment succeeded.
+     *
+     * @param  array  $payload
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function handleInvoicePaymentSucceeded(array $payload)
+    {
+        if (! $this->invoiceIsOnSessionCheckout($payload)) {
+            return $this->successMethod();
+        }
+
+        if (is_null($subscriptionId = $payload['data']['object']['parent']['subscription_details']['subscription'] ?? null)) {
+            return $this->successMethod();
+        }
+
+        if ($user = $this->getUserByStripeId($payload['data']['object']['customer'])) {
+            $user->stripe()->subscriptions->update($subscriptionId, [
+                'metadata' => ['is_on_session_checkout' => ''],
+            ]);
+        }
+
+        return $this->successMethod();
+    }
+
+    /**
      * Get the customer instance by Stripe ID.
      *
      * @param  string|null  $stripeId
@@ -327,6 +348,18 @@ class WebhookController extends Controller
     protected function getUserByStripeId($stripeId)
     {
         return Cashier::findBillable($stripeId);
+    }
+
+    /**
+     * Determine whether the invoice belongs to an on-session checkout.
+     *
+     * @param  array  $payload
+     * @return bool
+     */
+    protected function invoiceIsOnSessionCheckout(array $payload)
+    {
+        return ($payload['data']['object']['metadata']['is_on_session_checkout'] ?? false) || // One-time payment invoice
+               ($payload['data']['object']['parent']['subscription_details']['metadata']['is_on_session_checkout'] ?? false); // Subscription
     }
 
     /**

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -339,8 +339,82 @@ class WebhooksTest extends FeatureTestCase
 
             Notification::assertSentTo($user, ConfirmPayment::class, function (ConfirmPayment $notification) use ($exception) {
                 return $notification->paymentId === $exception->payment->id &&
-                    $notification->amount === $exception->payment->amount();
+                       $notification->amount === $exception->payment->amount();
             });
         }
+    }
+
+    public function test_payment_action_required_email_is_not_sent_during_on_session_checkout()
+    {
+        $user = $this->createCustomer('payment_action_required_email_is_not_sent_during_on_session_checkout', [
+            'stripe_id' => 'cus_foo',
+        ]);
+
+        Notification::fake();
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'invoice.payment_action_required',
+            'data' => [
+                'object' => [
+                    'id' => 'in_foo',
+                    'customer' => 'cus_foo',
+                    'payment_intent' => 'pi_foo',
+                    'parent' => [
+                        'type' => 'subscription_details',
+                        'subscription_details' => [
+                            'subscription' => 'sub_foo',
+                            'metadata' => ['is_on_session_checkout' => 'true'],
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_on_session_checkout_metadata_is_cleared_when_invoice_payment_succeeds()
+    {
+        $user = $this->createCustomer('on_session_checkout_metadata_is_cleared_when_invoice_payment_succeeds');
+
+        $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        // Mimic the metadata Cashier stores on subscriptions created during an on-session checkout...
+        $user->stripe()->subscriptions->update($subscription->stripe_id, ['metadata' => [
+            'name' => 'main',
+            'type' => 'main',
+            'is_on_session_checkout' => 'true',
+        ]]);
+
+        $this->assertSame('true', $subscription->asStripeSubscription()->metadata->is_on_session_checkout);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'invoice.payment_succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'in_'.Str::random(10),
+                    'customer' => $user->stripe_id,
+                    'parent' => [
+                        'type' => 'subscription_details',
+                        'subscription_details' => [
+                            'subscription' => $subscription->stripe_id,
+                            'metadata' => [
+                                'name' => 'main',
+                                'type' => 'main',
+                                'is_on_session_checkout' => 'true',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $metadata = $subscription->asStripeSubscription()->metadata->toArray();
+
+        $this->assertSame('main', $metadata['name'] ?? null);
+        $this->assertSame('main', $metadata['type'] ?? null);
+        $this->assertArrayNotHasKey('is_on_session_checkout', $metadata);
     }
 }


### PR DESCRIPTION
When a subscription is created through Stripe Checkout, Cashier stores an `is_on_session_checkout` flag on it so the payment confirmation notification isn't sent while the customer is still on the checkout page. The flag was never cleared though, so it stuck around on every future invoice. This meant off-session renewals that need authentication (e.g. 3DS) had their `invoice.payment_action_required` notification suppressed too, and customers were never asked to confirm.

This handles `invoice.payment_succeeded` and clears the flag from the subscription once the initial payment goes through, so renewals can notify again. Only that one key is unset (`['is_on_session_checkout' => '']`), leaving the rest of the subscription's metadata (`name`, `type`, …) intact.

The on-session check now also reads `parent.subscription_details`. This is where this metadata lives under the API version Cashier currently pins — the old top-level `subscription_details` read no longer matches. Both the suppression check and the new clearing go through a shared `invoiceIsOnSessionCheckout()` helper so they can't drift apart.

Added feature tests for both sides: the notification is suppressed while the flag is set, and the flag is cleared once the invoice is paid.

Fixes #1676 which had been closed pending a PR.