### PR TITLE
Supports `stripe/stripe-php` version 21

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.5]
-        stripe: [17, 18, 19, 20]
+        stripe: [17, 18, 19, 20, 21]
 
     name: Stripe API ${{ matrix.stripe }}
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
         "moneyphp/money": "^4.0",
         "nesbot/carbon": "^2.0|^3.0",
-        "stripe/stripe-php": "^17.4|^18.0|^19.0|^20.0",
+        "stripe/stripe-php": "^17.4|^18.0|^19.0|^20.0|^21.0",
         "symfony/console": "^6.0|^7.0|^8.0",
         "symfony/http-kernel": "^6.0|^7.0|^8.0",
         "symfony/polyfill-intl-icu": "^1.22.1",


### PR DESCRIPTION
Version 21 still uses `dahlia` codename.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
