### PR TITLE
Fix trial_ends_at not being cleared when trial_end is null in webhook payload

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -158,11 +158,15 @@ class WebhookController extends Controller
             $subscription->quantity = $isSinglePrice && isset($firstItem['quantity']) ? $firstItem['quantity'] : null;
 
             // Trial ending date...
-            if (isset($data['trial_end'])) {
-                $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
+            if (array_key_exists('trial_end', $data)) {
+                if ($data['trial_end']) {
+                    $trialEnd = Carbon::createFromTimestamp($data['trial_end']);
 
-                if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
-                    $subscription->trial_ends_at = $trialEnd;
+                    if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trialEnd)) {
+                        $subscription->trial_ends_at = $trialEnd;
+                    }
+                } else {
+                    $subscription->trial_ends_at = null;
                 }
             }
 

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -204,6 +204,49 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
+    public function test_trial_ends_at_is_cleared_when_trial_end_is_null_in_webhook()
+    {
+        $user = $this->createCustomer('trial_ends_at_is_cleared_when_trial_end_is_null', ['stripe_id' => 'cus_foo']);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_price' => 'price_foo',
+            'stripe_status' => StripeSubscription::STATUS_ACTIVE,
+            'trial_ends_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $subscription->items()->create([
+            'stripe_id' => 'it_'.Str::random(10),
+            'stripe_product' => 'prod_bar',
+            'stripe_price' => 'price_foo',
+            'quantity' => 1,
+        ]);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'foo',
+            'type' => 'customer.subscription.updated',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => 'cus_foo',
+                    'cancel_at_period_end' => false,
+                    'trial_end' => null,
+                    'status' => StripeSubscription::STATUS_ACTIVE,
+                    'items' => [
+                        'data' => [[
+                            'id' => 'bar',
+                            'price' => ['id' => 'price_foo', 'product' => 'prod_bar'],
+                            'quantity' => 1,
+                        ]],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertNull($subscription->fresh()->trial_ends_at);
+    }
+
     public function test_subscription_updated_before_created()
     {
         $user = $this->createCustomer('canceled_subscription_is_properly_reactivated');


### PR DESCRIPTION
Closes #1824

When Stripe sends a `customer.subscription.updated` webhook with `"trial_end": null` (trial ended naturally), the current `isset($data['trial_end'])` check returns `false` for null and skips the block entirely — so `trial_ends_at` is never cleared. This causes `onTrial()` to keep returning `true` and `resume()` to throw a 400 by re-sending the stale `trial_end` date to Stripe.

Replaces `isset` with `array_key_exists` so the key's presence controls the branch, and adds an `else` to explicitly null out `trial_ends_at` when `trial_end` is `null`.

Added `test_trial_ends_at_is_cleared_when_trial_end_is_null_in_webhook` to `WebhooksTest`.