### PR TITLE
[16.x] Add missing @throws docblocks for Stripe exceptions in Subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -264,6 +264,8 @@ class Subscription extends Model
      * Sync the Stripe status of the subscription.
      *
      * @return void
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function syncStripeStatus(): void
     {
@@ -441,6 +443,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function incrementQuantity(int $count = 1, ?string $price = null)
     {
@@ -469,6 +472,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function incrementAndInvoice(int $count = 1, ?string $price = null)
     {
@@ -487,6 +491,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function decrementQuantity(int $count = 1, ?string $price = null)
     {
@@ -514,6 +519,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function updateQuantity(int $quantity, ?string $price = null)
     {
@@ -659,6 +665,8 @@ class Subscription extends Model
      * Force the subscription's trial to end immediately.
      *
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function endTrial()
     {
@@ -683,6 +691,8 @@ class Subscription extends Model
      *
      * @param  \Carbon\CarbonInterface  $date
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function extendTrial(CarbonInterface $date)
     {
@@ -711,6 +721,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function swap(string|array $prices, array $options = [])
     {
@@ -783,6 +794,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function swapAndInvoice(string|array $prices, array $options = [])
     {
@@ -827,6 +839,8 @@ class Subscription extends Model
      *
      * @param  \Illuminate\Support\Collection  $items
      * @return \Illuminate\Support\Collection
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     protected function mergeItemsThatShouldBeDeletedDuringSwap(Collection $items): Collection
     {
@@ -901,6 +915,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function addPrice(string $price, ?int $quantity = 1, array $options = [])
     {
@@ -970,6 +985,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function addPriceAndInvoice(string $price, int $quantity = 1, array $options = [])
     {
@@ -986,6 +1002,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function addMeteredPrice(string $price, array $options = [])
     {
@@ -1001,6 +1018,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function addMeteredPriceAndInvoice(string $price, array $options = [])
     {
@@ -1014,6 +1032,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function removePrice(string $price)
     {
@@ -1048,6 +1067,8 @@ class Subscription extends Model
      * Cancel the subscription at the end of the billing period.
      *
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancel()
     {
@@ -1076,6 +1097,8 @@ class Subscription extends Model
      *
      * @param  \DateTimeInterface|int  $endsAt
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelAt(DateTimeInterface|int $endsAt)
     {
@@ -1101,6 +1124,8 @@ class Subscription extends Model
      * Cancel the subscription immediately without invoicing.
      *
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelNow()
     {
@@ -1117,6 +1142,8 @@ class Subscription extends Model
      * Cancel the subscription immediately and invoice.
      *
      * @return $this
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelNowAndInvoice()
     {
@@ -1151,6 +1178,7 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \LogicException
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function resume()
     {
@@ -1178,6 +1206,8 @@ class Subscription extends Model
      * Determine if the subscription has pending updates.
      *
      * @return bool
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function pending(): bool
     {
@@ -1249,6 +1279,7 @@ class Subscription extends Model
      * @return \Laravel\Cashier\Invoice
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function invoice(array $options = []): Invoice
     {
@@ -1268,6 +1299,8 @@ class Subscription extends Model
      * Get the latest invoice for the subscription.
      *
      * @return \Laravel\Cashier\Invoice|null
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function latestInvoice(array $expand = []): ?Invoice
     {
@@ -1303,6 +1336,8 @@ class Subscription extends Model
      * @param  string|array  $prices
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function previewInvoice(string|array $prices, array $options = []): ?Invoice
     {
@@ -1363,6 +1398,8 @@ class Subscription extends Model
      * Sync the tax rates of the user to the subscription.
      *
      * @return void
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function syncTaxRates(): void
     {
@@ -1408,6 +1445,8 @@ class Subscription extends Model
      * Get the latest payment for a Subscription.
      *
      * @return \Laravel\Cashier\Payment|null
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function latestPayment(): ?Payment
     {
@@ -1432,6 +1471,8 @@ class Subscription extends Model
      * The discount that applies to the subscription, if applicable.
      *
      * @return \Laravel\Cashier\Discount|null
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function discount(): ?Discount
     {
@@ -1448,6 +1489,8 @@ class Subscription extends Model
      * Get all discounts that apply to the subscription.
      *
      * @return \Illuminate\Support\Collection<int, \Laravel\Cashier\Discount>
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function discounts(): Collection
     {
@@ -1470,6 +1513,7 @@ class Subscription extends Model
      *
      * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
      * @throws \Stripe\Exception\InvalidRequestException
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function applyCoupon(string $couponId): void
     {
@@ -1508,6 +1552,8 @@ class Subscription extends Model
      *
      * @param  string  $promotionCodeId
      * @return void
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function applyPromotionCode(string $promotionCodeId): void
     {
@@ -1554,6 +1600,8 @@ class Subscription extends Model
      *
      * @param  array  $options
      * @return \Stripe\Subscription
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function updateStripeSubscription(array $options = [])
     {
@@ -1567,6 +1615,8 @@ class Subscription extends Model
      *
      * @param  array  $expand
      * @return \Stripe\Subscription
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function asStripeSubscription(array $expand = [])
     {
@@ -1580,6 +1630,8 @@ class Subscription extends Model
      *
      * @param  StripeSubscription|null  $subscription
      * @return bool
+     * 
+     * @throws \Stripe\Exception\ApiErrorException
      */
     public function usesFlexibleBilling(?StripeSubscription $subscription = null): bool
     {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -264,7 +264,7 @@ class Subscription extends Model
      * Sync the Stripe status of the subscription.
      *
      * @return void
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function syncStripeStatus(): void
@@ -665,7 +665,7 @@ class Subscription extends Model
      * Force the subscription's trial to end immediately.
      *
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function endTrial()
@@ -691,7 +691,7 @@ class Subscription extends Model
      *
      * @param  \Carbon\CarbonInterface  $date
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function extendTrial(CarbonInterface $date)
@@ -839,7 +839,7 @@ class Subscription extends Model
      *
      * @param  \Illuminate\Support\Collection  $items
      * @return \Illuminate\Support\Collection
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     protected function mergeItemsThatShouldBeDeletedDuringSwap(Collection $items): Collection
@@ -1067,7 +1067,7 @@ class Subscription extends Model
      * Cancel the subscription at the end of the billing period.
      *
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancel()
@@ -1097,7 +1097,7 @@ class Subscription extends Model
      *
      * @param  \DateTimeInterface|int  $endsAt
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelAt(DateTimeInterface|int $endsAt)
@@ -1124,7 +1124,7 @@ class Subscription extends Model
      * Cancel the subscription immediately without invoicing.
      *
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelNow()
@@ -1142,7 +1142,7 @@ class Subscription extends Model
      * Cancel the subscription immediately and invoice.
      *
      * @return $this
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function cancelNowAndInvoice()
@@ -1206,7 +1206,7 @@ class Subscription extends Model
      * Determine if the subscription has pending updates.
      *
      * @return bool
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function pending(): bool
@@ -1299,7 +1299,7 @@ class Subscription extends Model
      * Get the latest invoice for the subscription.
      *
      * @return \Laravel\Cashier\Invoice|null
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function latestInvoice(array $expand = []): ?Invoice
@@ -1336,7 +1336,7 @@ class Subscription extends Model
      * @param  string|array  $prices
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|null
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function previewInvoice(string|array $prices, array $options = []): ?Invoice
@@ -1398,7 +1398,7 @@ class Subscription extends Model
      * Sync the tax rates of the user to the subscription.
      *
      * @return void
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function syncTaxRates(): void
@@ -1445,7 +1445,7 @@ class Subscription extends Model
      * Get the latest payment for a Subscription.
      *
      * @return \Laravel\Cashier\Payment|null
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function latestPayment(): ?Payment
@@ -1471,7 +1471,7 @@ class Subscription extends Model
      * The discount that applies to the subscription, if applicable.
      *
      * @return \Laravel\Cashier\Discount|null
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function discount(): ?Discount
@@ -1489,7 +1489,7 @@ class Subscription extends Model
      * Get all discounts that apply to the subscription.
      *
      * @return \Illuminate\Support\Collection<int, \Laravel\Cashier\Discount>
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function discounts(): Collection
@@ -1552,7 +1552,7 @@ class Subscription extends Model
      *
      * @param  string  $promotionCodeId
      * @return void
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function applyPromotionCode(string $promotionCodeId): void
@@ -1600,7 +1600,7 @@ class Subscription extends Model
      *
      * @param  array  $options
      * @return \Stripe\Subscription
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function updateStripeSubscription(array $options = [])
@@ -1615,7 +1615,7 @@ class Subscription extends Model
      *
      * @param  array  $expand
      * @return \Stripe\Subscription
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function asStripeSubscription(array $expand = [])
@@ -1630,7 +1630,7 @@ class Subscription extends Model
      *
      * @param  StripeSubscription|null  $subscription
      * @return bool
-     * 
+     *
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function usesFlexibleBilling(?StripeSubscription $subscription = null): bool


### PR DESCRIPTION
what:
- Add missing `@throws \Stripe\Exception\ApiErrorException` declarations to `Subscription` methods that call Stripe API

why:
- PHPStan (level 4+, default config) will report consumers' error handling as "Dead catch", causing consumers to use stub files and/or ignore rules.

scope:
- docblock-only changes; no behaviour impact