### PR TITLE
[Issue][1862] - Upcoming invoices, check if the subscription is ended. 

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1321,7 +1321,7 @@ class Subscription extends Model
      */
     public function upcomingInvoice(array $options = []): ?Invoice
     {
-        if ($this->canceled()) {
+        if ($this->ended()) {
             return null;
         }
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -976,6 +976,18 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertSame(2000, $invoice->total);
     }
 
+    public function test_upcoming_invoice_is_not_null_during_grace_period()
+    {
+        $user = $this->createCustomer('upcoming_invoice_grace_period');
+
+        $subscription = $user->newSubscription('main', static::$priceId)->create('pm_card_visa');
+
+        $subscription->ends_at = now()->addMonths(3);
+        $subscription->save();
+
+        $this->assertNotNull($subscription->upcomingInvoice());
+    }
+
     public function test_updating_single_price_subscription_quantity_updates_the_quantity_of_the_subscription_item()
     {
         $user = $this->createCustomer('invoice_subscription_directly');


### PR DESCRIPTION
Upcoming invoices should be guarded using `ended()` not `canceled()`.

In the scenario where someone has cancelled their subscription but they potentially have 3 months left this guard would have wrongfully skipped. 

So, instead we check if the subscription is ended. 

This has been tested against a feature test, a regression test was also put in place to check before and after to ensure the issue was correctly caught.

Closes: [1862](https://github.com/laravel/cashier-stripe/issues/1862)




