### PR TITLE
[16.x] Give subscription items their parent subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -107,6 +107,26 @@ class Subscription extends Model
     }
 
     /**
+     * Set the given relationship on the model.
+     *
+     * @param  string  $relation
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setRelation($relation, $value)
+    {
+        // Subscription items are always eager loaded, and every item belongs to
+        // the subscription that just loaded them. Handing each item the parent
+        // it already has keeps calls such as "asStripeSubscriptionItem" from
+        // lazy loading a subscription that is sitting right there in memory.
+        if ($relation === 'items' && $value instanceof Collection) {
+            $value->each(fn ($item) => $item->setRelation('subscription', $this));
+        }
+
+        return parent::setRelation($relation, $value);
+    }
+
+    /**
      * Determine if the subscription has multiple prices.
      *
      * @return bool

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -42,6 +42,17 @@ class SubscriptionItem extends Model
     ];
 
     /**
+     * The relationships that should be hidden from serialization.
+     *
+     * The parent subscription hands each of its items a reference back to
+     * itself, so hiding it here keeps that reference out of the array and
+     * JSON representations, which would otherwise nest circularly.
+     *
+     * @var array
+     */
+    protected $hidden = ['subscription'];
+
+    /**
      * Get the subscription that the item belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/tests/Feature/SubscriptionItemLazyLoadingTest.php
+++ b/tests/Feature/SubscriptionItemLazyLoadingTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Laravel\Cashier\Tests\TestCase;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
+use Stripe\Subscription as StripeSubscription;
+
+#[WithMigration]
+class SubscriptionItemLazyLoadingTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithLaravelMigrations;
+
+    protected function tearDown(): void
+    {
+        Model::preventLazyLoading(false);
+
+        parent::tearDown();
+    }
+
+    public function test_subscription_items_are_given_their_parent_subscription()
+    {
+        $this->createSubscriptionWithItems();
+
+        Model::preventLazyLoading();
+
+        $subscription = Subscription::firstOrFail();
+
+        foreach ($subscription->items as $item) {
+            $this->assertTrue($item->relationLoaded('subscription'));
+            $this->assertTrue($subscription->is($item->subscription));
+        }
+    }
+
+    public function test_subscription_items_do_not_query_for_their_parent_subscription()
+    {
+        $this->createSubscriptionWithItems();
+
+        $subscription = Subscription::firstOrFail();
+
+        $queries = 0;
+
+        $this->app['db']->listen(function () use (&$queries) {
+            $queries++;
+        });
+
+        foreach ($subscription->items as $item) {
+            $item->subscription;
+        }
+
+        $this->assertSame(0, $queries);
+    }
+
+    public function test_subscription_items_are_given_their_parent_subscription_when_loaded_lazily()
+    {
+        $this->createSubscriptionWithItems();
+
+        $subscription = Subscription::firstOrFail();
+
+        $subscription->unsetRelation('items');
+
+        foreach ($subscription->items as $item) {
+            $this->assertTrue($subscription->is($item->subscription));
+        }
+    }
+
+    public function test_the_parent_subscription_is_not_serialized_onto_its_items()
+    {
+        $this->createSubscriptionWithItems();
+
+        $subscription = Subscription::firstOrFail();
+
+        $array = $subscription->toArray();
+
+        $this->assertArrayHasKey('items', $array);
+        $this->assertArrayNotHasKey('subscription', $array['items'][0]);
+
+        // A circular reference would recurse forever on Laravel 10, which has
+        // no PreventsCircularRecursion guard, so assert the shape stays flat:
+        // the items collection must appear exactly once in the payload.
+        $this->assertSame(1, substr_count($subscription->toJson(), '"items":'));
+    }
+
+    protected function createSubscriptionWithItems(): Subscription
+    {
+        $user = User::forceCreate([
+            'email' => 'taylor@cashier-test.com',
+            'name' => 'Taylor Otwell',
+            'password' => 'secret',
+        ]);
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_foo',
+            'stripe_status' => StripeSubscription::STATUS_ACTIVE,
+        ]);
+
+        foreach (['si_foo', 'si_bar'] as $stripeId) {
+            $subscription->items()->create([
+                'stripe_id' => $stripeId,
+                'stripe_product' => 'prod_foo',
+                'stripe_price' => 'price_foo',
+                'quantity' => 1,
+            ]);
+        }
+
+        return $subscription;
+    }
+}


### PR DESCRIPTION
Subscriptions always eager load their items via `$with`, but Eloquent never sets the inverse relation, so every `SubscriptionItem` method that reaches through `$this->subscription->owner` re-queries a subscription that is already in memory.

Under `preventLazyLoading()` that surfaces as a
`LazyLoadingViolationException` when iterating subscriptions, and without it as a silent N+1: because the refetched subscription eager loads its own items in turn, each item costs two extra queries.

Handing each item the parent that just loaded it removes those queries. The items are also hidden from the item's serialized form, since the resulting circular reference would otherwise recurse without bound on Laravel 10, which has no `PreventsCircularRecursion` guard.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
