### PR TITLE
Allow forever amount-off coupons

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,9 +66,9 @@ The new `taxBehavior` method supports Basil's enhanced tax modeling (e.g., inclu
 
 ### Coupon Ending Dates
 
-Stripe's Basil API no longer supports setting discount coupons without an end date, and any application using a coupon without an end date will trigger `Laravel\Cashier\Exceptions\InvalidCoupon` exception after updating to Cashier 16.
+Stripe's Basil API originally restricted `amount_off` coupons with a `forever` duration. Stripe later reversed this restriction, and Cashier no longer rejects these coupons client-side.
 
-For existing infinite coupons, recreate them in Stripe with a finite duration before upgrading, or handle the exception by falling back to time-bound alternatives in code.
+Coupon validity is now determined by Stripe when the coupon is applied.
 
 ### Apply a Coupon by Subscription Type
 
@@ -100,7 +100,7 @@ $billable->applyPromotionCode('promotion_code_id', 'default');
 
 ### Coupon Validation in Checkouts
 
-New traits like `AllowsCoupons` introduce stricter validation for coupons in checkout sessions (e.g., ensuring compatibility with Basil). If you customize checkouts, test for rejection of invalid promotions.
+Coupon compatibility is validated by Stripe when creating Checkout sessions.
 
 ### Payment Failure Handling
 

--- a/src/Concerns/AllowsCoupons.php
+++ b/src/Concerns/AllowsCoupons.php
@@ -2,9 +2,6 @@
 
 namespace Laravel\Cashier\Concerns;
 
-use Laravel\Cashier\Coupon;
-use Laravel\Cashier\Exceptions\InvalidCoupon;
-
 trait AllowsCoupons
 {
     use InteractsWithStripe;
@@ -66,16 +63,12 @@ trait AllowsCoupons
      * Return the discounts for a Stripe Checkout session.
      *
      * @return array[]|null
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
      */
     protected function checkoutDiscounts(): ?array
     {
         $discounts = [];
 
         if ($this->couponId) {
-            $this->validateCouponForCheckout($this->couponId);
-
             $discounts[] = ['coupon' => $this->couponId];
         }
 
@@ -86,26 +79,4 @@ trait AllowsCoupons
         return ! empty($discounts) ? $discounts : null;
     }
 
-    /**
-     * Validate that a coupon can be used in checkout sessions.
-     *
-     * @param  string  $couponId
-     * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
-     * @throws \Stripe\Exception\ApiErrorException
-     */
-    protected function validateCouponForCheckout(string $couponId): void
-    {
-        /** @var \Stripe\Service\CouponService $couponsService */
-        $couponsService = static::stripe()->coupons;
-
-        $stripeCoupon = $couponsService->retrieve($couponId);
-
-        $coupon = new Coupon($stripeCoupon);
-
-        if ($coupon->isForeverAmountOff()) {
-            throw InvalidCoupon::cannotUseForeverAmountOffInCheckout($couponId);
-        }
-    }
 }

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -5,11 +5,9 @@ namespace Laravel\Cashier\Concerns;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Coupon;
 use Laravel\Cashier\CustomerBalanceTransaction;
 use Laravel\Cashier\Discount;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
-use Laravel\Cashier\Exceptions\InvalidCoupon;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
 use Laravel\Cashier\PromotionCode;
 use Laravel\Cashier\Subscription;
@@ -321,15 +319,10 @@ trait ManagesCustomer
      * @param  string  $couponId
      * @param  string|array<int, string>|null  $subscriptionTypes
      * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
      */
     public function applyCoupon(string $couponId, string|array|null $subscriptionTypes = null): void
     {
         $this->assertCustomerExists();
-
-        // Validate the coupon to ensure it's not a forever amount_off coupon...
-        $this->validateCouponForCustomerApplication($couponId);
 
         $subscriptions = $this->getTargetSubscriptions($subscriptionTypes);
 
@@ -367,8 +360,6 @@ trait ManagesCustomer
      *
      * @param  string  $couponId
      * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
      */
     public function applyCouponToAllSubscriptions(string $couponId): void
     {
@@ -411,29 +402,6 @@ trait ManagesCustomer
         $types = is_array($subscriptionTypes) ? $subscriptionTypes : [$subscriptionTypes];
 
         return $this->subscriptions->whereIn('type', $types)->where('stripe_status', 'active');
-    }
-
-    /**
-     * Validate that a coupon can be applied to a customer.
-     *
-     * @param  string  $couponId
-     * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
-     * @throws \Stripe\Exception\ApiErrorException
-     */
-    protected function validateCouponForCustomerApplication(string $couponId): void
-    {
-        /** @var \Stripe\Service\CouponService $couponsService */
-        $couponsService = static::stripe()->coupons;
-
-        $stripeCoupon = $couponsService->retrieve($couponId);
-
-        $coupon = new Coupon($stripeCoupon);
-
-        if ($coupon->isForeverAmountOff()) {
-            throw InvalidCoupon::foreverAmountOffCouponNotAllowed($couponId);
-        }
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -19,7 +19,6 @@ use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Exceptions\IncompletePayment;
-use Laravel\Cashier\Exceptions\InvalidCoupon;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
 use Stripe\Subscription as StripeSubscription;
@@ -1511,40 +1510,17 @@ class Subscription extends Model
      * @param  string  $couponId
      * @return void
      *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
      * @throws \Stripe\Exception\InvalidRequestException
      * @throws \Stripe\Exception\ApiErrorException
      */
     public function applyCoupon(string $couponId): void
     {
-        // Validate the coupon to ensure it's not a forever amount_off coupon...
-        $this->validateCouponForSubscriptionApplication($couponId);
-
         $this->updateStripeSubscription([
             'discounts' => [['coupon' => $couponId]],
         ]);
 
         // Clear any cached discount data to ensure fresh data is retrieved...
         unset($this->discount, $this->discounts);
-    }
-
-    /**
-     * Validate that a coupon can be applied to a subscription.
-     *
-     * @param  string  $couponId
-     * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
-     * @throws \Stripe\Exception\ApiErrorException
-     */
-    protected function validateCouponForSubscriptionApplication(string $couponId): void
-    {
-        $stripeCoupon = $this->owner::stripe()->coupons->retrieve($couponId);
-        $coupon = new Coupon($stripeCoupon);
-
-        if ($coupon->isForeverAmountOff()) {
-            throw InvalidCoupon::cannotApplyForeverAmountOffToSubscription($couponId);
-        }
     }
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -16,7 +16,6 @@ use Laravel\Cashier\Concerns\HandlesTaxes;
 use Laravel\Cashier\Concerns\InteractsWithPaymentBehavior;
 use Laravel\Cashier\Concerns\InteractsWithStripe;
 use Laravel\Cashier\Concerns\Prorates;
-use Laravel\Cashier\Exceptions\InvalidCoupon;
 use Stripe\Subscription as StripeSubscription;
 use Stripe\Util\ApiVersion as StripeApiVersion;
 
@@ -459,9 +458,6 @@ class SubscriptionBuilder
             $discounts = [];
 
             if ($this->couponId) {
-                // Validate the coupon before applying...
-                $this->validateCouponForSubscriptionApplication($this->couponId);
-
                 $discounts[] = ['coupon' => $this->couponId];
             }
 
@@ -524,29 +520,6 @@ class SubscriptionBuilder
         }
 
         return null;
-    }
-
-    /**
-     * Validate that a coupon can be applied to a subscription.
-     *
-     * @param  string  $couponId
-     * @return void
-     *
-     * @throws \Laravel\Cashier\Exceptions\InvalidCoupon
-     * @throws \Stripe\Exception\ApiErrorException
-     */
-    protected function validateCouponForSubscriptionApplication(string $couponId): void
-    {
-        /** @var \Stripe\Service\CouponService $couponsService */
-        $couponsService = $this->owner::stripe()->coupons;
-
-        $stripeCoupon = $couponsService->retrieve($couponId);
-
-        $coupon = new Coupon($stripeCoupon);
-
-        if ($coupon->isForeverAmountOff()) {
-            throw InvalidCoupon::cannotApplyForeverAmountOffToSubscription($couponId);
-        }
     }
 
     /**

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -72,6 +72,33 @@ class CheckoutTest extends FeatureTestCase
         $this->assertInstanceOf(Checkout::class, $checkout);
     }
 
+    public function test_customers_can_start_a_checkout_session_with_a_forever_amount_off_coupon()
+    {
+        $user = $this->createCustomer('customers_can_start_checkout_with_forever_amount_off_coupon');
+
+        $shirtPrice = self::stripe()->prices->create([
+            'currency' => 'USD',
+            'product_data' => [
+                'name' => 'T-shirt',
+            ],
+            'unit_amount' => 1500,
+        ]);
+
+        $coupon = self::stripe()->coupons->create([
+            'duration' => 'forever',
+            'amount_off' => 500,
+            'currency' => 'USD',
+        ]);
+
+        $checkout = $user->withCoupon($coupon->id)
+            ->checkout($shirtPrice->id, [
+                'success_url' => 'http://example.com',
+                'cancel_url' => 'http://example.com',
+            ]);
+
+        $this->assertInstanceOf(Checkout::class, $checkout);
+    }
+
     public function test_customers_can_start_a_one_off_charge_checkout_session()
     {
         $user = $this->createCustomer('customers_can_start_a_one_off_charge_checkout_session');

--- a/tests/Feature/DiscountTest.php
+++ b/tests/Feature/DiscountTest.php
@@ -25,6 +25,11 @@ class DiscountTest extends FeatureTestCase
     /**
      * @var string
      */
+    protected static $foreverAmountOffCouponId;
+
+    /**
+     * @var string
+     */
     protected static $secondCouponId;
 
     /**
@@ -65,6 +70,12 @@ class DiscountTest extends FeatureTestCase
             'duration' => 'repeating',
             'amount_off' => 500,
             'duration_in_months' => 3,
+            'currency' => 'USD',
+        ])->id;
+
+        static::$foreverAmountOffCouponId = self::stripe()->coupons->create([
+            'duration' => 'forever',
+            'amount_off' => 500,
             'currency' => 'USD',
         ])->id;
 
@@ -110,6 +121,16 @@ class DiscountTest extends FeatureTestCase
         $this->assertEquals(static::$promotionCodeId, $user->discount()->promotionCode()->id);
         $this->assertEquals(static::$secondCouponId, $user->discount()->promotionCode()->coupon()->id);
         $this->assertEquals(static::$promotionCodeCode, $user->discount()->promotionCode()->code);
+    }
+
+    public function test_applying_a_forever_amount_off_coupon_to_an_existing_customer()
+    {
+        $user = $this->createCustomer('applying_forever_amount_off_coupon_to_existing_customer');
+        $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $user->applyCoupon(static::$foreverAmountOffCouponId);
+
+        $this->assertEquals(static::$foreverAmountOffCouponId, $user->discount()->coupon()->id);
     }
 
     public function test_applying_discounts_to_specific_subscription_types()
@@ -179,6 +200,16 @@ class DiscountTest extends FeatureTestCase
         $this->assertEquals(static::$promotionCodeId, $subscription->discount()->promotionCode()->id);
         $this->assertEquals(static::$secondCouponId, $subscription->discount()->promotionCode()->coupon()->id);
         $this->assertEquals(static::$promotionCodeCode, $subscription->discount()->promotionCode()->code);
+    }
+
+    public function test_applying_a_forever_amount_off_coupon_directly_to_a_subscription()
+    {
+        $user = $this->createCustomer('applying_forever_amount_off_coupon_directly_to_subscription');
+        $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $subscription->applyCoupon(static::$foreverAmountOffCouponId);
+
+        $this->assertEquals(static::$foreverAmountOffCouponId, $subscription->discount()->coupon()->id);
     }
 
     public function test_customers_can_retrieve_a_promotion_code()

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -43,6 +43,11 @@ class SubscriptionsTest extends FeatureTestCase
     /**
      * @var string
      */
+    protected static $foreverAmountOffCouponId;
+
+    /**
+     * @var string
+     */
     protected static $taxRateId;
 
     public static function setUpBeforeClass(): void
@@ -95,6 +100,12 @@ class SubscriptionsTest extends FeatureTestCase
             'duration' => 'repeating',
             'amount_off' => 500,
             'duration_in_months' => 3,
+            'currency' => 'USD',
+        ])->id;
+
+        static::$foreverAmountOffCouponId = self::stripe()->coupons->create([
+            'duration' => 'forever',
+            'amount_off' => 500,
             'currency' => 'USD',
         ])->id;
 
@@ -186,6 +197,17 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($invoice->hasStartingBalance());
         $this->assertEmpty($invoice->discounts());
         $this->assertInstanceOf(Carbon::class, $invoice->date());
+    }
+
+    public function test_subscriptions_can_be_created_with_a_forever_amount_off_coupon()
+    {
+        $user = $this->createCustomer('creating_subscription_with_forever_amount_off_coupon');
+
+        $subscription = $user->newSubscription('main', static::$priceId)
+            ->withCoupon(static::$foreverAmountOffCouponId)
+            ->create('pm_card_visa');
+
+        $this->assertEquals(static::$foreverAmountOffCouponId, $subscription->discount()->coupon()->id);
     }
 
     public function test_swapping_subscription_with_coupon()


### PR DESCRIPTION
Fixes #1867

Stripe reintroduced support for `amount_off` coupons with a `forever` duration in the 2026-01-28 Clover update, with the change applying across API versions. Cashier still performs the client-side validation introduced for the earlier Basil restriction, so these coupons are rejected before the subscription, customer, or Checkout request reaches Stripe.

This removes those obsolete preflight validations and lets Stripe validate coupon compatibility when the coupon is applied. The existing Stripe discount payloads are unchanged, so this only removes Cashier's stale rejection and does not alter how discounts are sent to Stripe.

This benefits applications using long-lived or grandfathered `amount_off` coupons by allowing them to upgrade to Cashier 16 without overriding the protected validation methods.

Regression coverage has been added for:

- creating a subscription with a forever amount-off coupon;
- applying one through the billable customer;
- applying one directly to an existing subscription;
- using one in Stripe Checkout.

The upgrade guidance has also been updated to reflect the restored Stripe behavior.

Locally, the full suite passes with **200 tests, 116 assertions, and 127 skipped tests**. The four new regression tests are Stripe-backed and are skipped because `STRIPE_SECRET` is not configured in my environment. I don't have access to Stripe test credentials here, so I followed Cashier's existing Stripe feature-test pattern and verified that the new tests are discovered correctly; they are ready to execute in an environment where the repository's Stripe test secret is available.